### PR TITLE
hotfix: relay dedup family-scope

### DIFF
--- a/apps/relaymon/deno.lock
+++ b/apps/relaymon/deno.lock
@@ -2,6 +2,7 @@
   "version": "5",
   "specifiers": {
     "npm:@types/node@*": "22.15.15",
+    "npm:murmurhash@2.0.1": "2.0.1",
     "npm:nostr-fetch@0.17.0": "0.17.0"
   },
   "npm": {
@@ -26,6 +27,9 @@
       "dependencies": [
         "undici-types"
       ]
+    },
+    "murmurhash@2.0.1": {
+      "integrity": "sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew=="
     },
     "nostr-fetch@0.17.0": {
       "integrity": "sha512-Q0k12uTB5Cj4zTe5ZNsyr7dBMxZrncU+7UNH8G9Z6zyEERVoPT5Z49vNCVDw8yvFwzslKiWeoT143NF/9FlKbQ==",
@@ -311,6 +315,7 @@
   },
   "workspace": {
     "dependencies": [
+      "npm:murmurhash@2.0.1",
       "npm:nostr-fetch@0.17.0"
     ]
   }

--- a/apps/relaymon/src/db/db.ts
+++ b/apps/relaymon/src/db/db.ts
@@ -1,6 +1,7 @@
 import { db, initDB } from "npm:@nostrwatch/db";
 import { getLogger } from "../utils/logger.ts";
 import type { RelayInfo } from "../types/relay.ts";
+import { createInfoHash } from "../utils/hostnames.ts";
 
 const logger = getLogger("DB");
 let isInitialized = false;
@@ -33,6 +34,18 @@ export function initializeDB(dbPath?: string, enableWAL: boolean = true): void {
     logger.info("Created relay_info table if it didn't exist");
   } catch (e) {
     logger.error(`Failed to create relay_info table: ${e}`);
+  }
+
+  // Phase 18 Fix 2: schema migration tracking for one-shot migrations
+  try {
+    db.query(`
+      CREATE TABLE IF NOT EXISTS relaymon_migrations (
+        name TEXT PRIMARY KEY,
+        applied_at INTEGER
+      )
+    `);
+  } catch (e) {
+    logger.error(`Failed to create relaymon_migrations table: ${e}`);
   }
 
   // Create the relay_delta_state table for tracking state changes
@@ -84,6 +97,15 @@ export function initializeDB(dbPath?: string, enableWAL: boolean = true): void {
     logger.error(`Failed to create relay_period_snapshots table: ${e}`);
   }
 
+  // Phase 18 Fix 2: re-hash existing relay_info rows using the new
+  // normalizeNip11-aware createInfoHash. Idempotent via relaymon_migrations
+  // sentinel.
+  try {
+    rehashRelayInfoMigration();
+  } catch (e) {
+    logger.error(`rehashRelayInfoMigration threw: ${e}`);
+  }
+
   isInitialized = true;
 }
 
@@ -107,6 +129,67 @@ export function storeRelayInfo(url: string, info: RelayInfo, infoHash: string): 
     logger.debug(`Stored NIP-11 info for ${url} with hash ${infoHash}`);
   } catch (e) {
     logger.error(`Failed to store relay info for ${url}: ${e}`);
+  }
+}
+
+/**
+ * Phase 18 Fix 2: re-hash every row in relay_info using the new
+ * normalizeNip11 → createInfoHash pipeline.
+ *
+ * Idempotent: the sentinel row in relaymon_migrations ensures this runs
+ * exactly once per database lifetime. Also, re-running on an already-
+ * migrated DB produces identical hashes (the pipeline is deterministic).
+ *
+ * Resilient: malformed info_json rows are logged and skipped.
+ */
+export function rehashRelayInfoMigration(): void {
+  const migrationName = "phase18_rehash_relay_info_normalizeNip11_v1";
+  try {
+    const existing = db.query(
+      `SELECT applied_at FROM relaymon_migrations WHERE name = ?`,
+      [migrationName],
+    );
+    if (existing.length > 0) {
+      logger.debug(`Migration ${migrationName} already applied, skipping`);
+      return;
+    }
+
+    logger.info(`Running migration: ${migrationName}`);
+    const rows = db.query(`SELECT url, info_json FROM relay_info`);
+    let updated = 0;
+    let skipped = 0;
+    for (const [url, infoJson] of rows) {
+      try {
+        if (!infoJson || typeof infoJson !== "string") {
+          skipped++;
+          continue;
+        }
+        const info = JSON.parse(infoJson);
+        const newHash = createInfoHash(info);
+        if (!newHash) {
+          skipped++;
+          continue;
+        }
+        db.query(
+          `UPDATE relay_info SET info_hash = ? WHERE url = ?`,
+          [newHash, url as string],
+        );
+        updated++;
+      } catch (e) {
+        logger.warn(`Failed to rehash relay_info row for ${url}: ${e}`);
+        skipped++;
+      }
+    }
+
+    db.query(
+      `INSERT INTO relaymon_migrations (name, applied_at) VALUES (?, ?)`,
+      [migrationName, Math.floor(Date.now() / 1000)],
+    );
+    logger.info(
+      `Migration ${migrationName} complete: ${updated} rows re-hashed, ${skipped} skipped`,
+    );
+  } catch (e) {
+    logger.error(`Migration ${migrationName} failed: ${e}`);
   }
 }
 

--- a/apps/relaymon/src/db/db.ts
+++ b/apps/relaymon/src/db/db.ts
@@ -2,6 +2,7 @@ import { db, initDB } from "npm:@nostrwatch/db";
 import { getLogger } from "../utils/logger.ts";
 import type { RelayInfo } from "../types/relay.ts";
 import { createInfoHash } from "../utils/hostnames.ts";
+import { rerunDedupForAllRowsMigration } from "../utils/remediation.ts";
 
 const logger = getLogger("DB");
 let isInitialized = false;
@@ -105,6 +106,17 @@ export function initializeDB(dbPath?: string, enableWAL: boolean = true): void {
   } catch (e) {
     logger.error(`rehashRelayInfoMigration threw: ${e}`);
   }
+
+  // Phase 19 REMED-01/REMED-02: re-run dedup over every row in
+  // relay_status using the now-fixed relayHostnameDedup (Phase 18 Fixes
+  // 1–3). Idempotent via relaymon_migrations sentinel. MUST run AFTER
+  // rehashRelayInfoMigration so the re-dedup sees stable hashes.
+  // Fire-and-forget async — initializeDB is sync, but the migration is
+  // async because relayHostnameDedup is async. Any error is swallowed
+  // inside the migration itself (never crashes startup).
+  rerunDedupForAllRowsMigration().catch((e) => {
+    logger.error(`rerunDedupForAllRowsMigration threw: ${e}`);
+  });
 
   isInitialized = true;
 }

--- a/apps/relaymon/src/utils/hostnames.ts
+++ b/apps/relaymon/src/utils/hostnames.ts
@@ -151,6 +151,19 @@ export const relayHostnameDedup = async (result: RelayCheckResult): Promise<Rela
       throw new Error(`Invalid result object: ${JSON.stringify(result)}`);
     }
 
+    // Phase 18 Fix 3: canonicalize mURL at function entry so all
+    // downstream URL comparisons happen in canonical form. normalizeURL
+    // (from nostr-tools/utils) strips trailing slashes from path URLs,
+    // which would otherwise cause orderedFamily.indexOf(mURL) to return
+    // -1 for URLs like "wss://haven.nostrfreedom.net/inbox/" — triggering
+    // the CRITICAL ERROR branch and wrongly ignoring legit path-only relays.
+    let canonicalMURL: string;
+    try {
+      canonicalMURL = normalizeURL(mURL);
+    } catch {
+      canonicalMURL = mURL;
+    }
+
     // Check if this relay is in the synced ignore list from other monitors
     if (ignoreListSyncInstance && ignoreListSyncInstance.isIgnored(mURL)) {
       logger.warn(`${mURL} is in synced ignore list from other monitors`);
@@ -256,7 +269,7 @@ export const relayHostnameDedup = async (result: RelayCheckResult): Promise<Rela
     }
 
     const hostnameFamily = online.filter((r: OnlineRelay) =>
-      r.hostname === HOSTNAME && r.protocol === PROTOCOL && r.url !== mURL
+      r.hostname === HOSTNAME && r.protocol === PROTOCOL && r.url !== canonicalMURL
     );
     const hostnameRelatives = [...hostnameFamily];
 
@@ -274,7 +287,7 @@ export const relayHostnameDedup = async (result: RelayCheckResult): Promise<Rela
       // or offline). If found, mark the current URL as a duplicate of the
       // shortest known sibling.
       const allKnownSiblings = getRelaysByHostname(HOSTNAME, PROTOCOL).filter(
-        (u) => u !== mURL
+        (u) => u !== canonicalMURL
       );
       if (allKnownSiblings.length > 0) {
         allKnownSiblings.sort((a, b) => {
@@ -346,7 +359,7 @@ export const relayHostnameDedup = async (result: RelayCheckResult): Promise<Rela
 
     // Order each relay in the hostname map by URL path depth.
     const urlSegmentOrderedMap = relayArrToHostnameProtocolKeyedMap(
-      [...hostnameRelatives.map((r) => r.url), mURL]
+      [...hostnameRelatives.map((r) => r.url), canonicalMURL]
     );
     const orderedFamily = (urlSegmentOrderedMap.get(`${PROTOCOL}//${HOSTNAME}`) || []).map((r) =>
       normalizeURL(r)
@@ -357,12 +370,12 @@ export const relayHostnameDedup = async (result: RelayCheckResult): Promise<Rela
       logger.debug(`  [${idx}] ${url}`);
     });
     
-    let orderedRelatives = orderedFamily.filter((r) => r !== mURL);
+    let orderedRelatives = orderedFamily.filter((r) => r !== canonicalMURL);
     if (!orderedRelatives || orderedRelatives.length === 0) {
       logger.error(`Ordered relatives not found for ${PROTOCOL}//${HOSTNAME}`);
       return result;
     }
-    const index = orderedFamily.indexOf(mURL);
+    const index = orderedFamily.indexOf(canonicalMURL);
     
     logger.debug(`Current URL index in ordered family: ${index}`);
     logger.debug(`Ordered relatives: ${JSON.stringify(orderedRelatives)}`);
@@ -389,9 +402,9 @@ export const relayHostnameDedup = async (result: RelayCheckResult): Promise<Rela
       
       const isSameAsOlderRelative = foundAtIndex < index;
       const isSameAsYoungerRelative = foundAtIndex > index;
-      const pathnameIsPubkey = new URL(mURL).pathname.split("/").some((p) => isPubkey(p));
-      const pathnameContainsPubkey = containsPubkey(new URL(mURL).pathname);
-      const pathnameContainsHostname = new URL(mURL).pathname.includes(HOSTNAME);
+      const pathnameIsPubkey = new URL(canonicalMURL).pathname.split("/").some((p) => isPubkey(p));
+      const pathnameContainsPubkey = containsPubkey(new URL(canonicalMURL).pathname);
+      const pathnameContainsHostname = new URL(canonicalMURL).pathname.includes(HOSTNAME);
 
       logger.debug(`Detailed condition analysis for ${mURL}:`);
       logger.debug(`  foundAtIndex: ${foundAtIndex}`);
@@ -422,7 +435,7 @@ export const relayHostnameDedup = async (result: RelayCheckResult): Promise<Rela
       
       // New condition for URLs with paths that have the same NIP-11 info as any relative
       const reason8 = "URL with path has identical NIP-11 info to another relay with same hostname";
-      const isPathUrl = (new URL(mURL).pathname !== "/" && new URL(mURL).pathname !== "");
+      const isPathUrl = (new URL(canonicalMURL).pathname !== "/" && new URL(canonicalMURL).pathname !== "");
       const case8 = isPathUrl && infoHash !== "" && isSameAsAnyRelative;
       
       logger.debug(`Case evaluations: [1:${case1}] [2:${case2}] [3:${case3}] [4:${case4}] [5:${case5}] [6:${case6}] [7:${case7}] [8:${case8}]`);

--- a/apps/relaymon/src/utils/hostnames.ts
+++ b/apps/relaymon/src/utils/hostnames.ts
@@ -7,6 +7,7 @@ import { deleteRelayCheckEvent } from "./deletion.ts";
 import type { Config } from "../config/config.ts";
 import type { RelayCheckResult, RelayInfo } from "../types/relay.ts";
 import { getErrorMessage } from "../types/errors.ts";
+import { normalizeNip11 } from "./nip11.ts";
 
 // Force console output for debugging
 
@@ -109,10 +110,23 @@ export function createInfoHash(infoData: RelayInfo | Record<string, unknown> | n
   }
 
   try {
+    // Phase 18 Fix 2: strip volatile NIP-11 fields BEFORE sorting/hashing.
+    // Phase 17 Hypothesis B confirmed that volatile fields (timestamps,
+    // counters, last_*, current_*) cause the same server to produce
+    // different hashes across check cycles, defeating case1/case2/case8.
+    const stripped = normalizeNip11(infoData as Record<string, unknown>);
+
+    // After stripping, the object may be empty (e.g., if every field was
+    // volatile). In that case return "" to match the early-return contract
+    // above and avoid a universal "empty-normalized" hash collision.
+    if (Object.keys(stripped).length === 0) {
+      return "";
+    }
+
     // Sort the keys to ensure consistent hashing regardless of object property order
     const normalized: Record<string, unknown> = {};
-    Object.keys(infoData).sort().forEach(key => {
-      normalized[key] = (infoData as Record<string, unknown>)[key];
+    Object.keys(stripped).sort().forEach(key => {
+      normalized[key] = stripped[key];
     });
     return `RelayCheckInfo@${hash(normalized)}`;
   } catch (e) {

--- a/apps/relaymon/src/utils/hostnames.ts
+++ b/apps/relaymon/src/utils/hostnames.ts
@@ -2,7 +2,7 @@
 import { getLogger, LogLevel } from "./logger.ts";
 import { normalizeURL } from "npm:nostr-tools/utils";
 import hash from "npm:object-hash";
-import { getOnlineRelays, getRelayInfo, storeRelayInfo, getRelaysWithSameInfo } from "../db/db.ts";
+import { getOnlineRelays, getRelayInfo, storeRelayInfo, getRelaysWithSameInfo, getRelaysByHostname } from "../db/db.ts";
 import { deleteRelayCheckEvent } from "./deletion.ts";
 import type { Config } from "../config/config.ts";
 import type { RelayCheckResult, RelayInfo } from "../types/relay.ts";
@@ -252,7 +252,35 @@ export const relayHostnameDedup = async (result: RelayCheckResult): Promise<Rela
     });
 
     if (!hostnameRelatives?.length) {
-      logger.debug(`No relatives found for ${mURL}, returning without modification`);
+      // Phase 18 Fix 1: defensive-deny against the no-relatives race.
+      // Phase 17 Hypothesis C confirmed that when a mutation URL's dedup runs
+      // before its legit sibling's relay_status online=1 commit is visible,
+      // the family is empty and the mutation escapes. Before giving up, check
+      // for ANY sibling of the same hostname+protocol in relay_status (online
+      // or offline). If found, mark the current URL as a duplicate of the
+      // shortest known sibling.
+      const allKnownSiblings = getRelaysByHostname(HOSTNAME, PROTOCOL).filter(
+        (u) => u !== mURL
+      );
+      if (allKnownSiblings.length > 0) {
+        allKnownSiblings.sort((a, b) => {
+          if (a.length !== b.length) return a.length - b.length;
+          return a < b ? -1 : a > b ? 1 : 0;
+        });
+        const shortestSibling = allKnownSiblings[0];
+        result.ignore = true;
+        result.parent = shortestSibling;
+        const reason = `hostname has known siblings (defensive deny — Phase 18 Fix 1, parent: ${shortestSibling})`;
+        logger.warn(`${mURL} | Ignored because: ${reason}`);
+        if (ignoreListSyncInstance) {
+          ignoreListSyncInstance.addToIgnoreList(mURL, reason);
+        }
+        if (appConfig) {
+          await deleteRelayCheckEvent(mURL, reason, appConfig);
+        }
+        return result;
+      }
+      logger.debug(`No relatives or known siblings found for ${mURL}, returning without modification`);
       return result;
     }
 

--- a/apps/relaymon/src/utils/nip11.ts
+++ b/apps/relaymon/src/utils/nip11.ts
@@ -1,0 +1,81 @@
+// apps/relaymon/src/utils/nip11.ts
+//
+// Phase 18 Fix 2: normalize NIP-11 info to strip volatile fields before
+// hashing. Phase 17 Hypothesis B confirmed that createInfoHash() produces
+// different hashes for the same server across check cycles when volatile
+// fields (timestamps, counters, last_*, current_*) are present — defeating
+// the case1/case2/case8 dedup logic.
+//
+// This helper is pure and dependency-free for ease of unit testing.
+
+/** Exact keys (case-insensitive) to strip before hashing. */
+const VOLATILE_KEYS = new Set<string>([
+  "time",
+  "timestamp",
+  "now",
+  "server_time",
+  "current_time",
+  "started_at",
+  "last_updated",
+  "updated_at",
+  "uptime",
+  "now_iso",
+  "url", // nostr-tools may reflect the requesting URL into info — strip it
+]);
+
+/** Key prefixes (case-insensitive) to strip before hashing. */
+const VOLATILE_PREFIXES: string[] = [
+  "last_",
+  "current_",
+  "counter_",
+  "count_",
+];
+
+/**
+ * Substring patterns (case-insensitive) to strip before hashing.
+ *
+ * KNOWN over-match: the substring "count" also strips benign keys like
+ * "account" and "discount". These are not standard NIP-11 fields for relay
+ * metadata, so the over-match is acceptable for Phase 18. If a future
+ * relay implementation starts exposing such a key as a persistent
+ * identifier, this list can be tightened.
+ */
+const VOLATILE_SUBSTRINGS: string[] = [
+  "count",
+];
+
+/**
+ * Strip volatile fields from a NIP-11 info object so that two check cycles
+ * of the same server produce the same hash.
+ *
+ * Returns a new object — never mutates the input.
+ * Null-safe: returns {} for null/undefined/non-object input.
+ *
+ * Matching rules (all case-insensitive):
+ *   1. Exact key in VOLATILE_KEYS → stripped
+ *   2. Key starts with any VOLATILE_PREFIXES entry → stripped
+ *   3. Key contains any VOLATILE_SUBSTRINGS entry → stripped
+ *
+ * Idempotent: normalizeNip11(normalizeNip11(x)) === normalizeNip11(x).
+ */
+export function normalizeNip11(
+  info: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  if (!info || typeof info !== "object") return {};
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(info)) {
+    const k = key.toLowerCase();
+    if (VOLATILE_KEYS.has(k)) continue;
+    let matched = false;
+    for (const prefix of VOLATILE_PREFIXES) {
+      if (k.startsWith(prefix)) { matched = true; break; }
+    }
+    if (matched) continue;
+    for (const sub of VOLATILE_SUBSTRINGS) {
+      if (k.includes(sub)) { matched = true; break; }
+    }
+    if (matched) continue;
+    out[key] = info[key];
+  }
+  return out;
+}

--- a/apps/relaymon/src/utils/remediation.ts
+++ b/apps/relaymon/src/utils/remediation.ts
@@ -1,0 +1,191 @@
+/**
+ * Phase 19 Remediation: Re-run dedup over every row in relay_status.
+ *
+ * Why this exists
+ * ---------------
+ * Pre-Phase-18, ~200 URL-path-mutation rows slipped past dedup and were
+ * promoted into `relay_status` as `ignore=0, parent=''`. Phase 18 Fixes
+ * 1–3 closed the bug going forward, but existing rows still carry the
+ * wrong state. This one-shot startup migration walks every row and
+ * re-evaluates it against the now-fixed `relayHostnameDedup`, writing
+ * back any changes.
+ *
+ * Narrowness guarantee
+ * --------------------
+ * Every `(ignore, parent)` mutation flows through `relayHostnameDedup`.
+ * There is NO independent decision logic in this file. A legit path-only
+ * relay that `relayHostnameDedup` returns as `ignore=false` stays
+ * `ignore=false`. A legit path-only relay WITH a matching-NIP-11 root
+ * sibling will correctly be flipped to `ignore=true` — that IS the
+ * dedup philosophy (shortest URL is canonical), not a regression.
+ *
+ * Idempotency
+ * -----------
+ * Guarded by the `rerun_dedup_all_rows_v1` sentinel row in the
+ * `relaymon_migrations` table (created by Phase 18 Fix 2). First call
+ * does the work and inserts the sentinel. Second call returns early.
+ *
+ * Ordering
+ * --------
+ * MUST run AFTER `rehashRelayInfoMigration()` so the re-dedup step sees
+ * the stable, normalizeNip11-scrubbed hashes. See db.ts `initializeDB`.
+ */
+
+import { db, getRelayInfo } from "../db/db.ts";
+import { relayHostnameDedup } from "./hostnames.ts";
+import { getLogger } from "./logger.ts";
+import type { RelayCheckResult } from "../types/relay.ts";
+import type { NetworkType } from "../types/config.ts";
+
+const logger = getLogger("Remediation");
+
+const MIGRATION_NAME = "rerun_dedup_all_rows_v1";
+
+export async function rerunDedupForAllRowsMigration(): Promise<void> {
+  // Top-level try: never let this migration crash startup.
+  try {
+    // Idempotency guard: sentinel row in relaymon_migrations means we
+    // already ran on this DB. Return silently.
+    const existing = db.query(
+      `SELECT applied_at FROM relaymon_migrations WHERE name = ?`,
+      [MIGRATION_NAME],
+    );
+    if (existing.length > 0) {
+      logger.debug(
+        `Migration ${MIGRATION_NAME} already applied, skipping`,
+      );
+      return;
+    }
+
+    logger.info(`Running migration: ${MIGRATION_NAME}`);
+    const startTime = Date.now();
+
+    // Iterate every row in relay_status regardless of online state. We
+    // need `ignore_reason` and `network` from the row because we
+    // construct a full RelayCheckResult to hand to relayHostnameDedup —
+    // the function asserts required fields via TypeScript.
+    const rows = db.query(
+      `SELECT url, ignore, parent, online, ignore_reason, network, checked_at
+       FROM relay_status`,
+    );
+
+    let evaluated = 0;
+    let newlyIgnored = 0;
+    let newlyUnignored = 0;
+    let unchanged = 0;
+
+    for (const row of rows) {
+      const [
+        urlRaw,
+        storedIgnoreRaw,
+        storedParentRaw,
+        onlineRaw,
+        ignoreReasonRaw,
+        networkRaw,
+        checkedAtRaw,
+      ] = row;
+
+      const url = urlRaw as string;
+      const storedIgnore = (storedIgnoreRaw as number) === 1;
+      const storedParent = (storedParentRaw as string) || "";
+      const online = (onlineRaw as number) === 1;
+      const ignoreReason = (ignoreReasonRaw as string) || "";
+      const network = ((networkRaw as string) || "clearnet") as NetworkType;
+      const checkedAt = (checkedAtRaw as number) || 0;
+
+      evaluated++;
+
+      try {
+        // Parse the URL so we can fill in hostname and protocol —
+        // relayHostnameDedup throws if these are missing.
+        let parsed: URL;
+        try {
+          parsed = new URL(url);
+        } catch (e) {
+          logger.warn(
+            `Skipping malformed URL in relay_status: ${url} (${e})`,
+          );
+          continue;
+        }
+
+        // Pull cached NIP-11 info if available. getRelayInfo returns
+        // null for rows with no cached NIP-11 — that's fine, the
+        // no-NIP-11 branch of relayHostnameDedup handles it.
+        const cachedInfo = getRelayInfo(url);
+        const infoForDedup = cachedInfo
+          ? {
+              data: cachedInfo.info,
+              duration: 0,
+            }
+          : undefined;
+
+        // Construct a minimal RelayCheckResult. relayHostnameDedup
+        // mutates .ignore and .parent on this object and returns it.
+        const result: RelayCheckResult = {
+          url,
+          hostname: parsed.hostname,
+          protocol: parsed.protocol,
+          checked_at: checkedAt,
+          online,
+          ignore: storedIgnore,
+          ignore_reason: ignoreReason,
+          parent: storedParent,
+          network,
+          info: infoForDedup,
+        };
+
+        const deduped = await relayHostnameDedup(result);
+
+        const newIgnore = deduped.ignore;
+        const newParent = deduped.parent || "";
+
+        if (newIgnore !== storedIgnore || newParent !== storedParent) {
+          db.query(
+            `UPDATE relay_status SET ignore = ?, parent = ? WHERE url = ?`,
+            [newIgnore ? 1 : 0, newParent, url],
+          );
+          if (newIgnore && !storedIgnore) newlyIgnored++;
+          else if (!newIgnore && storedIgnore) newlyUnignored++;
+          logger.info(
+            `Remediation: ${url} ignore=${storedIgnore}/parent="${storedParent}" → ignore=${newIgnore}/parent="${newParent}"`,
+          );
+        } else {
+          unchanged++;
+        }
+      } catch (e) {
+        logger.error(
+          `Remediation: failed to re-evaluate ${url}: ${e}`,
+        );
+      }
+    }
+
+    const durationMs = Date.now() - startTime;
+
+    // Structured JSON summary — single greppable line. Field names
+    // are stable for the operator's post-rollout grep.
+    logger.info(
+      JSON.stringify({
+        migration: MIGRATION_NAME,
+        rows_evaluated: evaluated,
+        newly_ignored: newlyIgnored,
+        newly_unignored: newlyUnignored,
+        unchanged: unchanged,
+        duration_ms: durationMs,
+      }),
+    );
+
+    // Insert sentinel only after successful completion so a partial
+    // run can be retried on next restart.
+    db.query(
+      `INSERT INTO relaymon_migrations (name, applied_at) VALUES (?, ?)`,
+      [MIGRATION_NAME, Math.floor(Date.now() / 1000)],
+    );
+
+    logger.info(
+      `Migration ${MIGRATION_NAME} complete: ${evaluated} evaluated, ${newlyIgnored} newly ignored, ${newlyUnignored} newly unignored, ${unchanged} unchanged, ${durationMs}ms`,
+    );
+  } catch (e) {
+    logger.error(`Migration ${MIGRATION_NAME} failed: ${e}`);
+    // Intentionally no rethrow — never crash startup.
+  }
+}

--- a/apps/relaymon/tests/unit/hostname-dedup.test.ts
+++ b/apps/relaymon/tests/unit/hostname-dedup.test.ts
@@ -15,6 +15,7 @@ import {
   relayArrToHostnameProtocolKeyedMap,
   createInfoHash,
   setConfig,
+  reevaluateAllDeduplication,
 } from "../../src/utils/hostnames.ts";
 import { mockConfig } from "../helpers/fixtures.ts";
 import { initializeDB, storeRelayInfo, db, getOnlineRelays, getRelayInfo } from "../../src/db/db.ts";
@@ -787,4 +788,272 @@ dedupTest("relay-dedup-family-scope split-outcome reproduction: canonical lumina
   assertEquals(typeof snapshots.umbraVertex.finalIgnore, "boolean");
   assert(Array.isArray(snapshots.hotel.branchHypothesis));
   assert(Array.isArray(snapshots.umbraVertex.branchHypothesis));
+});
+
+// ============================================================================
+// Phase 17 Plan 02: Hypothesis-isolating tests
+//
+// Each test flips exactly one variable against the canonical fixture and
+// captures the dedup outcome via captureDedupSnapshot. Five tests total:
+//   A: family scope coupled to online=1
+//   B: NIP-11 hash instability under volatile field deltas
+//   C: first-check race within a single batch
+//   D: reevaluateAllDeduplication reuses narrow scope
+//   red-herring: hostnames.ts:328-331 index===0 branch
+// ============================================================================
+
+/**
+ * Hypothesis A: family scope coupled to online=1
+ *
+ * Flips the sibling root from online=1 to online=0 — single variable change.
+ * If hypothesis A holds, the mutation URL escapes dedup when the root is offline
+ * because getOnlineRelays() excludes offline relays from the family.
+ */
+dedupTest("family-scope hypothesis A: sibling online=0 excludes legit root from family", async () => {
+  const canonicalNip11 = mockRelayInfo("Lumina Rocks", "relay.lumina.rocks unreadable");
+
+  // Variant 1: sibling online=1 (the "caught" configuration)
+  setupDatabase([
+    { url: "wss://relay.lumina.rocks/", online: true, info: canonicalNip11 },
+    { url: "wss://relay.lumina.rocks/umbra-vertex", online: true, info: canonicalNip11 },
+  ]);
+  const snapshotSiblingOnline = await captureDedupSnapshot({
+    url: "wss://relay.lumina.rocks/umbra-vertex",
+    hostname: "relay.lumina.rocks",
+    protocol: "wss:",
+    info: { data: canonicalNip11 },
+  });
+
+  // Variant 2: sibling online=0 — SINGLE VARIABLE FLIPPED
+  setupDatabase([
+    { url: "wss://relay.lumina.rocks/", online: false, info: canonicalNip11 },  // THE FLIP
+    { url: "wss://relay.lumina.rocks/umbra-vertex", online: true, info: canonicalNip11 },
+  ]);
+  const snapshotSiblingOffline = await captureDedupSnapshot({
+    url: "wss://relay.lumina.rocks/umbra-vertex",
+    hostname: "relay.lumina.rocks",
+    protocol: "wss:",
+    info: { data: canonicalNip11 },
+  });
+
+  console.log(JSON.stringify({
+    hypothesis: "A",
+    siblingOnline: snapshotSiblingOnline,
+    siblingOffline: snapshotSiblingOffline,
+  }, null, 2));
+
+  // Minimal invariants — plan 03 reads the console output to verdict the hypothesis
+  assert(snapshotSiblingOnline !== undefined);
+  assert(snapshotSiblingOffline !== undefined);
+});
+
+/**
+ * Hypothesis B: NIP-11 hash instability under volatile field deltas
+ *
+ * Compares hashes produced by createInfoHash() when volatile fields (timestamp,
+ * counters) are added to an otherwise identical NIP-11 object. If hashesEqual
+ * is false, hypothesis B is supported — the early-return path at lines 160-207
+ * would fail to match a relay whose NIP-11 gained new volatile fields since the
+ * last check.
+ */
+dedupTest("family-scope hypothesis B: NIP-11 hash stability across volatile field deltas", async () => {
+  // Build two NIP-11 objects that represent "same server" but with fields
+  // that commonly vary across checks (adjust if hostnames.ts/createInfoHash normalizes them):
+  const nip11Stable = { ...mockRelayInfo("Lumina Rocks", "unreadable") };
+  const nip11Volatile = {
+    ...mockRelayInfo("Lumina Rocks", "unreadable"),
+    // Candidate volatile additions — createInfoHash sorts keys but does not
+    // strip any. If any of these hash-diverges from nip11Stable, that is
+    // evidence for hypothesis B.
+    timestamp: Date.now(),
+    counters: { messages: 12345 },
+  };
+
+  const hashA = createInfoHash(nip11Stable);
+  const hashB = createInfoHash(nip11Volatile);
+
+  // Run dedup with stable family info but give the current relay the volatile variant
+  setupDatabase([
+    { url: "wss://relay.lumina.rocks/", online: true, info: nip11Stable },
+    { url: "wss://relay.lumina.rocks/hotel", online: true, info: nip11Stable },
+  ]);
+  const snapshotVolatile = await captureDedupSnapshot({
+    url: "wss://relay.lumina.rocks/umbra-vertex",
+    hostname: "relay.lumina.rocks",
+    protocol: "wss:",
+    info: { data: nip11Volatile },
+  });
+
+  console.log(JSON.stringify({
+    hypothesis: "B",
+    hashStable: hashA,
+    hashVolatile: hashB,
+    hashesEqual: hashA === hashB,
+    snapshot: snapshotVolatile,
+  }, null, 2));
+
+  assert(snapshotVolatile !== undefined);
+  // Do NOT assert hashA !== hashB — if they ARE equal, that is itself evidence
+  // ruling out hypothesis B. Plan 03 reads the log to verdict.
+});
+
+/**
+ * Hypothesis C: first-check race within a single batch
+ *
+ * Simulates the case where the mutation URL's dedup runs before the legit
+ * sibling's current-cycle online=1 commit appears in relay_status. The
+ * "pre-race" fixture has no sibling row at all.
+ */
+dedupTest("family-scope hypothesis C: mutation checked before sibling online=1 commit appears family-less", async () => {
+  const canonicalNip11 = mockRelayInfo("Lumina Rocks", "unreadable");
+
+  // Pre-race state: sibling row does not yet exist in relay_status at all
+  // (simulating the mutation being dedup'd BEFORE the legit sibling's batch
+  // entry has been committed this cycle).
+  setupDatabase([
+    { url: "wss://relay.lumina.rocks/umbra-vertex", online: true, info: canonicalNip11 },
+    // NOTE: no sibling row at all — simulates pre-commit race
+  ]);
+  const snapshotPreRace = await captureDedupSnapshot({
+    url: "wss://relay.lumina.rocks/umbra-vertex",
+    hostname: "relay.lumina.rocks",
+    protocol: "wss:",
+    info: { data: canonicalNip11 },
+  });
+
+  // Post-race state: sibling row exists and is online
+  setupDatabase([
+    { url: "wss://relay.lumina.rocks/", online: true, info: canonicalNip11 },
+    { url: "wss://relay.lumina.rocks/umbra-vertex", online: true, info: canonicalNip11 },
+  ]);
+  const snapshotPostRace = await captureDedupSnapshot({
+    url: "wss://relay.lumina.rocks/umbra-vertex",
+    hostname: "relay.lumina.rocks",
+    protocol: "wss:",
+    info: { data: canonicalNip11 },
+  });
+
+  console.log(JSON.stringify({
+    hypothesis: "C",
+    preRace: snapshotPreRace,
+    postRace: snapshotPostRace,
+  }, null, 2));
+
+  assert(snapshotPreRace !== undefined);
+  assert(snapshotPostRace !== undefined);
+});
+
+/**
+ * Hypothesis D: reevaluateAllDeduplication reuses getOnlineRelays narrow scope
+ *
+ * Seeds the DB with an offline root (legit sibling) and an online mutation
+ * URL that has not been caught (ignore=0, parent=""). Calls
+ * reevaluateAllDeduplication with a very long TTL (1 year) so the NIP-11
+ * cache is considered fresh — no network calls. If hypothesis D holds, the
+ * re-evaluation run also misses the mutation because it still uses the same
+ * getOnlineRelays() narrow scope.
+ *
+ * NOTE: reevaluateAllDeduplication does an unconditional dynamic import of
+ * @nostrwatch/nocap at its top. With sanitizeOps: false and needsNip11Refresh=false
+ * (since checked_at is fresh and relay_info is populated by setupDatabase),
+ * the import resolves but no network connection is opened.
+ */
+dedupTest("family-scope hypothesis D: reevaluateAllDeduplication reuses getOnlineRelays narrow scope", async () => {
+  const canonicalNip11 = mockRelayInfo("Lumina Rocks", "unreadable");
+
+  // Configuration: legit sibling currently online=0 (spam-promoted URL is online=1 and
+  // was previously marked ignore=0, parent=""). If hypothesis D holds, re-running
+  // dedup across all online relays will STILL miss the mutation because the offline
+  // sibling is invisible to getOnlineRelays().
+  setupDatabase([
+    { url: "wss://relay.lumina.rocks/", online: false, info: canonicalNip11 },  // offline sibling
+    {
+      url: "wss://relay.lumina.rocks/umbra-vertex",
+      online: true,
+      ignore: false,
+      parent: "",
+      info: canonicalNip11,
+    },
+  ]);
+
+  // Capture the pre-reevaluate state via snapshot (single check)
+  const snapshotBefore = await captureDedupSnapshot({
+    url: "wss://relay.lumina.rocks/umbra-vertex",
+    hostname: "relay.lumina.rocks",
+    protocol: "wss:",
+    info: { data: canonicalNip11 },
+  });
+
+  // Invoke reevaluateAllDeduplication. Seed a large TTL so the
+  // NIP-11 cache is considered fresh (no network call). The import at plan 01
+  // already brings in hostnames helpers — reevaluateAllDeduplication is added
+  // to the same import statement in this plan.
+  const changedRelays = await reevaluateAllDeduplication(365 * 24 * 60 * 60 * 1000); // 1 year TTL
+
+  // Capture post-reevaluate state by re-reading the DB directly for the mutation URL
+  const postRow = db.query(
+    "SELECT ignore, parent FROM relay_status WHERE url = ?",
+    ["wss://relay.lumina.rocks/umbra-vertex"],
+  );
+  const postIgnore = postRow.length > 0 ? postRow[0][0] : null;
+  const postParent = postRow.length > 0 ? postRow[0][1] : null;
+
+  console.log(JSON.stringify({
+    hypothesis: "D",
+    before: snapshotBefore,
+    reevaluateChangedRelays: changedRelays.length,
+    reevaluateChangedUrls: changedRelays.map((r: any) => r.url),
+    afterIgnore: postIgnore,
+    afterParent: postParent,
+  }, null, 2));
+
+  assert(snapshotBefore !== undefined);
+  assert(Array.isArray(changedRelays));
+});
+
+/**
+ * Red-herring test: hostnames.ts:328-331 index===0 branch
+ *
+ * Tests the specific branch at lines 328-331 that resets ignore=false and
+ * parent="" when the URL is the ordered family's index===0 member. Seeds a URL
+ * with ignore=1 and parent set to a sibling that no longer exists. Runs dedup
+ * and observes whether the result flips back to ignore=false.
+ *
+ * If finalIgnore flips to false: the index===0 branch IS active in the defect path.
+ * If finalIgnore stays true: the line is a red herring for this failure mode.
+ */
+dedupTest("red-herring test: hostnames.ts:328-331 index===0 branch behavior when target was previously ignore=1", async () => {
+  const canonicalNip11 = mockRelayInfo("Test Relay", "test");
+
+  // Setup: target URL was previously ignore=1, parent='wss://sibling.tld/'.
+  // Now the sibling is gone from relay_status entirely. Target is the only
+  // online entry — it WILL become the ordered family's index 0 member.
+  setupDatabase([
+    {
+      url: "wss://relay.lumina.rocks/orphaned-mutation",
+      online: true,
+      ignore: true,
+      parent: "wss://sibling.tld/",
+      info: canonicalNip11,
+    },
+  ]);
+
+  const snapshot = await captureDedupSnapshot({
+    url: "wss://relay.lumina.rocks/orphaned-mutation",
+    hostname: "relay.lumina.rocks",
+    protocol: "wss:",
+    info: { data: canonicalNip11 },
+  });
+
+  console.log(JSON.stringify({
+    hypothesis: "328-331-red-herring",
+    snapshot,
+    interpretation: {
+      flippedBackToIgnoreFalse: snapshot.finalIgnore === false,
+      clearedParent: snapshot.finalParent === "",
+      note: "If flippedBackToIgnoreFalse is true, the index===0 branch IS active in the defect path. If false, the line is a red herring for this failure mode.",
+    },
+  }, null, 2));
+
+  assert(snapshot !== undefined);
 });

--- a/apps/relaymon/tests/unit/hostname-dedup.test.ts
+++ b/apps/relaymon/tests/unit/hostname-dedup.test.ts
@@ -17,7 +17,7 @@ import {
   setConfig,
 } from "../../src/utils/hostnames.ts";
 import { mockConfig } from "../helpers/fixtures.ts";
-import { initializeDB, storeRelayInfo, db } from "../../src/db/db.ts";
+import { initializeDB, storeRelayInfo, db, getOnlineRelays, getRelayInfo } from "../../src/db/db.ts";
 import type { Config } from "../../src/types/config.ts";
 
 // Helper to create mock relay info
@@ -562,4 +562,229 @@ dedupTest("relayHostnameDedup - different hostnames are NOT deduped", async () =
 
   // Should NOT be deduped because hostname is different
   assertEquals(dedupResult.ignore, false);
+});
+
+// ============================================================================
+// Phase 17: relay-dedup-family-scope split-outcome reproduction
+//
+// Reproduces the observed split-outcome behavior where dedup catches some
+// URL-path mutations on a hostname (e.g. wss://relay.lumina.rocks/hotel)
+// and misses others on the same hostname (e.g. /umbra-vertex). Scaffolding
+// only — hypothesis-isolating tests live in a later plan.
+//
+// DO NOT remove these tests after Phase 17 ships. Per 17-CONTEXT.md, they
+// become the seed for Phase 18's TEST-01/02/03 regression tests.
+// ============================================================================
+
+/**
+ * Structured snapshot of what relayHostnameDedup did for a given URL.
+ * Captured post-hoc by querying the in-memory DB state after the dedup call.
+ * JSON-serializable — suitable for console.log output in CI.
+ */
+type DedupSnapshot = {
+  url: string;
+  finalIgnore: boolean;
+  finalParent: string;
+  // What the dedup function saw at decision time, derived by re-querying the
+  // test DB after the fact (getOnlineRelays, getRelayInfo per sibling):
+  familyComposition: {
+    onlineCount: number;
+    hostnameFamilyUrls: string[];      // siblings with same hostname+protocol, online=1
+    hostnameFamilyInfoHashes: Record<string, string>;
+  };
+  currentInfoHash: string;
+  // Classification of which branch the dedup result is consistent with.
+  // Use the known branches enumerated in hostnames.ts. If multiple branches
+  // could explain the outcome, list all candidates.
+  branchHypothesis: string[];  // e.g. ["case8"], ["index-0-cleared"], ["no-relatives"]
+};
+
+/**
+ * Runs relayHostnameDedup on the provided input and returns a structured
+ * DedupSnapshot describing what the function did. No assertions inside this
+ * helper — it is purely observational scaffolding for Phase 17 diagnosis.
+ */
+async function captureDedupSnapshot(
+  input: {
+    url: string;
+    hostname: string;
+    protocol: string;
+    info?: { data: any };
+  }
+): Promise<DedupSnapshot> {
+  const resultObj = {
+    url: input.url,
+    hostname: input.hostname,
+    protocol: input.protocol,
+    online: true,
+    ignore: false,
+    parent: "",
+    checked_at: Date.now(),
+    network: "clearnet" as const,
+    ...(input.info ? { info: input.info } : {})
+  };
+
+  const dedupResult = await relayHostnameDedup(resultObj as any);
+
+  // Re-query the DB to reconstruct what the family looked like.
+  // Note: relayHostnameDedup may have stored/updated relay_info rows for input.url,
+  // so we query sibling URLs (url !== input.url) with same hostname+protocol.
+  const allOnline = getOnlineRelays();
+  const hostnameFamilyUrls = allOnline.filter(url => {
+    try {
+      const parsed = new URL(url);
+      return parsed.hostname === input.hostname &&
+        parsed.protocol === input.protocol &&
+        url !== input.url;
+    } catch {
+      return false;
+    }
+  });
+
+  const hostnameFamilyInfoHashes: Record<string, string> = {};
+  for (const siblingUrl of hostnameFamilyUrls) {
+    const relayInfoRow = getRelayInfo(siblingUrl);
+    if (relayInfoRow?.info) {
+      const h = createInfoHash(relayInfoRow.info);
+      if (h) hostnameFamilyInfoHashes[siblingUrl] = h;
+    }
+  }
+
+  const currentInfoHash = input.info?.data ? createInfoHash(input.info.data) : "";
+
+  // Classify branchHypothesis post-hoc from returned result + family state.
+  const finalIgnore = Boolean(dedupResult.ignore);
+  const finalParent = (dedupResult.parent as string) || "";
+  const branchHypothesis: string[] = [];
+
+  if (finalIgnore && finalParent === "") {
+    // Ignore set but no parent — synced ignore list branch
+    branchHypothesis.push("synced-ignore-list");
+  } else if (hostnameFamilyUrls.length === 0 && !finalIgnore && finalParent === "") {
+    // No siblings visible online → no-relatives early return
+    branchHypothesis.push("no-relatives");
+  } else if (!finalIgnore && finalParent === "" && hostnameFamilyUrls.length > 0) {
+    // Has relatives but not ignored and no parent — ambiguous:
+    // either index===0 branch cleared it, or fall-through-not-ignored, or same-nip11-as-shorter
+    // where this URL is the shortest (so it was NOT the one ignored).
+    branchHypothesis.push("index-0-cleared");
+    branchHypothesis.push("fall-through-not-ignored");
+  } else if (finalIgnore && finalParent !== "") {
+    // Was ignored with a parent. Classify by what hash/family state suggests.
+    const familyHashes = Object.values(hostnameFamilyInfoHashes);
+
+    // Check early-return paths (same-nip11-as-root / same-nip11-as-shorter)
+    // These fire before the getOnlineRelays() path in hostnames.ts
+    const parentIsRoot = (() => {
+      try {
+        const p = new URL(finalParent);
+        return p.pathname === "/" || p.pathname === "";
+      } catch { return false; }
+    })();
+
+    if (parentIsRoot && currentInfoHash && familyHashes.includes(currentInfoHash)) {
+      branchHypothesis.push("same-nip11-as-root");
+    } else if (!parentIsRoot && currentInfoHash && familyHashes.includes(currentInfoHash) &&
+               finalParent.length < input.url.length) {
+      branchHypothesis.push("same-nip11-as-shorter");
+    }
+
+    // Check for case-based branches (require index > 0 in ordered family)
+    if (currentInfoHash && familyHashes.includes(currentInfoHash)) {
+      // NIP-11 match with some relative → case1, case2, case8 candidates
+      if (parentIsRoot) {
+        branchHypothesis.push("case1");
+        branchHypothesis.push("case2");
+      }
+      // case8: path URL + NIP-11 matches any relative (no root requirement)
+      branchHypothesis.push("case8");
+    }
+
+    // case4: parent has NIP-11 but current does not
+    if (parentIsRoot && !currentInfoHash && familyHashes.length > 0) {
+      branchHypothesis.push("case4");
+    }
+
+    // case5: neither eldest nor current has NIP-11
+    if (!parentIsRoot && !currentInfoHash && familyHashes.length === 0) {
+      branchHypothesis.push("case5");
+    }
+
+    // case6/case7: pubkey or hostname in path
+    try {
+      const pathname = new URL(input.url).pathname;
+      if (/[0-9a-fA-F]{64}/.test(pathname)) {
+        branchHypothesis.push("case6");
+      }
+      if (pathname.includes(input.hostname)) {
+        branchHypothesis.push("case7");
+      }
+    } catch { /* ignore parse errors */ }
+
+    if (branchHypothesis.length === 0) {
+      branchHypothesis.push("unknown-case");
+    }
+  }
+
+  return {
+    url: input.url,
+    finalIgnore,
+    finalParent,
+    familyComposition: {
+      onlineCount: allOnline.length,
+      hostnameFamilyUrls,
+      hostnameFamilyInfoHashes
+    },
+    currentInfoHash,
+    branchHypothesis
+  };
+}
+
+/**
+ * Scaffolding test: canonical lumina.rocks pair
+ *
+ * Runs both URLs through relayHostnameDedup against an in-memory DB seeded
+ * with three siblings (root, /hotel, /umbra-vertex) that all carry the same
+ * NIP-11 info. Captures DedupSnapshot for each and logs JSON to CI output
+ * so plan 17-03 can cite the branch classification verbatim.
+ *
+ * No assertions on split-outcome correctness — plan 17-02 handles that.
+ */
+dedupTest("relay-dedup-family-scope split-outcome reproduction: canonical lumina.rocks pair captures dedup branches", async () => {
+  const canonicalNip11 = mockRelayInfo("Lumina Rocks", "relay.lumina.rocks unreadable");
+
+  setupDatabase([
+    { url: "wss://relay.lumina.rocks/", online: true, info: canonicalNip11 },        // root sibling
+    { url: "wss://relay.lumina.rocks/hotel", online: true, info: canonicalNip11 },   // caught in prod
+    { url: "wss://relay.lumina.rocks/umbra-vertex", online: true, info: canonicalNip11 }  // missed in prod
+  ]);
+
+  const hotelSnapshot = await captureDedupSnapshot({
+    url: "wss://relay.lumina.rocks/hotel",
+    hostname: "relay.lumina.rocks",
+    protocol: "wss:",
+    info: { data: canonicalNip11 }
+  });
+
+  const umbraVertexSnapshot = await captureDedupSnapshot({
+    url: "wss://relay.lumina.rocks/umbra-vertex",
+    hostname: "relay.lumina.rocks",
+    protocol: "wss:",
+    info: { data: canonicalNip11 }
+  });
+
+  const snapshots = {
+    hotel: hotelSnapshot,
+    umbraVertex: umbraVertexSnapshot
+  };
+
+  console.log(JSON.stringify(snapshots, null, 2));
+
+  // Minimal infrastructure invariants — not outcome assertions
+  assert(snapshots.hotel !== undefined);
+  assert(snapshots.umbraVertex !== undefined);
+  assertEquals(typeof snapshots.hotel.finalIgnore, "boolean");
+  assertEquals(typeof snapshots.umbraVertex.finalIgnore, "boolean");
+  assert(Array.isArray(snapshots.hotel.branchHypothesis));
+  assert(Array.isArray(snapshots.umbraVertex.branchHypothesis));
 });

--- a/apps/relaymon/tests/unit/hostname-dedup.test.ts
+++ b/apps/relaymon/tests/unit/hostname-dedup.test.ts
@@ -18,7 +18,8 @@ import {
   reevaluateAllDeduplication,
 } from "../../src/utils/hostnames.ts";
 import { mockConfig } from "../helpers/fixtures.ts";
-import { initializeDB, storeRelayInfo, db, getOnlineRelays, getRelayInfo } from "../../src/db/db.ts";
+import { initializeDB, storeRelayInfo, db, getOnlineRelays, getRelayInfo, rehashRelayInfoMigration } from "../../src/db/db.ts";
+import { normalizeNip11 } from "../../src/utils/nip11.ts";
 import type { Config } from "../../src/types/config.ts";
 
 // Helper to create mock relay info
@@ -912,6 +913,19 @@ dedupTest("family-scope hypothesis B: NIP-11 hash stability across volatile fiel
   assert(snapshotVolatile !== undefined);
   // Do NOT assert hashA !== hashB — if they ARE equal, that is itself evidence
   // ruling out hypothesis B. Plan 03 reads the log to verdict.
+
+  // Phase 18 Fix 2 hard assertion: hashes must now be equal after normalization.
+  assertEquals(
+    hashA,
+    hashB,
+    "Phase 18 Fix 2 (Hypothesis B promoted): createInfoHash must produce identical hashes for same-server NIP-11 that differs only in volatile fields",
+  );
+  // And the mutation must be caught.
+  assertEquals(
+    snapshotVolatile.finalIgnore,
+    true,
+    "Phase 18 Fix 2: mutation with volatile NIP-11 must be caught after hash normalization",
+  );
 });
 
 /**
@@ -1368,4 +1382,205 @@ dedupTest("generalization: succeeding-sample controls (relay.jerseyplebs.com/whi
     true,
     "Control sample relay.shawnyeager.com/november-anchor-tango should be caught under sibling online=1",
   );
+});
+
+// ============================================================================
+// Phase 18 Plan 02 Task 4: normalizeNip11 unit tests + Hypothesis B regression
+// ============================================================================
+
+Deno.test("normalizeNip11 - preserves benign keys", () => {
+  const input = {
+    name: "Test Relay",
+    description: "A test",
+    software: "strfry",
+    version: "1.0.0",
+    supported_nips: [1, 2, 11],
+  };
+  const out = normalizeNip11(input);
+  assertEquals(out.name, "Test Relay");
+  assertEquals(out.description, "A test");
+  assertEquals(out.software, "strfry");
+  assertEquals(out.version, "1.0.0");
+  assertEquals(Array.isArray(out.supported_nips), true);
+});
+
+Deno.test("normalizeNip11 - strips exact-key volatile (timestamp)", () => {
+  const out = normalizeNip11({ name: "X", timestamp: 123 });
+  assertEquals(out, { name: "X" });
+});
+
+Deno.test("normalizeNip11 - strips exact-key volatile (url reflection)", () => {
+  const out = normalizeNip11({ name: "X", url: "wss://x.com" });
+  assertEquals(out, { name: "X" });
+});
+
+Deno.test("normalizeNip11 - strips last_ prefix", () => {
+  const out = normalizeNip11({ name: "X", last_seen: "2026-04-10", last_updated: 123 });
+  assertEquals(out, { name: "X" });
+});
+
+Deno.test("normalizeNip11 - strips current_ prefix", () => {
+  const out = normalizeNip11({ name: "X", current_time: 999, current_load: 0.5 });
+  assertEquals(out, { name: "X" });
+});
+
+Deno.test("normalizeNip11 - strips count substring (counters, event_count)", () => {
+  const out = normalizeNip11({ name: "X", counters: { m: 1 }, event_count: 5 });
+  assertEquals(out, { name: "X" });
+});
+
+Deno.test("normalizeNip11 - case-insensitive matching", () => {
+  const out = normalizeNip11({ name: "X", Timestamp: 123, LAST_SEEN: "now" });
+  assertEquals(out, { name: "X" });
+});
+
+Deno.test("normalizeNip11 - null and undefined safe", () => {
+  assertEquals(normalizeNip11(null), {});
+  assertEquals(normalizeNip11(undefined), {});
+});
+
+Deno.test("normalizeNip11 - does not mutate input", () => {
+  const input = { name: "X", timestamp: 123 };
+  normalizeNip11(input);
+  assertEquals(input.timestamp, 123, "input.timestamp should still be present");
+});
+
+Deno.test("normalizeNip11 - idempotent", () => {
+  const x = { name: "X", description: "Y", timestamp: 123, counters: { m: 1 } };
+  const once = normalizeNip11(x);
+  const twice = normalizeNip11(once);
+  assertEquals(once, twice);
+});
+
+Deno.test("Phase 18 Fix 2 regression: createInfoHash stable across volatile field deltas (Hypothesis B)", () => {
+  const stable = { name: "Lumina", description: "test", software: "strfry", version: "1.0.0" };
+  const volatile1 = { ...stable, timestamp: Date.now(), counters: { messages: 12345 } };
+  const volatile2 = { ...stable, timestamp: Date.now() + 1000, counters: { messages: 99999 }, last_seen: "2026-04-10" };
+
+  const hashStable = createInfoHash(stable);
+  const hashVolatile1 = createInfoHash(volatile1);
+  const hashVolatile2 = createInfoHash(volatile2);
+
+  assert(hashStable !== "", "stable hash must not be empty");
+  assertEquals(
+    hashStable,
+    hashVolatile1,
+    "Phase 18 Fix 2 (Hypothesis B): hash must be stable when only volatile fields (timestamp, counters) differ",
+  );
+  assertEquals(
+    hashStable,
+    hashVolatile2,
+    "Phase 18 Fix 2 (Hypothesis B): hash must be stable when multiple volatile fields differ (timestamp, counters, last_seen)",
+  );
+});
+
+Deno.test("Phase 18 Fix 2 regression: createInfoHash still differentiates distinct servers", () => {
+  const a = { name: "A", description: "alpha", software: "strfry", version: "1.0.0" };
+  const b = { name: "B", description: "bravo", software: "strfry", version: "1.0.0" };
+  const hashA = createInfoHash(a);
+  const hashB = createInfoHash(b);
+  assert(hashA !== "", "hashA must not be empty");
+  assert(hashB !== "", "hashB must not be empty");
+  assert(
+    hashA !== hashB,
+    "createInfoHash must still produce different hashes for servers with different names/descriptions",
+  );
+});
+
+dedupTest("Phase 18 Fix 2 regression: volatile NIP-11 mutation is caught via case-based logic (Hypothesis B promoted)", async () => {
+  const stableNip11 = mockRelayInfo("Lumina Rocks", "unreadable");
+  // Mutation URL has additional volatile fields but represents the same server
+  const volatileNip11 = {
+    ...mockRelayInfo("Lumina Rocks", "unreadable"),
+    timestamp: Date.now(),
+    counters: { messages: 12345 },
+  };
+
+  // Family: sibling online with stable NIP-11
+  setupDatabase([
+    { url: "wss://relay.lumina.rocks/", online: true, info: stableNip11 },
+    { url: "wss://relay.lumina.rocks/hotel", online: true, info: stableNip11 },
+  ]);
+
+  // Mutation: checked with volatile NIP-11. After Phase 18 Fix 2, the
+  // hashes normalize to identical values and case1/case2/case8 fires.
+  const snapshot = await captureDedupSnapshot({
+    url: "wss://relay.lumina.rocks/umbra-vertex",
+    hostname: "relay.lumina.rocks",
+    protocol: "wss:",
+    info: { data: volatileNip11 },
+  });
+
+  console.log(JSON.stringify({
+    test: "phase18-fix-2-volatile-mutation-caught",
+    snapshot,
+  }, null, 2));
+
+  assertEquals(
+    snapshot.finalIgnore,
+    true,
+    "Phase 18 Fix 2: mutation with volatile NIP-11 fields must be caught because hash normalizes to match sibling family",
+  );
+  assertEquals(
+    snapshot.finalParent,
+    "wss://relay.lumina.rocks/",
+    "Phase 18 Fix 2: parent must be the legit root sibling",
+  );
+});
+
+Deno.test("Phase 18 Fix 2: rehashRelayInfoMigration is idempotent", () => {
+  // The test bootstrap already called initializeDB which ran the migration
+  // once on an empty DB. Seed a few rows and run it again — this time with
+  // data. Verify a third call is a no-op.
+
+  // Clear any prior state
+  db.query("DELETE FROM relay_info");
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'phase18_rehash_relay_info_normalizeNip11_v1'");
+
+  // Seed 3 rows with stale hashes (pretend they were hashed pre-Phase-18
+  // by storing a dummy hash string directly)
+  const info1 = { name: "A", description: "alpha", software: "strfry" };
+  const info2 = { name: "B", description: "bravo", software: "strfry" };
+  const info3 = { name: "C", description: "charlie", software: "strfry" };
+  db.query(
+    `INSERT INTO relay_info (url, info_json, info_hash, last_updated) VALUES (?, ?, ?, ?)`,
+    ["wss://a.example/", JSON.stringify(info1), "STALE_HASH_A", 0],
+  );
+  db.query(
+    `INSERT INTO relay_info (url, info_json, info_hash, last_updated) VALUES (?, ?, ?, ?)`,
+    ["wss://b.example/", JSON.stringify(info2), "STALE_HASH_B", 0],
+  );
+  db.query(
+    `INSERT INTO relay_info (url, info_json, info_hash, last_updated) VALUES (?, ?, ?, ?)`,
+    ["wss://c.example/", JSON.stringify(info3), "STALE_HASH_C", 0],
+  );
+
+  // First call: should update all 3 rows
+  rehashRelayInfoMigration();
+
+  // Collect hashes after first migration
+  const hashesAfterFirst: Record<string, string> = {};
+  for (const [url, hash] of db.query("SELECT url, info_hash FROM relay_info ORDER BY url")) {
+    hashesAfterFirst[url as string] = hash as string;
+  }
+  assert(hashesAfterFirst["wss://a.example/"] !== "STALE_HASH_A", "row A should have been re-hashed");
+  assert(hashesAfterFirst["wss://b.example/"] !== "STALE_HASH_B", "row B should have been re-hashed");
+  assert(hashesAfterFirst["wss://c.example/"] !== "STALE_HASH_C", "row C should have been re-hashed");
+
+  // Verify sentinel was inserted
+  const sentinel = db.query(
+    "SELECT name FROM relaymon_migrations WHERE name = 'phase18_rehash_relay_info_normalizeNip11_v1'",
+  );
+  assertEquals(sentinel.length, 1, "migration sentinel should exist after first run");
+
+  // Second call: should be a no-op due to sentinel
+  rehashRelayInfoMigration();
+  const hashesAfterSecond: Record<string, string> = {};
+  for (const [url, hash] of db.query("SELECT url, info_hash FROM relay_info ORDER BY url")) {
+    hashesAfterSecond[url as string] = hash as string;
+  }
+  assertEquals(hashesAfterFirst, hashesAfterSecond, "Phase 18 Fix 2: second migration call must be a no-op (idempotent)");
+
+  // Cleanup — leave the DB clean for subsequent tests
+  db.query("DELETE FROM relay_info");
 });

--- a/apps/relaymon/tests/unit/hostname-dedup.test.ts
+++ b/apps/relaymon/tests/unit/hostname-dedup.test.ts
@@ -1272,14 +1272,202 @@ dedupTest("generalization: haven.nostrfreedom.net/inbox/ legit multi-segment vs 
   assertEquals(
     snapshotLegitSolo.finalIgnore,
     false,
-    "wss://haven.nostrfreedom.net/inbox/ is a legit path-only relay and MUST NOT be ignored",
+    "wss://haven.nostrfreedom.net/inbox/ is a legit path-only relay and MUST NOT be ignored (SOLO)",
   );
 
-  // Document the current broken behavior for the with-mutation case.
-  // Phase 18 regression target: this assertion must be flipped to assertEquals(false).
+  // Phase 18 Fix 3 regression (DEDUP-03, TEST-02): with a mutation sibling
+  // present, the legit path-only relay /inbox/ must ALSO remain un-ignored.
+  // Pre-Phase-18 this was wrongly set to ignore=true via the CRITICAL ERROR
+  // path due to the normalizeURL trailing-slash bug
+  // (orderedFamily.indexOf returned -1 because orderedFamily contained
+  // "wss://haven.nostrfreedom.net/inbox" but the search was for
+  // "wss://haven.nostrfreedom.net/inbox/"). Fix 3 canonicalizes mURL at
+  // function entry so indexOf succeeds.
+  assertEquals(
+    snapshotLegitWithMutation.finalIgnore,
+    false,
+    "Phase 18 Fix 3 (DEDUP-03, TEST-02): wss://haven.nostrfreedom.net/inbox/ must NOT be ignored even when a mutation sibling is present",
+  );
+
+  // The mutation with DIFFERENT NIP-11 and non-root parent is NOT caught by
+  // the case-based logic when both siblings are online. This is a known
+  // architectural limitation: cases 1/2/4 require eldestIsRoot, case 8
+  // requires matching NIP-11. Catching a mutation with distinct NIP-11
+  // when the parent is not a root URL requires a separate fix in Phase 19.
+  // Phase 18 Fix 3's primary goal is restoring DEDUP-03 (legit path-only
+  // relay protection), which is achieved by the snapshotLegitWithMutation
+  // assertion above.
   assert(
-    snapshotLegitWithMutation !== undefined,
-    "Snapshot captured for wss://haven.nostrfreedom.net/inbox/ with mutation sibling present",
+    snapshotMutation !== undefined,
+    "Phase 18 Fix 3: snapshotMutation captured for wss://haven.nostrfreedom.net/inbox/flint-november-alpha (note: different-NIP-11 mutation with non-root parent is not caught by case logic — Phase 19 concern)",
+  );
+
+  // The transient-sibling-offline case for the mutation (sibling online=0)
+  // — should also catch via defensive-deny (Plan 18-01).
+  assertEquals(
+    snapshotMutationOfflineSibling.finalIgnore,
+    true,
+    "Phase 18 (Fix 1): mutation must be caught via defensive-deny when legit sibling is online=0",
+  );
+});
+
+/**
+ * Phase 18 Fix 3 edge cases: trailing slash variants across path depths.
+ *
+ * Exercises the canonicalization invariant for URLs with pathnames
+ * `/`, `/foo`, `/foo/`, `/foo/bar`, `/foo/bar/`. Each URL must produce
+ * a deterministic dedup decision. In particular:
+ *   - `/` (root): always isRootUrl, never a mutation candidate → never ignored unless a same-NIP-11 root is found via the early-return.
+ *   - `/foo` (single-segment, no trailing slash): mutation candidate → caught when sibling present.
+ *   - `/foo/` (single-segment, trailing slash — the haven bug class): MUST behave the same as `/foo` after canonicalization.
+ *   - `/foo/bar` (multi-segment, no trailing slash): mutation candidate → caught when sibling present.
+ *   - `/foo/bar/` (multi-segment, trailing slash): MUST behave the same as `/foo/bar`.
+ */
+dedupTest("Phase 18 Fix 3 regression: trailing-slash edge cases are deterministic (DEDUP-03, TEST-02)", async () => {
+  const baseNip11 = mockRelayInfo("Edge Host", "test");
+
+  // Fixture: a legit root, a legit single-segment path, and a multi-segment path,
+  // all with the same NIP-11 (canonical "same-server" case).
+  setupDatabase([
+    { url: "wss://edge.example/", online: true, info: baseNip11 },
+    { url: "wss://edge.example/foo", online: true, info: baseNip11 },
+    { url: "wss://edge.example/foo/bar", online: true, info: baseNip11 },
+  ]);
+
+  // Case 1: bare root `/`
+  const snapshotRoot = await captureDedupSnapshot({
+    url: "wss://edge.example/",
+    hostname: "edge.example",
+    protocol: "wss:",
+    info: { data: baseNip11 },
+  });
+
+  // Case 2: single segment without trailing slash
+  const snapshotFoo = await captureDedupSnapshot({
+    url: "wss://edge.example/foo",
+    hostname: "edge.example",
+    protocol: "wss:",
+    info: { data: baseNip11 },
+  });
+
+  // Case 3: single segment WITH trailing slash (the haven class)
+  const snapshotFooSlash = await captureDedupSnapshot({
+    url: "wss://edge.example/foo/",
+    hostname: "edge.example",
+    protocol: "wss:",
+    info: { data: baseNip11 },
+  });
+
+  // Case 4: multi-segment without trailing slash
+  const snapshotFooBar = await captureDedupSnapshot({
+    url: "wss://edge.example/foo/bar",
+    hostname: "edge.example",
+    protocol: "wss:",
+    info: { data: baseNip11 },
+  });
+
+  // Case 5: multi-segment WITH trailing slash
+  const snapshotFooBarSlash = await captureDedupSnapshot({
+    url: "wss://edge.example/foo/bar/",
+    hostname: "edge.example",
+    protocol: "wss:",
+    info: { data: baseNip11 },
+  });
+
+  console.log(JSON.stringify({
+    test: "phase18-fix-3-trailing-slash-edge-cases",
+    snapshotRoot,
+    snapshotFoo,
+    snapshotFooSlash,
+    snapshotFooBar,
+    snapshotFooBarSlash,
+  }, null, 2));
+
+  // The root URL is never ignored (it is the canonical shortest member).
+  assertEquals(
+    snapshotRoot.finalIgnore,
+    false,
+    "Phase 18 Fix 3: root URL `/` is never ignored",
+  );
+
+  // Deterministic invariant: trailing-slash vs no-trailing-slash variants
+  // of the SAME path must produce the SAME ignore decision.
+  assertEquals(
+    snapshotFoo.finalIgnore,
+    snapshotFooSlash.finalIgnore,
+    "Phase 18 Fix 3: `/foo` and `/foo/` must produce the same ignore decision",
+  );
+  assertEquals(
+    snapshotFooBar.finalIgnore,
+    snapshotFooBarSlash.finalIgnore,
+    "Phase 18 Fix 3: `/foo/bar` and `/foo/bar/` must produce the same ignore decision",
+  );
+
+  // /foo and /foo/bar share NIP-11 with the root → they are caught as duplicates
+  // via case1/case2 (root is in the family with matching hash).
+  assertEquals(
+    snapshotFoo.finalIgnore,
+    true,
+    "Phase 18 Fix 3: `/foo` is caught as duplicate of root (same NIP-11)",
+  );
+  assertEquals(
+    snapshotFooBar.finalIgnore,
+    true,
+    "Phase 18 Fix 3: `/foo/bar` is caught as duplicate of root (same NIP-11)",
+  );
+});
+
+/**
+ * Phase 18 Fix 3 narrowness: a legit path-only relay with DIFFERENT NIP-11
+ * from any sibling must remain un-ignored, regardless of trailing slash.
+ *
+ * Direct regression of the haven.nostrfreedom.net/inbox/ protection case
+ * but parameterized over trailing-slash variants.
+ */
+dedupTest("Phase 18 Fix 3 regression: legit path-only relay with distinct NIP-11 remains un-ignored under all slash variants (DEDUP-03, TEST-02)", async () => {
+  const legitNip11 = mockRelayInfo("Legit Path", "legit path-only");
+  const mutationNip11 = mockRelayInfo("Spam", "mutation");
+
+  // Variant A: legit path relay has trailing slash, mutation does not
+  setupDatabase([
+    { url: "wss://path.example/inbox/", online: true, info: legitNip11 },
+    { url: "wss://path.example/inbox/spam-alpha", online: true, info: mutationNip11 },
+  ]);
+  const snapshotLegitTrailingSlash = await captureDedupSnapshot({
+    url: "wss://path.example/inbox/",
+    hostname: "path.example",
+    protocol: "wss:",
+    info: { data: legitNip11 },
+  });
+
+  // Variant B: legit path relay has NO trailing slash, mutation extends further
+  setupDatabase([
+    { url: "wss://path.example/inbox", online: true, info: legitNip11 },
+    { url: "wss://path.example/inbox/spam-alpha", online: true, info: mutationNip11 },
+  ]);
+  const snapshotLegitNoSlash = await captureDedupSnapshot({
+    url: "wss://path.example/inbox",
+    hostname: "path.example",
+    protocol: "wss:",
+    info: { data: legitNip11 },
+  });
+
+  console.log(JSON.stringify({
+    test: "phase18-fix-3-legit-path-only-under-slash-variants",
+    legitTrailingSlash: snapshotLegitTrailingSlash,
+    legitNoSlash: snapshotLegitNoSlash,
+  }, null, 2));
+
+  // DEDUP-03: legit path-only relay must NOT be ignored regardless of slash form.
+  assertEquals(
+    snapshotLegitTrailingSlash.finalIgnore,
+    false,
+    "Phase 18 Fix 3 (DEDUP-03): legit path relay with trailing slash must NOT be ignored",
+  );
+  assertEquals(
+    snapshotLegitNoSlash.finalIgnore,
+    false,
+    "Phase 18 Fix 3 (DEDUP-03): legit path relay without trailing slash must NOT be ignored",
   );
 });
 

--- a/apps/relaymon/tests/unit/hostname-dedup.test.ts
+++ b/apps/relaymon/tests/unit/hostname-dedup.test.ts
@@ -1057,3 +1057,215 @@ dedupTest("red-herring test: hostnames.ts:328-331 index===0 branch behavior when
 
   assert(snapshot !== undefined);
 });
+
+// ============================================================================
+// Phase 17 Plan 02 Task 2: Generalization fixtures
+//
+// Additional failing-sample pairs and succeeding-sample controls from STATE.md
+// to confirm the hypothesis A mechanism generalizes beyond the canonical
+// lumina.rocks pair. Three tests:
+//   6: haven.nostrfreedom.net multi-segment legit path vs mutation
+//   7: relay.noswhere.com single-segment mutation under state flip
+//   8: succeeding-sample controls (relay.jerseyplebs.com + relay.shawnyeager.com)
+// ============================================================================
+
+/**
+ * Generalization test 6: haven.nostrfreedom.net multi-segment path
+ *
+ * Tests the critical legit-path-only relay protection invariant:
+ * wss://haven.nostrfreedom.net/inbox/ MUST NOT flip to ignore=true under
+ * any candidate fix. Also exercises the multi-segment mutation case
+ * (wss://haven.nostrfreedom.net/inbox/flint-november-alpha) that is in the
+ * STATE.md known-failing-samples list.
+ *
+ * NOTE: Current code has a pre-existing bug where normalizeURL() strips the
+ * trailing slash from "/inbox/" when building the orderedFamily map, causing
+ * indexOf(mURL) to return -1 and triggering the CRITICAL ERROR path that sets
+ * ignore=true. This is discovered-in-Phase-17 evidence — the bug is
+ * documented here and targeted for fix in Phase 18. The SOLO variant (legit
+ * relay with no siblings) correctly passes since there are no relatives to
+ * trigger the family-scope logic.
+ *
+ * Phase 18 regression target: snapshotLegitSolo.finalIgnore MUST be false,
+ * and snapshotLegitWithMutation.finalIgnore MUST ALSO be false after the fix.
+ */
+dedupTest("generalization: haven.nostrfreedom.net/inbox/ legit multi-segment vs /inbox/flint-* mutation", async () => {
+  const havenNip11 = mockRelayInfo("Haven", "inbox relay");
+  // A DIFFERENT info for the mutation — simulates spam instance that is on the
+  // same hostname but reports as a distinct server. Realistic failure shape.
+  const mutationNip11 = mockRelayInfo("Spam Relay", "mutation instance");
+
+  // Variant SOLO: legit path-only relay alone (no siblings) — tests the
+  // baseline: a legit relay with no mutation sibling must never be ignored.
+  setupDatabase([
+    { url: "wss://haven.nostrfreedom.net/inbox/", online: true, info: havenNip11 },
+  ]);
+  const snapshotLegitSolo = await captureDedupSnapshot({
+    url: "wss://haven.nostrfreedom.net/inbox/",
+    hostname: "haven.nostrfreedom.net",
+    protocol: "wss:",
+    info: { data: havenNip11 },
+  });
+
+  // Variant 1: sibling online=1 — diagnostic only (current code has normalizeURL
+  // trailing-slash bug that causes CRITICAL ERROR for /inbox/ in this variant)
+  setupDatabase([
+    { url: "wss://haven.nostrfreedom.net/inbox/", online: true, info: havenNip11 },
+    { url: "wss://haven.nostrfreedom.net/inbox/flint-november-alpha", online: true, info: mutationNip11 },
+  ]);
+
+  // Snapshot A: the legit path-only relay with mutation sibling present
+  const snapshotLegitWithMutation = await captureDedupSnapshot({
+    url: "wss://haven.nostrfreedom.net/inbox/",
+    hostname: "haven.nostrfreedom.net",
+    protocol: "wss:",
+    info: { data: havenNip11 },
+  });
+
+  // Snapshot B: the mutation — in prod this is missed
+  const snapshotMutation = await captureDedupSnapshot({
+    url: "wss://haven.nostrfreedom.net/inbox/flint-november-alpha",
+    hostname: "haven.nostrfreedom.net",
+    protocol: "wss:",
+    info: { data: mutationNip11 },
+  });
+
+  // Variant 2: legit path-only sibling online=0 (state-flip per hypothesis A)
+  setupDatabase([
+    { url: "wss://haven.nostrfreedom.net/inbox/", online: false, info: havenNip11 },
+    { url: "wss://haven.nostrfreedom.net/inbox/flint-november-alpha", online: true, info: mutationNip11 },
+  ]);
+  const snapshotMutationOfflineSibling = await captureDedupSnapshot({
+    url: "wss://haven.nostrfreedom.net/inbox/flint-november-alpha",
+    hostname: "haven.nostrfreedom.net",
+    protocol: "wss:",
+    info: { data: mutationNip11 },
+  });
+
+  console.log(JSON.stringify({
+    sample: "haven.nostrfreedom.net-multi-segment",
+    legitPathOnlySolo: snapshotLegitSolo,
+    legitPathOnlyWithMutation: snapshotLegitWithMutation,
+    mutationSiblingOnline: snapshotMutation,
+    mutationSiblingOffline: snapshotMutationOfflineSibling,
+    phase18RegressionTarget: {
+      note: "After Phase 18 fix: legitPathOnlyWithMutation.finalIgnore MUST be false. Current code incorrectly sets it true via CRITICAL ERROR path (normalizeURL trailing-slash bug).",
+    },
+  }, null, 2));
+
+  // CRITICAL narrowness invariant: solo legit relay (no mutation sibling) must
+  // NEVER be ignored. Phase 18 must not break this.
+  assertEquals(
+    snapshotLegitSolo.finalIgnore,
+    false,
+    "wss://haven.nostrfreedom.net/inbox/ is a legit path-only relay and MUST NOT be ignored",
+  );
+
+  // Document the current broken behavior for the with-mutation case.
+  // Phase 18 regression target: this assertion must be flipped to assertEquals(false).
+  assert(
+    snapshotLegitWithMutation !== undefined,
+    "Snapshot captured for wss://haven.nostrfreedom.net/inbox/ with mutation sibling present",
+  );
+});
+
+/**
+ * Generalization test 7: relay.noswhere.com single-segment mutation
+ *
+ * Exercises the single-segment path mutation case (golf-quebec-marble) from
+ * STATE.md's known-failing-samples list under the online=1 and online=0 sibling
+ * state variants to test hypothesis A generalization.
+ */
+dedupTest("generalization: relay.noswhere.com/golf-quebec-marble single-segment mutation under state flip", async () => {
+  const noswhereNip11 = mockRelayInfo("Noswhere", "relay.noswhere.com");
+
+  // Variant 1: legit sibling online=1
+  setupDatabase([
+    { url: "wss://relay.noswhere.com/", online: true, info: noswhereNip11 },
+    { url: "wss://relay.noswhere.com/golf-quebec-marble", online: true, info: noswhereNip11 },
+  ]);
+  const snapshotSiblingOnline = await captureDedupSnapshot({
+    url: "wss://relay.noswhere.com/golf-quebec-marble",
+    hostname: "relay.noswhere.com",
+    protocol: "wss:",
+    info: { data: noswhereNip11 },
+  });
+
+  // Variant 2: legit sibling online=0
+  setupDatabase([
+    { url: "wss://relay.noswhere.com/", online: false, info: noswhereNip11 },
+    { url: "wss://relay.noswhere.com/golf-quebec-marble", online: true, info: noswhereNip11 },
+  ]);
+  const snapshotSiblingOffline = await captureDedupSnapshot({
+    url: "wss://relay.noswhere.com/golf-quebec-marble",
+    hostname: "relay.noswhere.com",
+    protocol: "wss:",
+    info: { data: noswhereNip11 },
+  });
+
+  console.log(JSON.stringify({
+    sample: "relay.noswhere.com-single-segment",
+    siblingOnline: snapshotSiblingOnline,
+    siblingOffline: snapshotSiblingOffline,
+  }, null, 2));
+
+  assert(snapshotSiblingOnline !== undefined);
+  assert(snapshotSiblingOffline !== undefined);
+});
+
+/**
+ * Generalization test 8: succeeding-sample controls
+ *
+ * Exercises two URLs that dedup correctly caught in production (per STATE.md's
+ * known-succeeding-samples list) under the canonical "sibling online=1, same
+ * NIP-11 hash" fixture. These controls contrast with the failing-sample behavior
+ * to confirm that hypothesis A's evidence is not an artifact of the test setup.
+ */
+dedupTest("generalization: succeeding-sample controls (relay.jerseyplebs.com/whiskey, relay.shawnyeager.com/november-anchor-tango)", async () => {
+  const jerseyNip11 = mockRelayInfo("JerseyPlebs", "relay.jerseyplebs.com");
+  const shawnNip11 = mockRelayInfo("ShawnYeager", "relay.shawnyeager.com");
+
+  // Control 1 — legit sibling online=1 (caught in prod per STATE.md)
+  setupDatabase([
+    { url: "wss://relay.jerseyplebs.com/", online: true, info: jerseyNip11 },
+    { url: "wss://relay.jerseyplebs.com/whiskey", online: true, info: jerseyNip11 },
+  ]);
+  const snapshotJersey = await captureDedupSnapshot({
+    url: "wss://relay.jerseyplebs.com/whiskey",
+    hostname: "relay.jerseyplebs.com",
+    protocol: "wss:",
+    info: { data: jerseyNip11 },
+  });
+
+  // Control 2 — legit sibling online=1 (caught in prod)
+  setupDatabase([
+    { url: "wss://relay.shawnyeager.com/", online: true, info: shawnNip11 },
+    { url: "wss://relay.shawnyeager.com/november-anchor-tango", online: true, info: shawnNip11 },
+  ]);
+  const snapshotShawn = await captureDedupSnapshot({
+    url: "wss://relay.shawnyeager.com/november-anchor-tango",
+    hostname: "relay.shawnyeager.com",
+    protocol: "wss:",
+    info: { data: shawnNip11 },
+  });
+
+  console.log(JSON.stringify({
+    sample: "succeeding-sample-controls",
+    jersey: snapshotJersey,
+    shawn: snapshotShawn,
+  }, null, 2));
+
+  // Controls should be caught (finalIgnore=true with a parent) when fixtures
+  // match the canonical "sibling online=1, same hash" shape. This contrast is
+  // what makes the hypothesis A evidence meaningful.
+  assertEquals(
+    snapshotJersey.finalIgnore,
+    true,
+    "Control sample relay.jerseyplebs.com/whiskey should be caught under sibling online=1",
+  );
+  assertEquals(
+    snapshotShawn.finalIgnore,
+    true,
+    "Control sample relay.shawnyeager.com/november-anchor-tango should be caught under sibling online=1",
+  );
+});

--- a/apps/relaymon/tests/unit/hostname-dedup.test.ts
+++ b/apps/relaymon/tests/unit/hostname-dedup.test.ts
@@ -842,9 +842,26 @@ dedupTest("family-scope hypothesis A: sibling online=0 excludes legit root from 
     siblingOffline: snapshotSiblingOffline,
   }, null, 2));
 
-  // Minimal invariants — plan 03 reads the console output to verdict the hypothesis
-  assert(snapshotSiblingOnline !== undefined);
-  assert(snapshotSiblingOffline !== undefined);
+  // Phase 18 regression (Fix 1): when the legit root sibling is online=0,
+  // the defensive-deny branch (added by Phase 18 Plan 18-01 Task 2) now finds
+  // the sibling via getRelaysByHostname and catches the mutation. Prior to
+  // Phase 18 the online variant was caught via the early-return path but the
+  // offline variant behavior was test-environment dependent.
+  assertEquals(
+    snapshotSiblingOnline.finalIgnore,
+    true,
+    "Hypothesis A online variant: mutation must be caught when sibling is online=1",
+  );
+  assertEquals(
+    snapshotSiblingOffline.finalIgnore,
+    true,
+    "Hypothesis A offline variant (Phase 18 Fix 1 defensive-deny): mutation must be caught when sibling is online=0 via getRelaysByHostname",
+  );
+  assertEquals(
+    snapshotSiblingOffline.finalParent,
+    "wss://relay.lumina.rocks/",
+    "Hypothesis A offline variant: parent must be the legit root sibling",
+  );
 });
 
 /**
@@ -939,8 +956,91 @@ dedupTest("family-scope hypothesis C: mutation checked before sibling online=1 c
     postRace: snapshotPostRace,
   }, null, 2));
 
-  assert(snapshotPreRace !== undefined);
-  assert(snapshotPostRace !== undefined);
+  // Phase 18 regression (Fix 1): preRace is the true SOLO case — no sibling
+  // row at all in relay_status. The defensive-deny branch correctly does NOT
+  // fire (nothing to find), so finalIgnore stays false. This is the baseline
+  // that protects solo legit relays.
+  assertEquals(
+    snapshotPreRace.finalIgnore,
+    false,
+    "Hypothesis C preRace (SOLO — no sibling row at all): defensive-deny must NOT fire, solo relay protection preserved",
+  );
+  // postRace: sibling row present and online=1. Mutation must be caught via
+  // the existing case-based logic (same-nip11-as-root / case8).
+  assertEquals(
+    snapshotPostRace.finalIgnore,
+    true,
+    "Hypothesis C postRace (sibling online=1): mutation must be caught via case-based logic",
+  );
+  assertEquals(
+    snapshotPostRace.finalParent,
+    "wss://relay.lumina.rocks/",
+    "Hypothesis C postRace: parent must be the legit root sibling",
+  );
+});
+
+/**
+ * Phase 18 Fix 1 regression: transient-sibling-offline (DEDUP-02, TEST-03)
+ *
+ * Directly asserts that dedup produces the SAME ignore decision for a
+ * mutation URL whether its legit sibling is online=1 OR online=0 in
+ * relay_status. This is the "identity stable under online/offline" invariant.
+ *
+ * Before Phase 18 Fix 1: offline sibling → empty family → no-relatives
+ * early-return → mutation escapes dedup (finalIgnore=false).
+ * After Phase 18 Fix 1: offline sibling → getRelaysByHostname finds it →
+ * defensive-deny fires → mutation is caught (finalIgnore=true).
+ */
+dedupTest("Phase 18 Fix 1 regression: transient-sibling-offline produces same ignore decision as online sibling (DEDUP-02, TEST-03)", async () => {
+  const canonicalNip11 = mockRelayInfo("Lumina Rocks", "unreadable");
+
+  // Variant A: sibling online=1 (baseline — dedup caught in prod)
+  setupDatabase([
+    { url: "wss://relay.lumina.rocks/", online: true, info: canonicalNip11 },
+    { url: "wss://relay.lumina.rocks/umbra-vertex", online: true, info: canonicalNip11 },
+  ]);
+  const snapshotSiblingOnline = await captureDedupSnapshot({
+    url: "wss://relay.lumina.rocks/umbra-vertex",
+    hostname: "relay.lumina.rocks",
+    protocol: "wss:",
+    info: { data: canonicalNip11 },
+  });
+
+  // Variant B: sibling online=0 (the transient race case)
+  setupDatabase([
+    { url: "wss://relay.lumina.rocks/", online: false, info: canonicalNip11 },
+    { url: "wss://relay.lumina.rocks/umbra-vertex", online: true, info: canonicalNip11 },
+  ]);
+  const snapshotSiblingOffline = await captureDedupSnapshot({
+    url: "wss://relay.lumina.rocks/umbra-vertex",
+    hostname: "relay.lumina.rocks",
+    protocol: "wss:",
+    info: { data: canonicalNip11 },
+  });
+
+  console.log(JSON.stringify({
+    test: "transient-sibling-offline",
+    siblingOnline: snapshotSiblingOnline,
+    siblingOffline: snapshotSiblingOffline,
+  }, null, 2));
+
+  // Identity invariant: same ignore decision for both variants.
+  assertEquals(
+    snapshotSiblingOnline.finalIgnore,
+    snapshotSiblingOffline.finalIgnore,
+    "DEDUP-02: dedup must produce the same ignore decision for a mutation URL whether its sibling is online=1 or online=0",
+  );
+  // Both variants must catch the mutation.
+  assertEquals(
+    snapshotSiblingOnline.finalIgnore,
+    true,
+    "DEDUP-02: sibling online=1 variant must catch the mutation",
+  );
+  assertEquals(
+    snapshotSiblingOffline.finalIgnore,
+    true,
+    "DEDUP-02: sibling online=0 variant must also catch the mutation (via Phase 18 Fix 1 defensive-deny)",
+  );
 });
 
 /**

--- a/apps/relaymon/tests/unit/hostname-dedup.test.ts
+++ b/apps/relaymon/tests/unit/hostname-dedup.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../../src/utils/hostnames.ts";
 import { mockConfig } from "../helpers/fixtures.ts";
 import { initializeDB, storeRelayInfo, db, getOnlineRelays, getRelayInfo, rehashRelayInfoMigration } from "../../src/db/db.ts";
+import { rerunDedupForAllRowsMigration } from "../../src/utils/remediation.ts";
 import { normalizeNip11 } from "../../src/utils/nip11.ts";
 import type { Config } from "../../src/types/config.ts";
 
@@ -1771,4 +1772,346 @@ Deno.test("Phase 18 Fix 2: rehashRelayInfoMigration is idempotent", () => {
 
   // Cleanup — leave the DB clean for subsequent tests
   db.query("DELETE FROM relay_info");
+});
+
+// ============================================================================
+// Phase 19: rerunDedupForAllRowsMigration unit tests
+// ----------------------------------------------------------------------------
+// These tests verify the one-shot startup migration that re-runs the
+// Phase 18 dedup over every row in relay_status. All decisions flow through
+// `relayHostnameDedup` by construction — there is no independent decision
+// logic in remediation.ts — so these tests simultaneously prove REMED-01
+// (counts captured) and REMED-02 (narrowness invariant: no legit relay is
+// flipped unless relayHostnameDedup itself would flip it).
+//
+// IMPORTANT: initializeDB() at file load already ran the migration once on
+// an empty DB, which inserted the `rerun_dedup_all_rows_v1` sentinel. Every
+// test in this block MUST reset that sentinel before calling the migration
+// or it will short-circuit and be a no-op.
+// ============================================================================
+
+dedupTest("Phase 19 REMED-01: canonical mutation is flipped to ignore=1 with parent set", async () => {
+  // Reset the sentinel so the migration actually runs.
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'");
+
+  // Seed: legit root sibling + canonical mutation with MATCHING NIP-11.
+  // The shared info object ensures createInfoHash produces the same hash
+  // for both rows, so case 2 / case 8 fires inside relayHostnameDedup.
+  const sharedInfo = mockRelayInfo("Lumina Root", "shared NIP-11 across siblings");
+  setupDatabase([
+    {
+      url: "wss://relay.lumina.rocks/",
+      online: true,
+      ignore: false,
+      parent: "",
+      info: sharedInfo,
+    },
+    {
+      // Failing-sample-class mutation: same hostname, non-root path,
+      // matching NIP-11, currently wrongly promoted as ignore=0.
+      url: "wss://relay.lumina.rocks/umbra-vertex",
+      online: true,
+      ignore: false,
+      parent: "",
+      info: sharedInfo,
+    },
+  ]);
+
+  await rerunDedupForAllRowsMigration();
+
+  // Post-state: mutation must now be ignore=1 with parent set to the root.
+  const mutation = db.query(
+    `SELECT ignore, parent FROM relay_status WHERE url = ?`,
+    ["wss://relay.lumina.rocks/umbra-vertex"],
+  );
+  assertEquals(mutation.length, 1, "mutation row must still exist");
+  assertEquals(mutation[0][0], 1, "REMED-01: canonical mutation must be flipped to ignore=1");
+  const parent = mutation[0][1] as string;
+  assert(
+    parent === "wss://relay.lumina.rocks/" || parent === "wss://relay.lumina.rocks",
+    `REMED-01: parent must point at the root sibling, got "${parent}"`,
+  );
+
+  // Root must remain untouched (still ignore=0, no self-parent).
+  const root = db.query(
+    `SELECT ignore, parent FROM relay_status WHERE url = ?`,
+    ["wss://relay.lumina.rocks/"],
+  );
+  assertEquals(root[0][0], 0, "legit root must stay ignore=0");
+});
+
+dedupTest("Phase 19 REMED-02: legit path-only relay WITHOUT root sibling is left untouched (narrowness invariant)", async () => {
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'");
+
+  // A legit path-only relay with ZERO same-hostname siblings.
+  // This is the exact shape REMED-02 protects: the migration must NEVER
+  // flip this row, because relayHostnameDedup (with Phase 18 Fix 1's
+  // defensive-deny + no-relatives branch) will NOT flip it.
+  setupDatabase([
+    {
+      url: "wss://example.com/only-path",
+      online: true,
+      ignore: false,
+      parent: "",
+      info: mockRelayInfo("Solo Path Relay", "no siblings"),
+    },
+  ]);
+
+  await rerunDedupForAllRowsMigration();
+
+  const row = db.query(
+    `SELECT ignore, parent FROM relay_status WHERE url = ?`,
+    ["wss://example.com/only-path"],
+  );
+  assertEquals(row.length, 1, "solo path relay row must still exist");
+  assertEquals(row[0][0], 0, "REMED-02: solo legit path-only relay must stay ignore=0 (narrowness invariant)");
+  assertEquals((row[0][1] as string) || "", "", "REMED-02: parent must stay empty for solo path-only relay");
+});
+
+dedupTest("Phase 19 philosophy: legit path-only relay WITH matching-NIP-11 root is correctly flipped (shortest URL wins)", async () => {
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'");
+
+  // This is the subtle case the user clarified in 19-CONTEXT.md:
+  // When haven.nostrfreedom.net/inbox/ has a matching-NIP-11 root sibling
+  // wss://haven.nostrfreedom.net/, case 2 correctly fires and /inbox/ is
+  // ignored in favor of the root. That IS the dedup philosophy — the
+  // shortest URL is the canonical representation — NOT a regression.
+  const sharedInfo = mockRelayInfo("Haven", "same relay served at root and path");
+  setupDatabase([
+    {
+      url: "wss://haven.nostrfreedom.net/",
+      online: true,
+      ignore: false,
+      parent: "",
+      info: sharedInfo,
+    },
+    {
+      url: "wss://haven.nostrfreedom.net/inbox/",
+      online: true,
+      ignore: false,
+      parent: "",
+      info: sharedInfo,
+    },
+  ]);
+
+  await rerunDedupForAllRowsMigration();
+
+  // /inbox/ must be flipped to ignore=1 with parent=root.
+  // The canonical URL for the mutation after normalizeURL is /inbox
+  // (no trailing slash) — Phase 18 Fix 3 canonicalizes both ways.
+  // Query by both trailing and non-trailing forms to be resilient to
+  // whether normalizeURL rewrote the stored URL (it doesn't — remediation
+  // only UPDATEs by the stored raw URL).
+  const inboxRows = db.query(
+    `SELECT url, ignore, parent FROM relay_status WHERE url LIKE ?`,
+    ["%haven.nostrfreedom.net/inbox%"],
+  );
+  assertEquals(inboxRows.length, 1, "/inbox/ row must still exist");
+  assertEquals(
+    inboxRows[0][1],
+    1,
+    "philosophy: /inbox/ must be flipped to ignore=1 when a matching-NIP-11 root sibling is present (shortest URL wins)",
+  );
+  const parent = inboxRows[0][2] as string;
+  assert(
+    parent.includes("haven.nostrfreedom.net") && !parent.includes("/inbox"),
+    `philosophy: /inbox/ parent must point at the root, got "${parent}"`,
+  );
+
+  // Root must remain ignore=0.
+  const root = db.query(
+    `SELECT ignore FROM relay_status WHERE url = ?`,
+    ["wss://haven.nostrfreedom.net/"],
+  );
+  assertEquals(root[0][0], 0, "haven root must stay ignore=0");
+});
+
+dedupTest("Phase 19: already-correctly-ignored row is left unchanged (no redundant UPDATE)", async () => {
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'");
+
+  // Seed a row that is ALREADY ignored with a parent set. The migration
+  // should call relayHostnameDedup, see the same (ignore=true, parent=X)
+  // come back, and issue NO UPDATE. We verify by checking the row is
+  // unchanged AND by running the migration and confirming it completes.
+  const sharedInfo = mockRelayInfo("Already Ignored", "pre-ignored test");
+  setupDatabase([
+    {
+      url: "wss://spam.example.tld/",
+      online: true,
+      ignore: false,
+      parent: "",
+      info: sharedInfo,
+    },
+    {
+      url: "wss://spam.example.tld/mutation-a",
+      online: true,
+      ignore: true,
+      parent: "wss://spam.example.tld/",
+      info: sharedInfo,
+    },
+  ]);
+
+  await rerunDedupForAllRowsMigration();
+
+  const row = db.query(
+    `SELECT ignore, parent FROM relay_status WHERE url = ?`,
+    ["wss://spam.example.tld/mutation-a"],
+  );
+  assertEquals(row[0][0], 1, "already-ignored row must stay ignore=1");
+  const rowParent = row[0][1] as string;
+  assert(
+    rowParent.includes("spam.example.tld"),
+    `already-ignored row parent must remain pointing at the root, got "${rowParent}"`,
+  );
+});
+
+dedupTest("Phase 19: migration is idempotent — second call is a no-op (sentinel-guarded)", async () => {
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'");
+
+  const sharedInfo = mockRelayInfo("Idempotent Test", "shared");
+  setupDatabase([
+    {
+      url: "wss://idem.example.com/",
+      online: true,
+      ignore: false,
+      parent: "",
+      info: sharedInfo,
+    },
+    {
+      url: "wss://idem.example.com/mutant",
+      online: true,
+      ignore: false,
+      parent: "",
+      info: sharedInfo,
+    },
+  ]);
+
+  // First call: does the work, inserts the sentinel.
+  await rerunDedupForAllRowsMigration();
+
+  const sentinelAfterFirst = db.query(
+    "SELECT name FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'",
+  );
+  assertEquals(sentinelAfterFirst.length, 1, "sentinel must be present after first call");
+
+  // Snapshot post-first-run state of the mutation row.
+  const afterFirst = db.query(
+    `SELECT ignore, parent FROM relay_status WHERE url = ?`,
+    ["wss://idem.example.com/mutant"],
+  );
+  const firstIgnore = afterFirst[0][0];
+  const firstParent = afterFirst[0][1] as string;
+
+  // Manually mutate the row to an obviously-wrong state. If the migration
+  // runs a SECOND time (breaking idempotency), it will correct this back
+  // to the dedup answer and the assertion below will fail.
+  db.query(
+    `UPDATE relay_status SET ignore = 0, parent = '' WHERE url = ?`,
+    ["wss://idem.example.com/mutant"],
+  );
+
+  // Second call: MUST be a no-op because sentinel is present.
+  await rerunDedupForAllRowsMigration();
+
+  const afterSecond = db.query(
+    `SELECT ignore, parent FROM relay_status WHERE url = ?`,
+    ["wss://idem.example.com/mutant"],
+  );
+  assertEquals(afterSecond[0][0], 0, "idempotency: second call must not have re-run the migration (row stays at the manually-set 0)");
+  assertEquals((afterSecond[0][1] as string) || "", "", "idempotency: second call must not have re-set parent");
+
+  // And the sentinel must still be there (exactly one row).
+  const sentinelAfterSecond = db.query(
+    "SELECT COUNT(*) FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'",
+  );
+  assertEquals(sentinelAfterSecond[0][0], 1, "sentinel must still be present exactly once after the second call");
+
+  // Sanity-check: if the first-run values look plausible, the migration
+  // did the right thing originally (i.e. the no-op test is meaningful).
+  assert(
+    firstIgnore === 1 && firstParent.length > 0,
+    `first-run dedup sanity: expected ignore=1 with non-empty parent, got ignore=${firstIgnore} parent="${firstParent}"`,
+  );
+});
+
+dedupTest("Phase 19: sentinel row is inserted exactly once after a successful run", async () => {
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'");
+
+  // Zero-row DB: migration should still complete cleanly and insert the sentinel.
+  setupDatabase([]);
+
+  await rerunDedupForAllRowsMigration();
+
+  const sentinelRows = db.query(
+    "SELECT name, applied_at FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'",
+  );
+  assertEquals(sentinelRows.length, 1, "sentinel row must exist exactly once after a successful run");
+  assertEquals(sentinelRows[0][0], "rerun_dedup_all_rows_v1", "sentinel name must match the expected constant");
+  assert(
+    (sentinelRows[0][1] as number) > 0,
+    `sentinel applied_at must be a non-zero unix timestamp, got ${sentinelRows[0][1]}`,
+  );
+});
+
+dedupTest("Phase 19 REMED-02: mixed DB — canonical mutation flipped AND solo path-only preserved in the same run", async () => {
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'");
+
+  // A single run over a realistic mixed DB: one canonical-mutation class
+  // (root + sibling with matching NIP-11) that MUST flip, and one solo
+  // path-only relay that MUST stay untouched. This directly mirrors the
+  // production rollout shape and proves that REMED-01 and REMED-02 hold
+  // simultaneously in the same migration invocation.
+  const mutationSharedInfo = mockRelayInfo("Mixed Root", "shared info");
+  const soloInfo = mockRelayInfo("Solo Legit", "no siblings");
+  setupDatabase([
+    {
+      url: "wss://mixed.example.com/",
+      online: true,
+      ignore: false,
+      parent: "",
+      info: mutationSharedInfo,
+    },
+    {
+      url: "wss://mixed.example.com/foxtrot-papa",
+      online: true,
+      ignore: false,
+      parent: "",
+      info: mutationSharedInfo,
+    },
+    {
+      url: "wss://solo-legit.example.net/only",
+      online: true,
+      ignore: false,
+      parent: "",
+      info: soloInfo,
+    },
+  ]);
+
+  await rerunDedupForAllRowsMigration();
+
+  // Mutation: flipped.
+  const mutation = db.query(
+    `SELECT ignore, parent FROM relay_status WHERE url = ?`,
+    ["wss://mixed.example.com/foxtrot-papa"],
+  );
+  assertEquals(mutation[0][0], 1, "REMED-01: mutation row must be flipped to ignore=1");
+  assert(
+    (mutation[0][1] as string).includes("mixed.example.com"),
+    "REMED-01: mutation parent must point at the mixed.example.com root",
+  );
+
+  // Solo legit: untouched.
+  const solo = db.query(
+    `SELECT ignore, parent FROM relay_status WHERE url = ?`,
+    ["wss://solo-legit.example.net/only"],
+  );
+  assertEquals(solo[0][0], 0, "REMED-02: solo legit path-only must stay ignore=0 in mixed run");
+  assertEquals((solo[0][1] as string) || "", "", "REMED-02: solo legit parent must stay empty in mixed run");
+
+  // Root: untouched.
+  const root = db.query(
+    `SELECT ignore FROM relay_status WHERE url = ?`,
+    ["wss://mixed.example.com/"],
+  );
+  assertEquals(root[0][0], 0, "mixed root must stay ignore=0");
 });

--- a/libraries/db/src/index.ts
+++ b/libraries/db/src/index.ts
@@ -262,6 +262,44 @@ export function getOnlineRelays(): string[] {
     return onlineRelays;
 }
 
+/**
+ * Get all relays whose parsed URL hostname exactly matches `hostname`,
+ * regardless of online state. Optionally filter by protocol (e.g. "wss:").
+ *
+ * Used by relaymon's dedup defensive-deny branch in relayHostnameDedup to
+ * detect the no-relatives race (Phase 17 Hypothesis C): when the current
+ * online-family is empty but a known sibling exists in relay_status that
+ * just hasn't been committed to online=1 yet this cycle.
+ *
+ * SQL prefilter uses LIKE for speed; URL parsing is the correctness gate.
+ */
+export function getRelaysByHostname(hostname: string, protocol?: string): string[] {
+  if (!hostname || typeof hostname !== "string") return [];
+  const matches: string[] = [];
+  try {
+    // Parameterized LIKE prefilter: fast, avoids full table scan when
+    // relay_status has thousands of rows. The URL-parse filter below is
+    // the correctness guarantee.
+    const likePattern = `%${hostname}%`;
+    for (const [url] of db.query(
+      "SELECT url FROM relay_status WHERE url LIKE ?",
+      [likePattern],
+    )) {
+      try {
+        const parsed = new URL(url as string);
+        if (parsed.hostname !== hostname) continue;
+        if (protocol && parsed.protocol !== protocol) continue;
+        matches.push(url as string);
+      } catch {
+        // skip malformed URL rows silently
+      }
+    }
+  } catch (e) {
+    logger.error(`Error in getRelaysByHostname for ${hostname}: ${e}`);
+  }
+  return matches;
+}
+
 export function saveSeederTimestamp(method: string, timestamp: number): void {
   db.query(
     `

--- a/libraries/db/src/index.ts
+++ b/libraries/db/src/index.ts
@@ -1,5 +1,6 @@
 import { DB } from "https://deno.land/x/sqlite/mod.ts";
 import Logger from "npm:@nostrwatch/logger";
+import { normalizeURL } from "https://esm.sh/nostr-tools@2.23.3/utils";
 
 const logger = new Logger("DB");
 export let db: DB;
@@ -249,7 +250,11 @@ export function seedNewRelay(url: string, network: string): boolean {
 export function getAllRelays(): Set<string> {
   const onlineRelays: Set<string> = new Set();
   for (const [url] of db.query("SELECT url FROM relay_status")) {
-    onlineRelays.add(url as string);
+    try {
+      onlineRelays.add(normalizeURL(url as string));
+    } catch {
+      onlineRelays.add(url as string); // fall back to raw if normalizeURL throws
+    }
   }
   return onlineRelays;
 }
@@ -257,7 +262,11 @@ export function getAllRelays(): Set<string> {
 export function getOnlineRelays(): string[] {
     const onlineRelays: string[] = [];
     for (const [url] of db.query("SELECT url FROM relay_status WHERE online = 1")) {
-      onlineRelays.push(url as string);
+      try {
+        onlineRelays.push(normalizeURL(url as string));
+      } catch {
+        onlineRelays.push(url as string);
+      }
     }
     return onlineRelays;
 }
@@ -289,7 +298,11 @@ export function getRelaysByHostname(hostname: string, protocol?: string): string
         const parsed = new URL(url as string);
         if (parsed.hostname !== hostname) continue;
         if (protocol && parsed.protocol !== protocol) continue;
-        matches.push(url as string);
+        try {
+          matches.push(normalizeURL(url as string));
+        } catch {
+          matches.push(url as string);
+        }
       } catch {
         // skip malformed URL rows silently
       }


### PR DESCRIPTION
## Summary

Fixes relaymon's deduplication failing to collapse URL-path mutations of live relays. Resolves the ~200 rows in `relay_status` that slipped past dedup as `ignore=0, parent=''` and were being published as independent relays when they were actually mutations (spam, typo, copy-paste, or misconfiguration) targeting the same underlying WebSocket server as a legit sibling.

**The original bug analysis pointed at `hostnames.ts:328-331`. Phase 17 diagnosis proved that was a red herring — the actual defect path never reaches line 328.** The real causes are a first-check race and NIP-11 hash instability from volatile fields, compounded by a separate trailing-slash bug in `normalizeURL()`. The `index === 0` block at 328-331 is byte-identical across this PR.

## Root cause (multi-factor)

| Hypothesis | Verdict | Role |
|---|---|---|
| **C — First-check race** (`no-relatives` early-return at `hostnames.ts:254`) | CONFIRMED | **Primary cause.** When dedup runs for a mutation URL before its legit sibling is in `relay_status`, the family is empty → early-return → URL escapes dedup |
| **B — NIP-11 hash instability** (volatile fields in `createInfoHash`) | CONFIRMED | **Compounding.** `time`, `counters`, etc. cause identical servers to hash to different values, defeating case8's `isSameAsAnyRelative` check |
| **A — Family scope too narrow** (`getOnlineRelays()`) | PARTIAL | Secondary contributor only — early-return path at 160-207 bypasses it |
| **D — `reevaluateAllDeduplication` narrow scope** | INCONCLUSIVE | Structurally confirmed; Fix 1 incidentally closes it at the dedup call site |
| **328-331 `index===0` branch** | RULED OUT | Red herring — defect path hits `no-relatives` early-return at line 254 first |

**Bonus discovery:** `normalizeURL()` (from `nostr-tools/utils`) strips trailing slashes, so `orderedFamily.indexOf(mURL)` returns `-1` for legit multi-segment relays like `wss://haven.nostrfreedom.net/inbox/`, dropping them into the CRITICAL ERROR branch where `ignore=true` is set. Fixed in Fix 3.

## Three fixes

- **Fix 1 — Close the no-relatives race.** New `getRelaysByHostname(hostname)` helper in `libraries/db/src/index.ts`. `relayHostnameDedup` checks for known siblings regardless of online state when the online family is empty; defensively marks the URL as a duplicate of the shortest known sibling.
- **Fix 2 — Stabilize `createInfoHash()`.** New `apps/relaymon/src/utils/nip11.ts` with `normalizeNip11()` that strips volatile fields (`time`, `timestamp`, `now`, `last_*`, `current_*`, anything containing `count`, etc.) before hashing. Idempotent startup migration (`rehashRelayInfoMigration`) re-hashes existing `relay_info` rows via the `relaymon_migrations` sentinel table.
- **Fix 3 — `normalizeURL()` trailing-slash.** `canonicalMURL` derivation at function entry in `relayHostnameDedup` used consistently at all 7 URL-comparison sites. DB read helpers (`getOnlineRelays`, `getAllRelays`, `getRelaysByHostname`) canonicalize on read — no write-side migration needed.

## Remediation

New `apps/relaymon/src/utils/remediation.ts` with `rerunDedupForAllRowsMigration()` — idempotent startup migration gated by the `rerun_dedup_all_rows_v1` sentinel, wired into `initializeDB()` after `rehashRelayInfoMigration` (order matters). Iterates all `relay_status` rows regardless of online state, routes every decision through `relayHostnameDedup`, logs per-mutation lines plus a final structured JSON summary:

```
{"migration":"rerun-dedup-all-rows-v1","rows_evaluated":N,"newly_ignored":M,"newly_unignored":K,"unchanged":P,"duration_ms":T}
```

Runs automatically on each monitor's next restart — zero manual intervention for the 10-monitor fleet.

**REMED-02 narrowness invariant** is enforced by construction: the migration has exactly one SQL UPDATE, gated on `await relayHostnameDedup(result)`. No independent dedup decision logic. A legit path-only relay that `relayHostnameDedup` returns `ignore=false` for cannot be flipped by the migration.

## Philosophy clarification (why there's no `case9`)

An initial proposal to add a new `case9` for "non-root eldest + NIP-11 differs → ignore child" was discarded after clarifying the existing dedup philosophy:

- **NIP-11 match → same relay → shorter URL wins** (existing cases 1/2/4/8)
- **NIP-11 differs → genuinely different relays → both get published** (no rule needed)
- **NIP-11 absent → pessimistic → ignore path URLs** (existing case 5)

Under this philosophy, the Phase 18 deviation note about "mutation with genuinely different NIP-11 and a non-root eldest sibling cannot be caught by the 8-case logic" is **not a limitation** — it's the philosophy working as designed. Different NIP-11 = different relays. No new case.

## Files changed

**New files:**
- `apps/relaymon/src/utils/nip11.ts` — `normalizeNip11()` helper
- `apps/relaymon/src/utils/remediation.ts` — `rerunDedupForAllRowsMigration()`

**Modified:**
- `apps/relaymon/src/utils/hostnames.ts` — Fix 1 (defensive-deny), Fix 2 (createInfoHash → normalizeNip11), Fix 3 (canonicalMURL at 7 sites). `index === 0` block byte-identical.
- `apps/relaymon/src/db/db.ts` — wires both migrations in `initializeDB()` (rehash before rerun)
- `libraries/db/src/index.ts` — `getRelaysByHostname()` helper + canonicalize-on-read in all three read helpers

**Tests:** `apps/relaymon/tests/unit/hostname-dedup.test.ts` grows from 22 baseline → 54 passing. Covers:
- Hypothesis A/B/C isolation (Phase 17 tests promoted to hard regression assertions)
- Transient-sibling-offline (DEDUP-02 / TEST-03)
- `haven.nostrfreedom.net/inbox/` narrowness (Fix 3 / DEDUP-03)
- Trailing-slash edge cases: `/`, `/foo`, `/foo/`, `/foo/bar`, `/foo/bar/`
- `normalizeNip11()` stability across volatile-field permutations
- Migration unit tests: canonical mutation flipped, solo legit preserved, philosophy case (legit `/inbox/` WITH matching root correctly flipped), already-ignored untouched, idempotency, sentinel verification

## Test plan

- [x] `cd apps/relaymon && deno test --allow-all --no-check --no-lock --sloppy-imports tests/unit/hostname-dedup.test.ts` → **54 passed / 0 failed**
- [x] `git diff` confirms `hostnames.ts:328-331` (the `index === 0` branch content) is byte-identical to pre-v2.3
- [x] Narrowness invariant: `wss://haven.nostrfreedom.net/inbox/` stays `ignore=false` when it has no root sibling (hard `assertEquals`)
- [x] Philosophy case: `wss://haven.nostrfreedom.net/inbox/` is correctly flipped to `ignore=true, parent=<root>` when a matching-NIP-11 root sibling exists (this is the intended behavior, not a regression)
- [x] Migration idempotency: second call is a no-op (sentinel guard)
- [ ] **Manual verification after deploy:** `grep 'rerun-dedup-all-rows-v1' /path/to/relaymon.log | jq .` on each monitor after first restart to confirm the summary JSON line and spot-check row counts

## Known follow-ups (deferred, non-blocking)

- **Hypothesis D runtime test** blocked by Deno module-scope singleton issue in `reevaluateAllDeduplication` tests. Structurally confirmed by code review; Fix 1 incidentally closes it at the dedup call site. Follow-up: fix the harness or route re-eval through the Fix 1 helper.
- **`deno.lock` `agent-base@7.1.4` integrity mismatch** — pre-existing, unrelated. Tests currently require `--no-lock --sloppy-imports`. Regenerate lockfile separately.
- **`apps/relaymon/src/db/db.ts` local `getOnlineRelays` shadow** — shadows `libraries/db/src/index.ts`'s canonicalized export. Fix 3 narrowness holds via `canonicalMURL` + `orderedFamily.map(normalizeURL)`, but removing the shadow is a cleanup opportunity.
- **Pre-existing fall-through at `hostnames.ts:479-481`** — not a v2.3 regression. Philosophy-correct under the clarified rules but merits a documented assertion test to lock it in.

## Philosophical notes

1. **Source-agnostic:** The fix handles spam mutations, typos, copy-paste errors, and misconfigured clients identically. No source detection.
2. **`index === 0` invariant:** Deliberately untouched per Phase 17 red-herring verdict. Modifying it would risk mass-ignoring legit path-only relays.
3. **Migration-first remediation:** Integrated into the existing daemon startup rather than a standalone script because the user runs 10 monitors and manual deployment per-monitor is operationally infeasible.

See `.planning/phases/17-diagnose-dedup-family-scope-failure/17-DIAGNOSIS.md` for the full root-cause analysis and `.planning/milestones/v2.3-MILESTONE-AUDIT.md` for the audit report.