### PR TITLE
New pay-to-relay server bitcoiner.social

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -273,3 +273,4 @@ relays:
   - wss://relay.bleskop.com
   - wss://nostr.pcdkd.fyi
   - wss://spore.ws
+  - wss://bitcoiner.social


### PR DESCRIPTION
This is a new server that is separate from the existing public relay on nostr.bitcoiner.social