### PR TITLE
Add relay.nostrss.re relay

### DIFF
--- a/relays.yaml
+++ b/relays.yaml
@@ -441,3 +441,4 @@ relays:
 - wss://nostr.cr0.bar
 - wss://relay.deezy.io
 - wss://nostr.maximacitadel.org
+- wss://relay.nostrss.re


### PR DESCRIPTION
Adds wss://relay.nostrss.re relay which is the main relay for personal [nostrss](https://www.github.com/Asone/nostrss) instance