### PR TITLE
Add new relay nostr.developer.li

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -171,3 +171,5 @@ relays:
   - wss://nostr.uselessshit.co
   - wss://brb.io
   - wss://nostream.gromeul.eu
+  - wss://nostr.developer.li
+


### PR DESCRIPTION
Relay located at nostr.developer.li.
General purpose public relay using nostream v1.16.0.