### PR TITLE
Update relays.yaml - rm tunnelsats test relays

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -224,7 +224,6 @@ relays:
 - wss://nostr.swiss-enigma.ch
 - wss://dublin.saoirse.dev
 - wss://nostr.thibautrey.fr
-- wss://nostr.tunnelsats.com
 - wss://nostr.unknown.place
 - wss://nostr.up.railway.app
 - wss://nostr.uselessshit.co
@@ -249,7 +248,6 @@ relays:
 - wss://nostr01.opencult.com
 - wss://nostr01.vida.dev
 - wss://nostr1.starbackr.me
-- wss://nostr1.tunnelsats.com
 - wss://nostr2.actn.io
 - wss://nostr2.namek.link
 - wss://nostr21.com


### PR DESCRIPTION
This PR removes both tunnelsats test relays from the nostr.watch list. 