### PR TITLE
hotfix: bump bunny-deploy to v2.1.1

### DIFF
--- a/.github/workflows/daily-seeded-gui-deploy.yml
+++ b/.github/workflows/daily-seeded-gui-deploy.yml
@@ -47,7 +47,7 @@ jobs:
           purge: true
 
       - name: Deploy to Bunny
-        uses: R-J-dev/bunny-deploy@v2.0.3
+        uses: R-J-dev/bunny-deploy@v2.1.1
         with:
           access-key: ${{ secrets.BUNNY_API_KEY }}
           directory-to-upload: "./apps/gui/dist"

--- a/.github/workflows/daily-seeded-gui-deploy.yml
+++ b/.github/workflows/daily-seeded-gui-deploy.yml
@@ -59,4 +59,6 @@ jobs:
           enable-purge-pull-zone: true
           pull-zone-id: "3313140"
           replication-timeout: "15000"
+          request-timeout: "30000"
+          retry-limit: "5"
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -54,3 +54,5 @@ jobs:
           enable-purge-pull-zone: true
           pull-zone-id: ${{ secrets.BUNNY_DOCS_PULL_ZONE_ID }}
           replication-timeout: "15000"
+          request-timeout: "30000"
+          retry-limit: "5"

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -42,7 +42,7 @@ jobs:
         run: du -sh docs/.vitepress/dist
 
       - name: Deploy to Bunny
-        uses: R-J-dev/bunny-deploy@v2.0.3
+        uses: R-J-dev/bunny-deploy@v2.1.1
         with:
           access-key: ${{ secrets.BUNNY_API_KEY }}
           directory-to-upload: "./docs/.vitepress/dist"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -106,3 +106,5 @@ jobs:
           enable-purge-pull-zone: true
           pull-zone-id: "3313140"
           replication-timeout: "15000"
+          request-timeout: "30000"
+          retry-limit: "5"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -94,7 +94,7 @@ jobs:
           purge: true
 
       - name: Deploy to Bunny
-        uses: R-J-dev/bunny-deploy@v2.0.3
+        uses: R-J-dev/bunny-deploy@v2.1.1
         with:
           access-key: ${{ secrets.BUNNY_API_KEY }}
           directory-to-upload: "./apps/gui/dist"


### PR DESCRIPTION
## Summary
- Previous fix added `request-timeout` and `retry-limit` inputs, but `v2.0.3` silently ignored them — support was only added in `v2.1.0`
- Bumps `R-J-dev/bunny-deploy` from `v2.0.3` to `v2.1.1` across all three workflows

## Test plan
- [ ] Verify next GUI deploy to Bunny succeeds without timeout errors on seed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)