### PR TITLE
[do not merge] NIP-23 demo

### DIFF
--- a/src/components/relays/blocks/RelaysResultTable.vue
+++ b/src/components/relays/blocks/RelaysResultTable.vue
@@ -19,7 +19,7 @@
                             :class="getThemeBtnClass('spacious')" 
                             @click="store.prefs.changeTheme('spacious')">spacious</span>
                         </span>
-                        <NostrSyncPopoverNag  v-if="subsection == 'favorite'"  />
+                        <NostrSyncPopoverNag  v-if="subsection == 'favorite' && isLoggedIn"  />
                         <span v-if="subsection != 'favorite' && store.relays.getFavorites.length" class="ml-6 text-slate-600">
                           <input type="checkbox" class=" cursor-pointer relative top-0.5 mr-1" id="relays-pin-favorites" v-model="store.prefs.pinFavorites" /> 
                           <label class="cursor-pointer font-thin text-xs" for="relays-pin-favorites">
@@ -31,6 +31,15 @@
                       <!-- <th scope="col" class="relative py-3.5 pl-0 pr-0 sm:pr-0" v-if="isLoggedIn()">
                         <code class="text-xs block">Upvote</code>
                       </th> -->
+                      <th v-if="subsection == 'favorite'"  class="synced">
+                        Synced
+                      </th>
+                      <th v-if="subsection == 'favorite'"  class="synced">
+                        Read
+                      </th>
+                      <th v-if="subsection == 'favorite'"  class="synced">
+                        Write
+                      </th>
                       <th scope="col" class="hidden md:table-cell lg:table-cell xl:table-cell verified">
                         <!-- <span class="verified-shape-wrapper">
                           <span class="shape verified"></span>
@@ -85,6 +94,18 @@
                           👍
                         </a>
                       </td> -->
+
+                      <th v-if="subsection == 'favorite'"  class="synced">
+                        {{ ifSyncedWithNostr(relay) ? "yes" : "no" }}
+                      </th>
+
+                      <th v-if="subsection == 'favorite'"  class="do-read">
+                        <input v-if="typeof store.relays.nip23?.[relay]?.read !== 'undefined'" type="checkbox" v-model="store.relays.nip23[relay].read" />
+                      </th>
+
+                      <th v-if="subsection == 'favorite'"  class="do-write">
+                        <input v-if="typeof store.relays.nip23?.[relay]?.write !== 'undefined'" type="checkbox" v-model="store.relays.nip23[relay].write" />
+                      </th>
 
                       <td class="w-12 verified text-center md:table-cell lg:table-cell xl:table-cell">
                         <span v-if="this.results[relay]?.identities">
@@ -152,6 +173,7 @@
   
   import RelaysLib from '@/shared/relays-lib.js'
   import UserLib from '@/shared/user-lib.js'
+  import SharedComputed from '@/shared/computed.js'
 
   import {validateEvent, getEventHash, verifySignature} from 'nostr-tools'
   
@@ -244,7 +266,15 @@
         activePageData: {}
       }
     },
-    computed: {
+    computed: Object.assign(SharedComputed, {
+      ifSyncedWithNostr(){
+        return (relay) => {
+          const nip23 = this.store.relays.getNip23
+          if(typeof nip23?.[relay] === 'undefined')
+            return 
+          return true
+        }
+      },
       subsectionRelays(){
         return this.getRelays( this.store.relays.getRelays(this.subsection, this.results ) )
       },
@@ -348,7 +378,7 @@
       relayClean() {
         return (relay) => relay.replace('wss://', '')
       },
-    },
+    }),
     methods: Object.assign(RelaysLib, UserLib, localMethods),
   })
   </script>

--- a/src/components/relays/blocks/RelaysResultTable.vue
+++ b/src/components/relays/blocks/RelaysResultTable.vue
@@ -269,10 +269,9 @@
     computed: Object.assign(SharedComputed, {
       ifSyncedWithNostr(){
         return (relay) => {
-          const nip23 = this.store.relays.getNip23
-          if(typeof nip23?.[relay] === 'undefined')
-            return 
-          return true
+          relay
+          if(this.store.relays.nip23Synced?.[relay])
+            return true
         }
       },
       subsectionRelays(){

--- a/src/components/relays/partials/NostrSyncPopoverNag.vue
+++ b/src/components/relays/partials/NostrSyncPopoverNag.vue
@@ -125,8 +125,16 @@ export default {
       await this.getNip23
       const currentNip23 = this.store.relays.getNip23
       Object.keys(currentNip23).forEach( relay => {
-        currentNip23[relay].read = currentNip23[relay].read ? "true" : 'false'
-        currentNip23[relay].write = currentNip23[relay].write ? "true" : 'false'
+        const read = currentNip23[relay].read,
+              write = currentNip23[relay].write
+        
+        if(!read && !write) {
+          delete currentNip23[relay] 
+          return 
+        }
+
+        currentNip23[relay].read = read ? "true" : 'false'
+        currentNip23[relay].write = write ? "true" : 'false'
       })
       const event = {
         kind: 10001,

--- a/src/components/relays/partials/NostrSyncPopoverNag.vue
+++ b/src/components/relays/partials/NostrSyncPopoverNag.vue
@@ -96,12 +96,18 @@ export default {
             })
             this.persistNip23(parsed)
             this.setSyncStatus(parsed)
+            // this.makeFavorites(parsed)
             console.log(event)
             resolve()
           })
         this.$pool
           .on('ok', () => console.log('event saved'))
         setTimeout( () => resolve(), 2000 ) 
+      })
+    },
+    makeFavorites: function(nip23){
+      Object.keys(nip23).forEach( relay => {
+        this.store.relays.setFavorite(relay)
       })
     },
     setSyncStatus: function(nip23){

--- a/src/components/relays/partials/NostrSyncPopoverNag.vue
+++ b/src/components/relays/partials/NostrSyncPopoverNag.vue
@@ -122,7 +122,7 @@ export default {
       console.log('synced?', this.store.relays.nip23Synced)
     },  
     updateNip23: async function(){
-      await this.getNip32
+      await this.getNip23
       const currentNip23 = this.store.relays.getNip23
       Object.keys(currentNip23).forEach( relay => {
         currentNip23[relay].read = currentNip23[relay].read ? "true" : 'false'

--- a/src/components/relays/partials/NostrSyncPopoverNag.vue
+++ b/src/components/relays/partials/NostrSyncPopoverNag.vue
@@ -4,11 +4,11 @@
       <button 
         ref="btnRef" 
         type="button" 
-        v-on:click="togglePopover()" 
-        class="items-start cursor-not-allowed inline-flex items-center rounded border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
-            Sync Favs with Nostr
+        v-on:click="updateNip23()" 
+        class="items-start cursor-pointer inline-flex items-center rounded border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+            Sync with Nostr
         </button>
-      <div  ref="popoverRef" 
+      <!-- <div  ref="popoverRef" 
             v-bind:class="{'hidden': !popoverShow, 'block': popoverShow}" 
             class="bg-pink-600 border-0 mr-3 z-50 font-normal leading-normal text-sm max-w-xs text-left no-underline break-words rounded-lg
             ">
@@ -23,21 +23,107 @@
             implementation of user relay lists easier for everyone.
           </div>
         </div>
-      </div>
+      </div> -->
     </div>
   </div>
 </template>
 <script>
+import { toRefs } from "vue"
 import { createPopper } from "@popperjs/core";
+import { validateEvent, verifySignature, getEventHash } from 'nostr-tools'
+import safeStringify from 'fast-safe-stringify'
+
+import { setupStore } from '@/store'
 
 export default {
   name: "NostrSyncPopoverNag",
+  setup(props){
+    const {favoritesProp: favorites} = toRefs(props)
+    return { 
+      store : setupStore(),
+      favorites: favorites,
+    }
+  },
   data() {
     return {
       popoverShow: false
     }
   },
+  async mounted(){
+    this.setFavoritesAsNip23()
+    await this.getNip23()
+    console.log('nip23', this.store.relays.getNip23)
+    this.store.relays.$subscribe( mutation => {
+      console.log(mutation.events)
+    })
+  },  
   methods: {
+    setFavoritesAsNip23: function(){
+      // const nip23 = {}
+      // this.store.relays.getFavorites.forEach( relay => {
+      //   nip23[relay] = {}
+      //   nip23[relay].read = true
+      //   nip23[relay].write = true
+      // })
+      // this.store.relays.setNip23(nip23)
+      return true
+    },  
+    getNip23: async function(){
+      return new Promise( resolve => {
+        const subid = `kind1001-${this.store.user.getPublicKey}`
+        const filters = { limit:1, kinds:[10001], authors: [this.store.user.getPublicKey] }
+        console.log(filters) 
+        this.$pool
+          .subscribe(subid, filters)
+        this.$pool
+          .on('event', (relay, sub_id, event) => {
+            console.log(event)
+            if(sub_id !== subid)
+              return 
+            this.$pool.unsubscribe(subid)
+            const parsed = this.parseNip23(event)
+            // this.updateFavorites(parsed)
+            this.persistNip23(parsed)
+            console.log(event)
+            resolve()
+          })
+        setTimeout( () => resolve(), 2000 ) 
+      })
+    },
+    updateNip23: async function(){
+      await this.getNip32
+      const currentNip23 = this.store.relays.getNip23
+      const event = {
+        kind: 10001,
+        created_at: Math.floor(Date.now()/1000),
+        content: safeStringify(currentNip23),
+        tags: [],
+        pubkey: this.store.user.getPublicKey
+      }
+      console.log(event)
+      event.id = getEventHash(event)
+      console.log(event)
+      const signedEvent = await window.nostr.signEvent(event)
+
+      let ok = validateEvent(signedEvent)
+      let veryOk = await verifySignature(signedEvent)
+
+      if(!ok || !veryOk)
+        return
+
+      this.$pool.send(['EVENT', signedEvent])
+    },
+    parseNip23: function(event){
+      return JSON.parse(event.content)
+    },
+    updateFavorites: function(relays){
+      Object.keys(relays).forEach( relayUrl => {
+        this.store.relays.setFavorite(relayUrl)
+      })
+    }, 
+    persistNip23: function(relays){
+      this.store.relays.setNip23(relays)
+    },
     togglePopover: function(){
       if(this.popoverShow){
         this.popoverShow = false;

--- a/src/store/relays.js
+++ b/src/store/relays.js
@@ -16,7 +16,8 @@ export const useRelaysStore = defineStore('relays', {
     aggregatesAreSet: false,
     cached: new Object(),
     canonicals: new Object(),
-    nip23: new Object()
+    nip23: new Object(),
+    nip23Synced: new Object(),
   }),
   getters: {
     getAll: (state) => state.urls,
@@ -89,11 +90,13 @@ export const useRelaysStore = defineStore('relays', {
       this.favorites.push(relayUrl)
       this.favorites = this.favorites.map( x => x )
       if(typeof this.nip23[relayUrl] === 'undefined')
-        this.setNip23({ [relayUrl]: { read: false, write: false } })
+        this.setNip23({ [relayUrl]: { read: true, write: true } })
     },
 
     unsetFavorite(relayUrl){ 
       this.favorites = this.favorites.filter(item => item !== relayUrl)
+      if(typeof this.nip23[relayUrl] !== 'undefined')
+        delete this.store.relays.nip23[relayUrl]
     },
 
     toggleFavorite(relayUrl){
@@ -116,7 +119,11 @@ export const useRelaysStore = defineStore('relays', {
     },
 
     setNip23(obj){
-      this.nip23 = Object.assign(this.nip23, obj)
+      this.nip23 = Object.assign(obj, this.nip23)
+    },
+
+    setNip23Status(obj) {
+      this.nip23Synced = obj
     },
   },
 })

--- a/src/store/relays.js
+++ b/src/store/relays.js
@@ -15,7 +15,8 @@ export const useRelaysStore = defineStore('relays', {
     aggregates: {},
     aggregatesAreSet: false,
     cached: new Object(),
-    canonicals: new Object()
+    canonicals: new Object(),
+    nip23: new Object()
   }),
   getters: {
     getAll: (state) => state.urls,
@@ -51,28 +52,34 @@ export const useRelaysStore = defineStore('relays', {
 
     getCanonicals: state => state.canonicals,
     getCanonical: state => relay => state.canonicals[relay],
+
+    getNip23: state => state.nip23
   },
   actions: {
-    addRelay(relayUrl){ this.urls.push(relayUrl) },
-    addRelays(relayUrls){ this.urls = Array.from(new Set(this.urls.concat(this.urls, relayUrls))) },
-    setRelays(relayUrls){ this.urls = relayUrls },
+    addRelay(relayUrl){ 
+      this.urls.push(relayUrl)
+    },
 
-    // setResult(result){ 
-    //   // this.setStat('relays', this.)
-    //   this.results[result.url] = result 
-    // },
-    // setResults(results){ this.results = results },
-    // clearResults(){ this.results = {} },
+    addRelays(relayUrls){ 
+      this.urls = Array.from(new Set(this.urls.concat(this.urls, relayUrls))) 
+    },
 
-    setGeo(geo){ this.geo = geo },
+    setRelays(relayUrls){ 
+      this.urls = relayUrls 
+    },
 
-
+    setGeo(geo){ 
+      this.geo = geo 
+    },
 
     setStat(type, value){ 
       this.count[type] = value 
     },
 
-    setAggregate(aggregate, arr){ this.aggregates[aggregate] = arr },
+    setAggregate(aggregate, arr){ 
+      this.aggregates[aggregate] = arr 
+    },
+
     setAggregates(obj){ 
       this.aggregatesAreSet = true
       this.aggregates = obj 
@@ -81,6 +88,8 @@ export const useRelaysStore = defineStore('relays', {
     setFavorite(relayUrl){ 
       this.favorites.push(relayUrl)
       this.favorites = this.favorites.map( x => x )
+      if(typeof this.nip23[relayUrl] === 'undefined')
+        this.setNip23({ [relayUrl]: { read: false, write: false } })
     },
 
     unsetFavorite(relayUrl){ 
@@ -104,6 +113,10 @@ export const useRelaysStore = defineStore('relays', {
 
     setCanonicals(c){
       this.canonicals = c
-    }
+    },
+
+    setNip23(obj){
+      this.nip23 = Object.assign(this.nip23, obj)
+    },
   },
 })


### PR DESCRIPTION
# abandoned

The demo is not fully functional, and the rules it was built around are unpopular for nebulous reasons. After an evaluation of the three available approaches, 
- the most popular had an overly complex implementation
- the second most popular was better but still too high
- The most unpopular one was elegant and would be the only one I would introduce at this time.

Going to focus efforts on other features and revisit once there is adequate demand or a suitable NIP has been accepted. 

~Demonstrates NIP-23b, quick and dirty.~  

~https://github.com/nostr-protocol/nips/pull/164~

~Preview: https://deploy-preview-185--nostrwatch.netlify.app/~

~**notice: Not really that functional, due to the various possible states, quick and dirty isn't really feasible. Fun experiment.**~

~Usage: 
Login with a nostr-compatible extension, select a few favorites from list (heart emoji),navigate to "favorites" and click "sync with nostr"~ 

~Caveats:
"quick and dirty" for demonstration purposes, not for production.~

Notes for later:
- implement completely differently, have an edit mode and show read/write everywhere. Add preferences to manage some things like "automatically sync favorites", "default policy," etc... 
- load nip23 and automatically set all relays in nip23 as favorites 
- highlight relays that have not been synced 
- prompt user if they have unsaved changes and attempt to leave. 
- potential race condition: undiscovered relays could cause issues, push the undiscovered relay first
- infinite loop possiblity with store in `relays.setFavorite`
- Need to track whether a relay is synced separately instead of piggybacking off nip23 store key (favorites are provided a default nip23 policy to display inputs, throwing a false `true` on 'isNostrSynced') 
- also: hash parsing broke, can no longer link directly to tabs #186