### PR TITLE
Add rsslay.nostr.moe

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -210,3 +210,4 @@ relays:
   - wss://nostr.kollider.xyz
   - wss://relay.nostr.band
   - wss://relay.nosphr.com
+  - wss://rsslay.nostr.moe


### PR DESCRIPTION
A custom fork of the rss-bridge relay of fiatjaf [piraces/rsslay](https://github.com/piraces/rsslay)