### PR TITLE
Adding Vida Global paid relay

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -354,3 +354,4 @@ relays:
   - wss://altcoinnect.xyz
   - wss://nostr.spleenrider.one
   - wss://noster.online
+  - wss://nostr01.vida.dev


### PR DESCRIPTION
Adding Vida Global's paid Nostream relay at wss://nostr01.vida.dev.  