### PR TITLE
Remove `nostr.mado.io` which is going dark soon.

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -162,7 +162,6 @@ relays:
 - wss://nostr.lordkno.ws
 - wss://nostr.lu.ke
 - wss://nostr.lukeacl.com
-- wss://nostr.mado.io
 - wss://nostr.massmux.com
 - wss://nostr.middling.mydns.jp
 - wss://nostr.mikedilger.com


### PR DESCRIPTION
When merged, this PR removes `nostr.mado.io` which is going offline soon.