### PR TITLE
fix: reject relay URLs with dotless hostnames

### DIFF
--- a/libraries/nostrings/src/relay-urls.test.ts
+++ b/libraries/nostrings/src/relay-urls.test.ts
@@ -172,6 +172,15 @@ describe('qualifyRelayUrl - spam word blocking', () => {
   });
 });
 
+describe('qualifyRelayUrl - mangled/double-slash URLs', () => {
+  it('should reject hostnames without a dot (mangled protocol URLs)', () => {
+    expect(qualifyRelayUrl('wss://wws//nos.lol')).toBe(false);
+    expect(qualifyRelayUrl('wss://wscp//192.168.8.23:4848')).toBe(false);
+    expect(qualifyRelayUrl('wss://was//nostr.land.cc')).toBe(false);
+    expect(qualifyRelayUrl('wss://(wss//relay.primal.net)')).toBe(false);
+  });
+});
+
 describe('sanitize - NATO phonetic spam end-to-end', () => {
   it('should filter out NATO spam URLs from a mixed list', () => {
     const relays = ['wss://relay.example.com/alpha', 'wss://good.relay.com'];

--- a/libraries/nostrings/src/relay-urls.ts
+++ b/libraries/nostrings/src/relay-urls.ts
@@ -174,8 +174,13 @@ export const qualifyRelayUrl = (maybeRelay: string): boolean => {
     return false;
   }
 
-  const hostname = url.hostname;  
-  const pathname = url.pathname;  
+  const hostname = url.hostname;
+  const pathname = url.pathname;
+
+  // Reject hostnames without a dot — catches mangled URLs like
+  // wss://wws//nos.lol (hostname="wws"), wss://was//x (hostname="was"),
+  // wss://(wss//relay.primal.net) (hostname="(wss")
+  if ( !hostname.includes('.') ) return false;
 
   if ( isLocalNet(maybeRelay) ) return false;
 


### PR DESCRIPTION
## Summary

- URLs like `wss://wws//nos.lol` parse as hostname=`wws` (no TLD) and slip through all existing checks
- Same for `wss://wscp//192.168.8.23:4848`, `wss://was//nostr.land.cc`, `wss://(wss//relay.primal.net)`
- Fix: reject any hostname without a dot in `qualifyRelayUrl()` — valid relay hostnames always have one

## Test plan

- [x] 27 nostrings relay-urls tests pass (added mangled URL test)
- [ ] Deploy, confirm trawler stops ingesting these