### PR TITLE
hotfix: local dedup precedes synced ignore list + deletion queue

### DIFF
--- a/apps/relaymon/src/core/daemon.ts
+++ b/apps/relaymon/src/core/daemon.ts
@@ -174,6 +174,17 @@ export async function runDaemon(config: Config): Promise<void> {
 
     const worker = new Worker(pubkey, queueManager, config, ignoreListSync);
 
+    // Drain remediation deletion queue now that config + keys + sync
+    // + worker are all wired. Deletions are published one-at-a-time
+    // via the normal deletion.ts pipeline; successfully OK'd entries
+    // are removed from the queue, failures are retried next startup.
+    try {
+      const { drainRemediationDeletionQueue } = await import("../utils/remediation.ts");
+      await drainRemediationDeletionQueue(config);
+    } catch (e) {
+      logger.error(`drainRemediationDeletionQueue failed: ${e}`);
+    }
+
     let seeder: RelaySeeder | undefined
     
     if(config?.relaymon?.seed) {

--- a/apps/relaymon/src/db/db.ts
+++ b/apps/relaymon/src/db/db.ts
@@ -12,7 +12,7 @@ let isInitialized = false;
  * @param dbPath Optional path to the SQLite database file
  * @param enableWAL Optional boolean to enable WAL mode (default: true)
  */
-export function initializeDB(dbPath?: string, enableWAL: boolean = true): void {
+export async function initializeDB(dbPath?: string, enableWAL: boolean = true): Promise<void> {
   if (isInitialized) {
     logger.warn("Database already initialized, ignoring repeated initialization");
     return;
@@ -47,6 +47,25 @@ export function initializeDB(dbPath?: string, enableWAL: boolean = true): void {
     `);
   } catch (e) {
     logger.error(`Failed to create relaymon_migrations table: ${e}`);
+  }
+
+  // Remediation deletion queue: rows written by remediation migrations
+  // that need kind:5 deletion events published once the daemon has
+  // config, keys, and a live nostr-tools SimplePool. Drained by the
+  // daemon after startup wiring — see drainRemediationDeletionQueue in
+  // remediation.ts. Rows are removed on successful OK.
+  try {
+    db.query(`
+      CREATE TABLE IF NOT EXISTS remediation_deletion_queue (
+        url TEXT PRIMARY KEY,
+        reason TEXT NOT NULL,
+        queued_at INTEGER NOT NULL,
+        attempts INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT
+      )
+    `);
+  } catch (e) {
+    logger.error(`Failed to create remediation_deletion_queue table: ${e}`);
   }
 
   // Create the relay_delta_state table for tracking state changes
@@ -108,15 +127,20 @@ export function initializeDB(dbPath?: string, enableWAL: boolean = true): void {
   }
 
   // Phase 19 REMED-01/REMED-02: re-run dedup over every row in
-  // relay_status using the now-fixed relayHostnameDedup (Phase 18 Fixes
-  // 1–3). Idempotent via relaymon_migrations sentinel. MUST run AFTER
-  // rehashRelayInfoMigration so the re-dedup sees stable hashes.
-  // Fire-and-forget async — initializeDB is sync, but the migration is
-  // async because relayHostnameDedup is async. Any error is swallowed
-  // inside the migration itself (never crashes startup).
-  rerunDedupForAllRowsMigration().catch((e) => {
+  // relay_status using the now-fixed relayHostnameDedup. Idempotent via
+  // relaymon_migrations sentinel. MUST run AFTER rehashRelayInfoMigration
+  // so the re-dedup sees stable hashes, and MUST complete BEFORE the
+  // daemon constructs IgnoreListSync (which snapshots relay_status
+  // ignore=1 rows into its in-memory map). initializeDB is therefore
+  // async so main.ts can await the migration before wiring the daemon.
+  // Migration writes deletion events to remediation_deletion_queue
+  // rather than publishing directly — the daemon drains that queue
+  // after setup via drainRemediationDeletionQueue.
+  try {
+    await rerunDedupForAllRowsMigration();
+  } catch (e) {
     logger.error(`rerunDedupForAllRowsMigration threw: ${e}`);
-  });
+  }
 
   isInitialized = true;
 }

--- a/apps/relaymon/src/utils/hostnames.ts
+++ b/apps/relaymon/src/utils/hostnames.ts
@@ -164,13 +164,17 @@ export const relayHostnameDedup = async (result: RelayCheckResult): Promise<Rela
       canonicalMURL = mURL;
     }
 
-    // Check if this relay is in the synced ignore list from other monitors
-    if (ignoreListSyncInstance && ignoreListSyncInstance.isIgnored(mURL)) {
-      logger.warn(`${mURL} is in synced ignore list from other monitors`);
-      result.ignore = true;
-      result.parent = ""; // We don't know the parent from synced lists
-      return result;
-    }
+    // NOTE: local dedup logic is authoritative. The synced ignore list
+    // from other monitors is NOT consulted here — a previous version of
+    // this code early-returned ignore=true/parent="" whenever a URL
+    // appeared in the synced list, which (a) wiped legitimate parent
+    // pointers computed by local logic and (b) propagated poisoned
+    // decisions from other monitors (including roots wrongly flipped by
+    // pre-Phase-18 bugs) back onto the local DB. Local dedup MUST run
+    // to completion on every URL, regardless of what peers believe.
+    // The synced list is still populated via addToIgnoreList calls
+    // downstream and remains useful to higher layers as an advisory
+    // cross-monitor signal, but it is never an override.
 
     // First, check if this relay has NIP-11 info and store it if available
     const currentHasNip11Info = result?.info?.data && Object.keys(result.info.data).length > 0;

--- a/apps/relaymon/src/utils/remediation.ts
+++ b/apps/relaymon/src/utils/remediation.ts
@@ -36,10 +36,16 @@ import { relayHostnameDedup } from "./hostnames.ts";
 import { getLogger } from "./logger.ts";
 import type { RelayCheckResult } from "../types/relay.ts";
 import type { NetworkType } from "../types/config.ts";
+import type { Config } from "../types/config.ts";
 
 const logger = getLogger("Remediation");
 
-const MIGRATION_NAME = "rerun_dedup_all_rows_v1";
+// Bumped to v2 after the synced-ignore-list override bug was fixed in
+// relayHostnameDedup. v1 ran under the broken early-return, which meant
+// every tainted-root row was short-circuited to ignore=true/parent=""
+// instead of being re-evaluated by local logic. v2 forces a fresh pass
+// so all rows see the corrected dedup path.
+const MIGRATION_NAME = "rerun_dedup_all_rows_v2";
 
 export async function rerunDedupForAllRowsMigration(): Promise<void> {
   // Top-level try: never let this migration crash startup.
@@ -144,8 +150,25 @@ export async function rerunDedupForAllRowsMigration(): Promise<void> {
             `UPDATE relay_status SET ignore = ?, parent = ? WHERE url = ?`,
             [newIgnore ? 1 : 0, newParent, url],
           );
-          if (newIgnore && !storedIgnore) newlyIgnored++;
-          else if (!newIgnore && storedIgnore) newlyUnignored++;
+          if (newIgnore && !storedIgnore) {
+            newlyIgnored++;
+            // Queue a deletion event for the newly-ignored URL. The
+            // daemon drains this queue after it has config + keys
+            // available. We can't publish directly from inside this
+            // migration because initializeDB runs before the daemon
+            // wires setConfig / SimplePool / private key.
+            const reason = newParent
+              ? `Duplicate of ${newParent} (remediation)`
+              : `Ignored by hostname dedup (remediation)`;
+            enqueueRemediationDeletion(url, reason);
+          } else if (!newIgnore && storedIgnore) {
+            newlyUnignored++;
+            // Un-ignored rows need no queue entry: kind:5 deletions are
+            // one-way on nostr. IgnoreListSync.loadLocalIgnoresFromDB
+            // will naturally exclude these rows when the daemon
+            // constructs the sync instance AFTER this migration has
+            // awaited to completion (see db.ts initializeDB order).
+          }
           logger.info(
             `Remediation: ${url} ignore=${storedIgnore}/parent="${storedParent}" → ignore=${newIgnore}/parent="${newParent}"`,
           );
@@ -187,5 +210,110 @@ export async function rerunDedupForAllRowsMigration(): Promise<void> {
   } catch (e) {
     logger.error(`Migration ${MIGRATION_NAME} failed: ${e}`);
     // Intentionally no rethrow — never crash startup.
+  }
+}
+
+/**
+ * Enqueue a URL for delayed kind:5 deletion publication. Called by the
+ * remediation migration (which cannot publish directly because daemon
+ * wiring hasn't happened yet) and available for any other code path
+ * that wants a deletion published once wiring completes. Idempotent on
+ * url via PRIMARY KEY — repeat calls just refresh the reason.
+ */
+export function enqueueRemediationDeletion(url: string, reason: string): void {
+  try {
+    db.query(
+      `INSERT INTO remediation_deletion_queue (url, reason, queued_at, attempts)
+       VALUES (?, ?, ?, 0)
+       ON CONFLICT(url) DO UPDATE SET reason = excluded.reason`,
+      [url, reason, Math.floor(Date.now() / 1000)],
+    );
+  } catch (e) {
+    logger.error(`enqueueRemediationDeletion failed for ${url}: ${e}`);
+  }
+}
+
+/**
+ * Drain the remediation_deletion_queue: publish a kind:5 deletion for
+ * each queued URL and remove the row on successful OK. Called by the
+ * daemon AFTER config / keys / SimplePool are wired up. Failures
+ * increment the attempts counter and leave the row in place for the
+ * next startup. Never throws — reports counts via a structured log
+ * line and returns.
+ */
+export async function drainRemediationDeletionQueue(config: Config): Promise<void> {
+  try {
+    const rows = db.query(
+      `SELECT url, reason, attempts FROM remediation_deletion_queue
+       ORDER BY queued_at ASC`,
+    );
+
+    if (rows.length === 0) {
+      logger.debug(`Deletion queue empty — nothing to drain`);
+      return;
+    }
+
+    logger.info(`Draining remediation deletion queue: ${rows.length} entries`);
+    const startTime = Date.now();
+    let published = 0;
+    let failed = 0;
+
+    // Lazy import so unit tests and non-daemon code paths that never
+    // drain the queue don't pay the deletion.ts import cost.
+    const { deleteRelayCheckEvent } = await import("./deletion.ts");
+
+    for (const row of rows) {
+      const [urlRaw, reasonRaw, attemptsRaw] = row;
+      const url = urlRaw as string;
+      const reason = (reasonRaw as string) || "";
+      const attempts = (attemptsRaw as number) || 0;
+
+      try {
+        const ok = await deleteRelayCheckEvent(url, reason, config);
+        if (ok) {
+          db.query(
+            `DELETE FROM remediation_deletion_queue WHERE url = ?`,
+            [url],
+          );
+          published++;
+          logger.info(`Deletion published for ${url}: queue entry removed`);
+        } else {
+          db.query(
+            `UPDATE remediation_deletion_queue
+             SET attempts = ?, last_error = ?
+             WHERE url = ?`,
+            [attempts + 1, "deleteRelayCheckEvent returned false", url],
+          );
+          failed++;
+          logger.warn(
+            `Deletion NOT ACK'd for ${url} (attempts=${attempts + 1}) — left in queue`,
+          );
+        }
+      } catch (e) {
+        const errStr = String(e);
+        db.query(
+          `UPDATE remediation_deletion_queue
+           SET attempts = ?, last_error = ?
+           WHERE url = ?`,
+          [attempts + 1, errStr.slice(0, 500), url],
+        );
+        failed++;
+        logger.error(
+          `Deletion threw for ${url} (attempts=${attempts + 1}): ${errStr}`,
+        );
+      }
+    }
+
+    const durationMs = Date.now() - startTime;
+    logger.info(
+      JSON.stringify({
+        drain: "remediation_deletion_queue",
+        published,
+        failed,
+        duration_ms: durationMs,
+      }),
+    );
+  } catch (e) {
+    logger.error(`drainRemediationDeletionQueue failed: ${e}`);
   }
 }

--- a/apps/relaymon/tests/unit/hostname-dedup.test.ts
+++ b/apps/relaymon/tests/unit/hostname-dedup.test.ts
@@ -15,6 +15,7 @@ import {
   relayArrToHostnameProtocolKeyedMap,
   createInfoHash,
   setConfig,
+  setIgnoreListSync,
   reevaluateAllDeduplication,
 } from "../../src/utils/hostnames.ts";
 import { mockConfig } from "../helpers/fixtures.ts";
@@ -1914,14 +1915,14 @@ Deno.test("Phase 18 Fix 2: rehashRelayInfoMigration is idempotent", () => {
 // flipped unless relayHostnameDedup itself would flip it).
 //
 // IMPORTANT: initializeDB() at file load already ran the migration once on
-// an empty DB, which inserted the `rerun_dedup_all_rows_v1` sentinel. Every
+// an empty DB, which inserted the `rerun_dedup_all_rows_v2` sentinel. Every
 // test in this block MUST reset that sentinel before calling the migration
 // or it will short-circuit and be a no-op.
 // ============================================================================
 
 dedupTest("Phase 19 REMED-01: canonical mutation is flipped to ignore=1 with parent set", async () => {
   // Reset the sentinel so the migration actually runs.
-  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'");
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v2'");
 
   // Seed: legit root sibling + canonical mutation with MATCHING NIP-11.
   // The shared info object ensures createInfoHash produces the same hash
@@ -1970,7 +1971,7 @@ dedupTest("Phase 19 REMED-01: canonical mutation is flipped to ignore=1 with par
 });
 
 dedupTest("Phase 19 REMED-02: legit path-only relay WITHOUT root sibling is left untouched (narrowness invariant)", async () => {
-  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'");
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v2'");
 
   // A legit path-only relay with ZERO same-hostname siblings.
   // This is the exact shape REMED-02 protects: the migration must NEVER
@@ -1998,7 +1999,7 @@ dedupTest("Phase 19 REMED-02: legit path-only relay WITHOUT root sibling is left
 });
 
 dedupTest("Phase 19 philosophy: legit path-only relay WITH matching-NIP-11 root is correctly flipped (shortest URL wins)", async () => {
-  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'");
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v2'");
 
   // This is the subtle case the user clarified in 19-CONTEXT.md:
   // When haven.nostrfreedom.net/inbox/ has a matching-NIP-11 root sibling
@@ -2056,7 +2057,7 @@ dedupTest("Phase 19 philosophy: legit path-only relay WITH matching-NIP-11 root 
 });
 
 dedupTest("Phase 19: already-correctly-ignored row is left unchanged (no redundant UPDATE)", async () => {
-  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'");
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v2'");
 
   // Seed a row that is ALREADY ignored with a parent set. The migration
   // should call relayHostnameDedup, see the same (ignore=true, parent=X)
@@ -2095,7 +2096,7 @@ dedupTest("Phase 19: already-correctly-ignored row is left unchanged (no redunda
 });
 
 dedupTest("Phase 19: migration is idempotent — second call is a no-op (sentinel-guarded)", async () => {
-  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'");
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v2'");
 
   const sharedInfo = mockRelayInfo("Idempotent Test", "shared");
   setupDatabase([
@@ -2119,7 +2120,7 @@ dedupTest("Phase 19: migration is idempotent — second call is a no-op (sentine
   await rerunDedupForAllRowsMigration();
 
   const sentinelAfterFirst = db.query(
-    "SELECT name FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'",
+    "SELECT name FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v2'",
   );
   assertEquals(sentinelAfterFirst.length, 1, "sentinel must be present after first call");
 
@@ -2151,7 +2152,7 @@ dedupTest("Phase 19: migration is idempotent — second call is a no-op (sentine
 
   // And the sentinel must still be there (exactly one row).
   const sentinelAfterSecond = db.query(
-    "SELECT COUNT(*) FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'",
+    "SELECT COUNT(*) FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v2'",
   );
   assertEquals(sentinelAfterSecond[0][0], 1, "sentinel must still be present exactly once after the second call");
 
@@ -2164,7 +2165,7 @@ dedupTest("Phase 19: migration is idempotent — second call is a no-op (sentine
 });
 
 dedupTest("Phase 19: sentinel row is inserted exactly once after a successful run", async () => {
-  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'");
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v2'");
 
   // Zero-row DB: migration should still complete cleanly and insert the sentinel.
   setupDatabase([]);
@@ -2172,10 +2173,10 @@ dedupTest("Phase 19: sentinel row is inserted exactly once after a successful ru
   await rerunDedupForAllRowsMigration();
 
   const sentinelRows = db.query(
-    "SELECT name, applied_at FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'",
+    "SELECT name, applied_at FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v2'",
   );
   assertEquals(sentinelRows.length, 1, "sentinel row must exist exactly once after a successful run");
-  assertEquals(sentinelRows[0][0], "rerun_dedup_all_rows_v1", "sentinel name must match the expected constant");
+  assertEquals(sentinelRows[0][0], "rerun_dedup_all_rows_v2", "sentinel name must match the expected constant");
   assert(
     (sentinelRows[0][1] as number) > 0,
     `sentinel applied_at must be a non-zero unix timestamp, got ${sentinelRows[0][1]}`,
@@ -2183,7 +2184,7 @@ dedupTest("Phase 19: sentinel row is inserted exactly once after a successful ru
 });
 
 dedupTest("Phase 19 REMED-02: mixed DB — canonical mutation flipped AND solo path-only preserved in the same run", async () => {
-  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v1'");
+  db.query("DELETE FROM relaymon_migrations WHERE name = 'rerun_dedup_all_rows_v2'");
 
   // A single run over a realistic mixed DB: one canonical-mutation class
   // (root + sibling with matching NIP-11) that MUST flip, and one solo


### PR DESCRIPTION
## Summary

Two compounding bugs were poisoning \`relay_status\`:

1. \`relayHostnameDedup\` early-returned \`ignore=true/parent=""\` whenever a URL appeared in the synced ignore list, wiping legitimate parent pointers AND propagating peer monitors' bad pre-Phase-18 decisions into the local DB.
2. \`rerunDedupForAllRowsMigration\` ran fire-and-forget inside \`initializeDB\` — BEFORE \`setConfig\`/\`IgnoreListSync\`/keys were wired — so the appConfig-guarded \`deleteRelayCheckEvent\` calls silently skipped every deletion.

## Changes

- Remove the synced-ignore early-return in \`relayHostnameDedup\`. Local logic is authoritative; peers are advisory only.
- Make \`initializeDB\` async and \`await\` the remediation migration so \`IgnoreListSync.loadLocalIgnoresFromDB\` snapshots clean state in its constructor. Sentinel bumped to \`rerun_dedup_all_rows_v2\`.
- Add persistent \`remediation_deletion_queue\` table. Migration writes \`(url, reason, queued_at, attempts, last_error)\` for every newly-ignored row instead of trying to publish directly.
- Add \`drainRemediationDeletionQueue(config)\` — daemon calls it right after the worker is constructed, publishes \`deleteRelayCheckEvent\` per row, removes on OK, records failures for retry on next startup.

Un-ignored rows need no queue entry: kind:5 deletions are one-way; \`loadLocalIgnoresFromDB\` naturally excludes them because the migration has already awaited-to-completion by the time the sync instance is built.

## Test plan

- [x] \`deno task test:hostname-dedup\` — 58/58 passing locally (sentinel references bumped v1→v2 in tests)
- [ ] CI runs the dedup + integration suites
- [ ] Deploy + watch logs: newly-ignored rows should produce drain log lines; synced-list precedence should stop flipping roots
- [ ] Regression tests for (a) local-takes-precedence with fake sync instance, (b) queue write on newly-ignored, (c) drain removing rows on OK — **follow-up**
- [ ] Invalid-URL purge migration using \`@nostrwatch/nostrings.qualifyRelayUrl\` — **follow-up branch**