### PR TITLE
Add relay.nostrology.org as a Nostr relay

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -285,3 +285,4 @@ relays:
   - wss://nostr.island.network
   - wss://nostr.nikolaj.online
   - wss://relay.nostrich.land
+  - wss://relay.nostrology.org


### PR DESCRIPTION
Hey folks, I'm hosting a new relay under the Nostrology brand. The underlying software is [astro](https://github.com/Nostrology/astro) and it currently supports  NIP-01, NIP-11, NIP-15, NIP-16, NIP-20