### PR TITLE
feat: adds zurich relay

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -221,3 +221,4 @@ relays:
   - wss://relay.nostr.moe
   - wss://relay.current.fyi
   - wss://nostr-bg01.ciph.rs
+  - wss://nostr-zu01.ciph.rs


### PR DESCRIPTION
adds: `wss://nostr-zu01.ciph.rs`