### PR TITLE
Add ws:// Support

### DIFF
--- a/src/components/relays/pages/RelaysSingle.vue
+++ b/src/components/relays/pages/RelaysSingle.vue
@@ -1,5 +1,4 @@
 <template>
-  
   <RelaysNav/>
 
   <MapSingle

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -41,6 +41,10 @@ const routes = [
         ]
     },
     {
+        path: '/relay/:protocol(ws?s)/:relayUrl(.*)',
+        component: RelaysSingle
+    },
+    {
         path: '/relay/:relayUrl(.*)',
         component: RelaysSingle
     },

--- a/src/shared/computed.js
+++ b/src/shared/computed.js
@@ -6,7 +6,8 @@ export default {
     },
     path: function() { return useRoute().path },
     relayFromUrl() {
-        return `wss://${this.$route.params.relayUrl}`
+        const protocol = this.$route.params.protocol ? this.$route.params.protocol : 'wss'
+        return `${protocol}://${this.$route.params.relayUrl}`
     },
     isSingle(){
         return typeof this.$route.params.relayUrl !== 'undefined'


### PR DESCRIPTION
Running locally is a valid use case.

To use `ws://` relay, format the link as follows, remove `ws://`

`<host>:<port>/relay/ws/<relayws>` 

There is presently no support for `relays.yaml` but I'll think of a graceful way to do it.

![Screen Shot 2023-01-11 at 3 30 47 AM](https://user-images.githubusercontent.com/299465/211704311-e153d7ed-2c2c-402c-9b1a-354d956264fe.png)
