### PR TITLE
Update nostr.plebchain.org to ca.orangepill.dev

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -193,7 +193,7 @@ relays:
 - wss://nostr.oxtr.dev
 - wss://nostr.pleb.network
 - wss://nostr.pleb.network
-- wss://nostr.plebchain.org
+- wss://ca.orangepill.dev
 - wss://nostr.pobblelabs.org
 - wss://nostr.portemonero.com
 - wss://nostr.radixrat.com


### PR DESCRIPTION
Hi,

Nostr.plebchain.org is now renamed to ca.orangepill.dev and maintained by orangepill.dev.

Requesting you to kindly update.

Thank you,
Ezofox