### PR TITLE
add flux nostr relay

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -241,3 +241,4 @@ relays:
   - wss://nostr.argdx.net
   - wss://global.relay.red
   - wss://relay.nostrgraph.net
+  - wss://nostr.app.runonflux.io


### PR DESCRIPTION
Flux hosts decentralized distributed applications on its network.

wss://nostr.app.runonflux.io