### PR TITLE
disable edit relays until there are more safeguards

### DIFF
--- a/src/components/relays/partials/NostrSync.vue
+++ b/src/components/relays/partials/NostrSync.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="inline" v-if="store.user.getPublicKey.length">
+<div class="inline" v-if="store.user.getPublicKey.length && false">
     <div class="inline text-left">
 
       <span v-if="savedSuccess" class="inline-block mr-3"> 


### PR DESCRIPTION
Was able to create an edge case that deletes contact lists, not an uncommon problem, but thought I had it figured out.

1. For relays that do not send `eose`, in certain network conditions and configurations, contact list can be completely wiped 
2. For specification configurations as the result of ignorance/haste, contact list can be completely wiped.

I have solutions that will be implemented, if I cannot do implement quickly, will add preference for advanced users to enable with warning. 