### PR TITLE
adding nostr.naut.social relay

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -384,3 +384,4 @@ relays:
 - wss://nostr.chainbits.co.uk
 - wss://nostrrelay.geforcy.com
 - wss://relay.codl.co
+- wss://nostr.naut.social


### PR DESCRIPTION
mutiny wallet are using this list as their source of relays, and we want to be on their push list