### PR TITLE
Add `satstacker.cloud` relay

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -1,4 +1,5 @@
 relays:
+  - 'wss://satstacker.cloud'
   - 'wss://freedom-relay.herokuapp.com/ws'
   - 'wss://nostr-relay.freeberty.net'
   - 'wss://nostr-relay.wlvs.space'


### PR DESCRIPTION
This relay node is hosted in a datacenter not controlled by AWS/GCP/Azure.
Currently, it's a single `nostr-rs-relay` instance in Chicago. Load balancing soon.