### PR TITLE
Public relay soft name change

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -180,7 +180,7 @@ relays:
   - wss://nostr.screaminglife.io
   - wss://deschooling.us
   - wss://relay-pub.deschooling.us
-  - wss://nostr.bitcoiner.social
+  - wss://offchain.pub
   - wss://nostr-pub1.southflorida.ninja
   - wss://nostr.ncsa.illinois.edu
   - wss://nostr.relayer.se


### PR DESCRIPTION
nostr.bitcoiner.social -> offchain.pub

I'm calling this "soft" since I don't plan to disable the old domain yet, and both domains work concurrently on the same relay server. But I want to (eventually) avoid the ambiguity of having two separate relays under the bitcoiner.social domain. Blame my lack of foresight and this [twitter poll](https://twitter.com/bitcoinersocial/status/1621231925057978368). Also I think the new name is cooler for the public relay.