### PR TITLE
hotfix: increase bunny deploy request timeout

### DIFF
--- a/.github/workflows/daily-seeded-gui-deploy.yml
+++ b/.github/workflows/daily-seeded-gui-deploy.yml
@@ -59,4 +59,6 @@ jobs:
           enable-purge-pull-zone: true
           pull-zone-id: "3313140"
           replication-timeout: "15000"
+          request-timeout: "30000"
+          retry-limit: "5"
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -54,3 +54,5 @@ jobs:
           enable-purge-pull-zone: true
           pull-zone-id: ${{ secrets.BUNNY_DOCS_PULL_ZONE_ID }}
           replication-timeout: "15000"
+          request-timeout: "30000"
+          retry-limit: "5"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -106,3 +106,5 @@ jobs:
           enable-purge-pull-zone: true
           pull-zone-id: "3313140"
           replication-timeout: "15000"
+          request-timeout: "30000"
+          retry-limit: "5"


### PR DESCRIPTION
## Summary
- Bunny CDN deploy was failing due to 5s default request timeout on large seed JSON files uploading to the Singapore endpoint
- Added `request-timeout: 30000` (30s) and `retry-limit: 5` to all three bunny-deploy workflow steps

## Test plan
- [ ] Verify next GUI deploy to Bunny succeeds without timeout errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)