### PR TITLE
Fix typo in node01.nostress.cc

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -161,5 +161,5 @@ relays:
   - wss://relay.realsearch.cc
   - wss://nostr.mrbits.it
   - wss://nostr.coollamer.com
-  - wss://node01.nostress.c
+  - wss://node01.nostress.cc
   - wss://nostr.zenon.wtf


### PR DESCRIPTION
Somehow a typo was introduced after my pull request. It says wss://node01.nostress.c in the relays file instead of wss://node01.nostress.cc I added the missing "c".