### PR TITLE
Added nostr.rocket-tech.net

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -308,3 +308,4 @@ relays:
   - wss://nostr.bitcoin-basel.ch
   - wss://relay.21baiwan.com
   - wss://nostr.howtobitcoin.shop
+  - wss://nostr.rocket-tech.net


### PR DESCRIPTION
nostr.rocket-tech.net is a new public relay.  Thanks for including it!