### PR TITLE
Adding nostr.ro public relay

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -171,3 +171,4 @@ relays:
   - wss://nostr.uselessshit.co
   - wss://brb.io
   - wss://nostream.gromeul.eu
+  - wss://relay.nostr.ro


### PR DESCRIPTION
URL: https://relay.nostr.ro
Software: https://git.sr.ht/~gheartsfield/nostr-rs-relay
Version: 0.7.15