### PR TITLE
fix: XSS via unsanitized NIP-11 fields rendered with {@html}

### DIFF
--- a/apps/gui/src/lib/components/layout/PageHeader.svelte
+++ b/apps/gui/src/lib/components/layout/PageHeader.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 
     import { clickToCopy } from "$utils/ux";
+    import { safeImageUrl } from "$utils/sanitize";
+    import * as DOMPurify from "dompurify";
 
     export let title: string;
     export let icon: string | undefined = undefined;
@@ -11,13 +13,28 @@
 
     const noop=()=>{}
 
+    // Validate the relay-controlled banner URL before interpolating it into a
+    // CSS `url('...')` value. safeImageUrl rejects any URL containing the
+    // attribute/CSS breakout characters and entity-encodes the result.
+    $: safeBanner = safeImageUrl(banner);
+
+    // Validate the relay-controlled icon URL before binding it to <img src>.
+    $: safeIcon = safeImageUrl(icon);
+
+    // Most callers pass plain text (e.g. NIP-11 description). The
+    // /relays/software/[softwareKey] page passes pre-formatted HTML, so we
+    // sanitize via DOMPurify rather than dropping {@html} entirely. DOMPurify
+    // is already a dependency of apps/gui (used in $utils/notes.ts).
+    // sanitize() defaults strip script tags and event-handler attributes.
+    $: safeSubtitle = subtitle ? (DOMPurify as any).sanitize(subtitle) : '';
+
 </script>
 <header
   id="relay-header"
   class="relative bg-center bg-cover bg-no-repeat px-3 pb-10 gradient-purple pt-24"
-  style={banner? `background: linear-gradient(rgba(0, 0, 0, ${bgOpacity}), rgba(0, 0, 0, ${bgOpacity})),  url('${banner}');
+  style={safeBanner ? `background: linear-gradient(rgba(0, 0, 0, ${bgOpacity}), rgba(0, 0, 0, ${bgOpacity})), url('${safeBanner}');
     background-repeat: no-repeat;
-    background-size: cover;`: ''}
+    background-size: cover;` : ''}
 >
   <!-- Absolute positioned slot for overlays like maps -->
   <slot name="absolute" />
@@ -25,9 +42,9 @@
   <div class="relative z-10 flex justify-between items-start p-6 h-full">
     <div class="flex">
     <div class="flex-shrink-0 mr-2">
-        {#if icon}
+        {#if safeIcon}
             <span class="inline-block overflow-hidden rounded-full w-20 h-20">
-            <img src="{icon}" alt="relay icon" class="inline mr-2 w-full h-auto" />
+            <img src={safeIcon} alt="relay icon" class="inline mr-2 w-full h-auto" />
             </span>
         {/if}
     </div>
@@ -49,7 +66,7 @@
           {/if}
         </h1>
         {#if subtitle}
-            <span class="ml-3 text-lg block">{@html subtitle}</span>
+            <span class="ml-3 text-lg block">{@html safeSubtitle}</span>
         {/if}
         <slot />
       </div>

--- a/apps/gui/src/lib/config/dataTable/isps.ts
+++ b/apps/gui/src/lib/config/dataTable/isps.ts
@@ -1,7 +1,8 @@
 import type { DataKeys, Formatters, NameFormatter } from '$lib/components/data-view/DataTableTypes';
 import { makeSoftwareReadable } from '$lib/synonyms/software';
 
-import { pastelPairFromString } from '$utils/colors'; 
+import { pastelPairFromString } from '$utils/colors';
+import { escapeHtml, safeImageUrl } from '$utils/sanitize';
 
 export const columnsDisable: DataKeys = ['id']
 export const filtersDisable: DataKeys = []
@@ -31,10 +32,12 @@ function truncateWithEllipsis(text: string, maxLength: number): string {
 export const tableFormatters: Formatters = {
     prettyName: (prettyName: string, row: any) => {
         if(typeof prettyName !== 'string') return '-';
-        prettyName = `<span class="my-1 text-sm font-mono" style="color:${pastelPairFromString(prettyName)?.dark};">${prettyName}</span>`;
-        const icon = row.icon? 
-            `<img src="${row.icon}" alt="${prettyName}" loading="lazy" decoding="async" referrerpolicy="no-referrer" class="w-6 h-6 inline-block mr-2">` 
-            :'<span class="w-6 h-6 inline-block mr-2"></span>';
+        const safeIcon = safeImageUrl(row.icon);
+        const safeName = escapeHtml(prettyName);
+        prettyName = `<span class="my-1 text-sm font-mono" style="color:${pastelPairFromString(prettyName)?.dark};">${safeName}</span>`;
+        const icon = safeIcon
+            ? `<img src="${safeIcon}" alt="${safeName}" loading="lazy" decoding="async" referrerpolicy="no-referrer" class="w-6 h-6 inline-block mr-2">`
+            : '<span class="w-6 h-6 inline-block mr-2"></span>';
         return `${icon}${prettyName}`;
     },
     percent: (percent: number) => {

--- a/apps/gui/src/lib/config/dataTable/relays.formatters.test.ts
+++ b/apps/gui/src/lib/config/dataTable/relays.formatters.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Stub out the store / framework imports that touch localStorage, IndexedDB,
+// or SvelteKit runtime at module load time. Keep mocks minimal — the goal is
+// to exercise the real formatter logic on attacker-controlled inputs, not to
+// substitute the formatters.
+
+vi.mock('$lib/stores/monitors.js', () => ({
+    monitorsMap: { subscribe: vi.fn() }
+}));
+
+vi.mock('$lib/stores/checks.js', () => ({
+    relaySpeedGroupResolver: { subscribe: vi.fn(() => () => {}) },
+    relayChecksActiveKeys: { subscribe: vi.fn() },
+    relayCheckAggregator: vi.fn(),
+    relayChecksDerivationStats: { subscribe: vi.fn(), set: vi.fn() },
+    overrideRelayChecksActiveKeys: { subscribe: vi.fn(), set: vi.fn() },
+    eventsChecks: { subscribe: vi.fn() },
+    relayChecks: { subscribe: vi.fn() },
+    relayCheckMap: { subscribe: vi.fn() },
+    relayCheckAggregates: { subscribe: vi.fn() },
+    relaysForMiniSearch: { subscribe: vi.fn() },
+    relayLivenessCounts: { subscribe: vi.fn() },
+    SpeedGroupBars: {},
+    SpeedGroupColors: {},
+    SpeedGroups: { Mid: 'Mid' }
+}));
+
+vi.mock('$stores/relays', () => ({
+    relays: { subscribe: vi.fn() }
+}));
+
+vi.mock('$lib/stores/relays', () => ({
+    relays: { subscribe: vi.fn() }
+}));
+
+vi.mock('$app/stores', () => ({
+    page: { subscribe: vi.fn() }
+}));
+
+vi.mock('$stores/nip11-validations', () => ({
+    nip11ValidationErrorCount: { subscribe: vi.fn() }
+}));
+
+vi.mock('$lib/stores/helpers/helpers-pubkey', () => ({
+    pubkeyProfile: vi.fn(() => undefined),
+    pubkeyUserInstance: vi.fn(() => undefined)
+}));
+
+import { tableFormatters as relayFormatters } from './relays';
+import { tableFormatters as softwareFormatters } from './softwares';
+import { tableFormatters as ispFormatters } from './isps';
+
+const ATTACK_URL = `http://x" onerror="alert(1)" x="`;
+const ATTACK_DESC = `<img src=x onerror=alert(1)>`;
+const ATTACK_NAME = `</span><script>alert(1)</script>`;
+
+describe('XSS regression: relay table formatters', () => {
+    it('relay formatter does not emit unescaped attack payload as icon src', () => {
+        const out = relayFormatters.relay('wss://test.example', { icon: ATTACK_URL });
+        // The dangerous chars from ATTACK_URL must NOT appear unescaped.
+        expect(out).not.toContain('onerror=');
+        expect(out).not.toContain(`x"`);
+        // And there should be no <img> at all (URL was rejected — fallback span instead).
+        expect(out).not.toContain('<img');
+    });
+
+    it('relay formatter accepts a benign https icon', () => {
+        const out = relayFormatters.relay('wss://test.example', {
+            icon: 'https://cdn.example.com/icon.png'
+        });
+        expect(out).toContain('https://cdn.example.com/icon.png');
+        expect(out).toContain('<img');
+    });
+
+    it('description formatter HTML-escapes the description', () => {
+        const out = relayFormatters.description(ATTACK_DESC, { relay: 'wss://test.example' });
+        expect(out).not.toContain('<img src=x');
+        expect(out).toContain('&lt;img');
+    });
+
+    it('name formatter HTML-escapes the name', () => {
+        const out = relayFormatters.name(ATTACK_NAME, { relay: 'wss://test.example' });
+        expect(out).not.toContain('<script>');
+        expect(out).toContain('&lt;script&gt;');
+    });
+
+    it('software formatter rejects malicious icon URL', () => {
+        const out = softwareFormatters.name('strfry', { icon: ATTACK_URL });
+        expect(out).not.toContain('onerror=');
+        // No <img> when the URL is rejected — fallback span.
+        expect(out).not.toContain('<img');
+    });
+
+    it('isp formatter rejects malicious icon URL', () => {
+        const out = ispFormatters.prettyName('Cloudflare', { icon: ATTACK_URL });
+        expect(out).not.toContain('onerror=');
+        expect(out).not.toContain('<img');
+    });
+});

--- a/apps/gui/src/lib/config/dataTable/relays.ts
+++ b/apps/gui/src/lib/config/dataTable/relays.ts
@@ -17,7 +17,8 @@ import type { DataFormatters, DataTableConfigDependencies, NameFormatter } from 
 import { nip11 } from 'nostr-tools';
 import { nip11ValidationErrorCount } from '$stores/nip11-validations';
 
-import { pastelPairFromString } from '$utils/colors'; 
+import { pastelPairFromString } from '$utils/colors';
+import { escapeHtml, safeImageUrl } from '$utils/sanitize';
 
 import pickaxe from 'lucide-svelte/icons/pickaxe';
 
@@ -299,9 +300,13 @@ export const tableFormatters: Formatters = {
 
     relay: (relay: string, row: any) => {
         const { icon } = row;
-        const formatted = `<span style="color: ${pastelPairFromString(relay)?.dark};" class="inline-block my-1 text-sm font-mono py-1 px-2 rounded-sm">${truncateWithEllipsis(relay, 44).replace('wss://', '').replace('ws://', '')}</span>`;
-        const iconHtml = icon
-            ? `<img src="${icon}" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" class="mr-2 h-6 w-6 rounded-full overflow-hidden inline-block" />`
+        const safeIcon = safeImageUrl(icon);
+        const visible = escapeHtml(
+            truncateWithEllipsis(relay, 44).replace('wss://', '').replace('ws://', '')
+        );
+        const formatted = `<span style="color: ${pastelPairFromString(relay)?.dark};" class="inline-block my-1 text-sm font-mono py-1 px-2 rounded-sm">${visible}</span>`;
+        const iconHtml = safeIcon
+            ? `<img src="${safeIcon}" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" class="mr-2 h-6 w-6 rounded-full overflow-hidden inline-block" />`
             : '<span class="inline-block mr-2 h-6 w-6"></span>';
         return `<a class="text-lg" href="/relays/${generateRelayPathFromUrl(relay)}">${iconHtml}${formatted}</a>`;
     },
@@ -379,8 +384,11 @@ export const tableFormatters: Formatters = {
         displayedPubkeys.forEach((pk: string) => {
             const monitor = $monitorsMap.get(pk);
             if (!monitor) return;
-    
-            str += `<img src="${monitor.photo}" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" class="border border-[1px] border-black w-5 h-5 relative rounded-full inline-block opacity-${100-i*20} ${i>0? '-ml-[10px]': ''}" style="z-index: ${z};" />`;
+
+            const safePhoto = safeImageUrl(monitor.photo);
+            if (!safePhoto) return;
+
+            str += `<img src="${safePhoto}" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" class="border border-[1px] border-black w-5 h-5 relative rounded-full inline-block opacity-${100-i*20} ${i>0? '-ml-[10px]': ''}" style="z-index: ${z};" />`;
             i++;
             z--;
         });
@@ -483,11 +491,13 @@ export const tableFormatters: Formatters = {
         if(!pk || typeof pk !== 'string') return '';
         const profile: StorePubkeyProfile = pubkeyProfile(pk);
         if(!profile) return '';
+        // Defensive guard: profile.pubkey flows into an href; only allow well-formed hex.
+        if(profile?.pubkey && !/^[0-9a-f]{64}$/i.test(profile.pubkey)) return '';
         let image = ''
-        let name = ''
-        if(profile?.photo) {
+        const safePhoto = safeImageUrl(profile?.photo);
+        if(profile?.photo && safePhoto) {
             image = `<a href="/operators/${profile.pubkey}" class="inline-block rounded-full overflow-hidden w-8 h-8 mr-2">
-                <img src="${profile.photo}" alt="${profile.photo}" loading="lazy" decoding="async" referrerpolicy="no-referrer" class="w-full h-auto" />
+                <img src="${safePhoto}" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" class="w-full h-auto" />
             </a>`
         }
         return `<div class="flex">${image}</div>`
@@ -504,11 +514,11 @@ export const tableFormatters: Formatters = {
     },
     name: (name, row) => {
         const { relay } = row;
-        return `<span class="text-xs lowercase font-mono opacity-80" style="color: ${pastelPairFromString(relay)?.dark}">${name}</div>`
+        return `<span class="text-xs lowercase font-mono opacity-80" style="color: ${pastelPairFromString(relay)?.dark}">${escapeHtml(name)}</span>`
     },
     description: (description, row) => {
         const { relay } = row;
-        return `<span class="text-xs lowercase font-mono opacity-80" style="color: ${pastelPairFromString(relay)?.dark}">${description}</div>`
+        return `<span class="text-xs lowercase font-mono opacity-80" style="color: ${pastelPairFromString(relay)?.dark}">${escapeHtml(description)}</span>`
     }
 }
 
@@ -530,16 +540,18 @@ export const filterFormatters: Formatters = {
         const profile: PubkeyProfile = pubkeyProfile(pk);
         if(!profile) return ' ';
         if(!profile?.photo) return ' ';
+        const safePhoto = safeImageUrl(profile.photo);
+        if(!safePhoto) return ' ';
         let name = truncateWithEllipsis(pk, 33);
         if(profile?.name){
             name = truncateWithEllipsis(profile.name, 33);
         }
         let image = `<span class="inline-block rounded-full overflow-hidden w-8 h-8 mr-2">
-             <img src="${profile.photo}" alt="${profile.photo}" loading="lazy" decoding="async" referrerpolicy="no-referrer" class="w-full h-auto" />
+             <img src="${safePhoto}" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" class="w-full h-auto" />
             </span>`
         return `<div class="flex">
             <div>${image}</div>
-            <div>${name}</div>
+            <div>${escapeHtml(name)}</div>
             </div>`
     }
 }

--- a/apps/gui/src/lib/config/dataTable/softwares.ts
+++ b/apps/gui/src/lib/config/dataTable/softwares.ts
@@ -1,7 +1,8 @@
 import type { DataKeys, Formatters, NameFormatter } from '$lib/components/data-view/DataTableTypes';
 import { makeSoftwareReadable } from '$lib/synonyms/software';
 
-import { pastelPairFromString } from '$utils/colors'; 
+import { pastelPairFromString } from '$utils/colors';
+import { escapeHtml, safeImageUrl } from '$utils/sanitize';
 
 export const columnsDisable: DataKeys = []
 export const filtersDisable: DataKeys = []
@@ -35,10 +36,12 @@ function truncateWithEllipsis(text: string, maxLength: number): string {
 export const tableFormatters: Formatters = {
     name: (software: string, row: any) => {
         if(typeof software !== 'string') return '-';
-        const htmlName = `<span class="my-1 text-sm font-mono" style="color:${pastelPairFromString(software)?.dark}">${truncateWithEllipsis(makeSoftwareReadable(software), 33)}</span>`;
-        const icon = row.icon? 
-            `<img src="${row.icon}" alt="${software}" loading="lazy" decoding="async" referrerpolicy="no-referrer" class="w-6 h-6 inline-block mr-2">` 
-            :'<span class="w-6 h-6 inline-block mr-2"></span>';
+        const safeIcon = safeImageUrl(row.icon);
+        const safeSoftware = escapeHtml(software);
+        const htmlName = `<span class="my-1 text-sm font-mono" style="color:${pastelPairFromString(software)?.dark}">${escapeHtml(truncateWithEllipsis(makeSoftwareReadable(software), 33))}</span>`;
+        const icon = safeIcon
+            ? `<img src="${safeIcon}" alt="${safeSoftware}" loading="lazy" decoding="async" referrerpolicy="no-referrer" class="w-6 h-6 inline-block mr-2">`
+            : '<span class="w-6 h-6 inline-block mr-2"></span>';
         return `${icon}<a href="/relays/software/${btoa(software)}">${htmlName}</a>`;
     },
     versionsNum: (versionsNum: number) => {

--- a/apps/gui/src/lib/utils/sanitize.test.ts
+++ b/apps/gui/src/lib/utils/sanitize.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { escapeHtml, safeImageUrl } from './sanitize';
+
+describe('escapeHtml', () => {
+    it('escapes <script> tags', () => {
+        expect(escapeHtml('<script>alert(1)</script>')).toBe(
+            '&lt;script&gt;alert(1)&lt;/script&gt;'
+        );
+    });
+
+    it('escapes ampersand', () => {
+        expect(escapeHtml('a & b')).toBe('a &amp; b');
+    });
+
+    it('escapes double quotes', () => {
+        expect(escapeHtml('he said "hi"')).toBe('he said &quot;hi&quot;');
+    });
+
+    it('escapes single quotes', () => {
+        expect(escapeHtml("it's")).toBe('it&#39;s');
+    });
+
+    it('returns empty string for null', () => {
+        expect(escapeHtml(null)).toBe('');
+    });
+
+    it('returns empty string for undefined', () => {
+        expect(escapeHtml(undefined)).toBe('');
+    });
+
+    it('returns empty string for numbers', () => {
+        expect(escapeHtml(123)).toBe('');
+    });
+
+    it('returns empty string for objects', () => {
+        expect(escapeHtml({})).toBe('');
+    });
+
+    it('encodes & before other entities (no double-encoding regression)', () => {
+        // If we escaped < first, we would produce &lt; and then re-encode the &.
+        // The correct order produces &amp;lt; ONLY if we double-encoded — we should not.
+        // 'a<b' must become 'a&lt;b', not 'a&amp;lt;b'.
+        expect(escapeHtml('a<b')).toBe('a&lt;b');
+        // And a literal & followed by < must encode the & once and the < once.
+        expect(escapeHtml('&<')).toBe('&amp;&lt;');
+    });
+
+    it('handles empty string', () => {
+        expect(escapeHtml('')).toBe('');
+    });
+});
+
+describe('safeImageUrl', () => {
+    it('accepts a valid https URL', () => {
+        expect(safeImageUrl('https://example.com/x.png')).toBe(
+            'https://example.com/x.png'
+        );
+    });
+
+    it('accepts a valid http URL', () => {
+        expect(safeImageUrl('http://example.com/x.png')).toBe(
+            'http://example.com/x.png'
+        );
+    });
+
+    it('accepts a data:image/ URL', () => {
+        const dataUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA';
+        expect(safeImageUrl(dataUrl)).toBe(dataUrl);
+    });
+
+    it('rejects data:image/svg+xml that contains <', () => {
+        // SVG data URLs can carry script — reject any with raw < anyway via the breakout filter.
+        expect(safeImageUrl('data:image/svg+xml,<svg></svg>')).toBe('');
+    });
+
+    it('rejects data:text/html', () => {
+        expect(safeImageUrl('data:text/html,<script>alert(1)</script>')).toBe('');
+    });
+
+    it('rejects javascript: URLs', () => {
+        expect(safeImageUrl('javascript:alert(1)')).toBe('');
+    });
+
+    it('rejects vbscript: URLs', () => {
+        expect(safeImageUrl('vbscript:msgbox')).toBe('');
+    });
+
+    it('rejects file: URLs', () => {
+        expect(safeImageUrl('file:///etc/passwd')).toBe('');
+    });
+
+    it('rejects the canonical attack payload (double-quote breakout)', () => {
+        expect(safeImageUrl('http://x" onerror="alert(1)" x="')).toBe('');
+    });
+
+    it('rejects a single-quote breakout payload', () => {
+        expect(safeImageUrl("http://x' onerror='alert(1)")).toBe('');
+    });
+
+    it('encodes ampersands in query strings', () => {
+        expect(safeImageUrl('https://example.com/img?a=1&b=2')).toBe(
+            'https://example.com/img?a=1&amp;b=2'
+        );
+    });
+
+    it('returns empty string for empty string', () => {
+        expect(safeImageUrl('')).toBe('');
+    });
+
+    it('returns empty string for null', () => {
+        expect(safeImageUrl(null)).toBe('');
+    });
+
+    it('returns empty string for undefined', () => {
+        expect(safeImageUrl(undefined)).toBe('');
+    });
+
+    it('returns empty string for numeric input', () => {
+        expect(safeImageUrl(42)).toBe('');
+    });
+
+    it('rejects URLs without http/https/data:image prefix', () => {
+        expect(safeImageUrl('not a url')).toBe('');
+        expect(safeImageUrl('//example.com/x.png')).toBe('');
+        expect(safeImageUrl('example.com/x.png')).toBe('');
+    });
+
+    it('rejects URLs containing newline characters', () => {
+        expect(safeImageUrl('https://x.com/\n<script>')).toBe('');
+        expect(safeImageUrl('https://x.com/\rfoo')).toBe('');
+    });
+
+    it('rejects URLs containing backslashes', () => {
+        expect(safeImageUrl('https://x.com/\\foo')).toBe('');
+    });
+
+    it('rejects URLs containing < or >', () => {
+        expect(safeImageUrl('https://x.com/<script>')).toBe('');
+        expect(safeImageUrl('https://x.com/>foo')).toBe('');
+    });
+});

--- a/apps/gui/src/lib/utils/sanitize.ts
+++ b/apps/gui/src/lib/utils/sanitize.ts
@@ -1,0 +1,74 @@
+/**
+ * Encode-on-output mitigation for relay-controlled NIP-11 / kind-0 fields.
+ *
+ * The DataTable layer renders cell contents via `{@html ...}` (see
+ * apps/gui/src/lib/components/data-view/table/DataTable.svelte). Many of the
+ * formatters in `apps/gui/src/lib/config/dataTable/*.ts` build HTML strings
+ * that interpolate fields a relay operator controls (icon, banner, name,
+ * description, photo, pubkey). Without escaping, a malicious relay can break
+ * out of an attribute or CSS context and execute arbitrary JS.
+ *
+ * This module exports two pure helpers:
+ *   - `escapeHtml`     — entity-encodes a string for safe interpolation into
+ *                        either element-text or double-quoted-attribute
+ *                        contexts.
+ *   - `safeImageUrl`   — allowlists `http(s)://` and `data:image/...` URLs and
+ *                        rejects any URL containing attribute/CSS breakout
+ *                        characters (`"`, `'`, `<`, `>`, `\n`, `\r`, `\\`).
+ *
+ * Use these helpers at every {@html} sink that interpolates relay-controlled
+ * data. The intent is encode-on-output at the formatter, not at the data layer.
+ *
+ * FOLLOW-UP (out of scope here): replace the HTML-string formatters in
+ * `apps/gui/src/lib/config/dataTable/*.ts` with Svelte components and remove
+ * `{@html ...}` from `DataTable.svelte` and `PageHeader.svelte`. Once that
+ * lands, this module can be deleted.
+ */
+
+/**
+ * Escape a string for safe interpolation into HTML element-text or
+ * double-quoted attribute contexts.
+ *
+ * Returns '' for null, undefined, or non-string input — never throws.
+ */
+export function escapeHtml(input: unknown): string {
+    if (typeof input !== 'string') return '';
+    return input
+        .replace(/&/g, '&amp;') // MUST be first to avoid double-encoding
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+/**
+ * Validate and entity-encode an image URL for safe interpolation into either
+ * an HTML `src=""` attribute or a CSS `url('...')` value.
+ *
+ * Allowlist:
+ *   - `http://...`
+ *   - `https://...`
+ *   - `data:image/...`
+ *
+ * Reject any URL containing characters that would break out of an attribute
+ * or CSS context (`"`, `'`, `<`, `>`, `\n`, `\r`, `\\`). Reject
+ * `javascript:`, `vbscript:`, `file:`, `data:text/html`, etc.
+ *
+ * On accept: returns the URL passed through `escapeHtml(...)` so query-string
+ * `&` becomes `&amp;` (safe in both attribute and CSS `url('...')` contexts;
+ * modern browsers accept `&amp;` in those positions).
+ *
+ * On reject: returns ''. Caller decides fallback. Never throws, never logs.
+ */
+export function safeImageUrl(input: unknown): string {
+    if (typeof input !== 'string' || input.length === 0) return '';
+    // Reject any breakout characters before any other check.
+    if (/["'<>\n\r\\]/.test(input)) return '';
+    // Allowlist: http://, https://, or data:image/...
+    const isHttp = /^https?:\/\//i.test(input);
+    const isDataImage = /^data:image\//i.test(input);
+    if (!isHttp && !isDataImage) return '';
+    // Encode entities (notably & in query strings) so the value is safe in
+    // both `src=""` attribute context and CSS `url('...')` context.
+    return escapeHtml(input);
+}


### PR DESCRIPTION
## Summary

Relay-controlled NIP-11 fields (`icon`, `banner`, `name`, `description`, plus monitor/operator kind-0 `photo`/`pubkey`) were interpolated into HTML template strings inside table formatters and rendered with Svelte's `{@html ...}`. A malicious relay could publish a NIP-11 doc with an `icon` like `http://x" onerror="location.href='https://attacker.example'" x="` and trigger arbitrary JS whenever its row was rendered.

This PR encodes-on-output at every sink. Two pure helpers in `apps/gui/src/lib/utils/sanitize.ts`:

- `escapeHtml(s)` — escapes `& < > " '` for text/attribute interpolation.
- `safeImageUrl(url)` — rejects breakout characters, allowlists `http(s):` and `data:image/`, returns `''` on rejection.

Wired at all 9 sinks: `apps/gui/src/lib/config/dataTable/{relays,softwares,isps}.ts` and `apps/gui/src/lib/components/layout/PageHeader.svelte`. The `PageHeader` subtitle uses DOMPurify because the `/relays/software/[softwareKey]` route legitimately passes pre-formatted HTML; all other callers were switched to plain text.

A component-based refactor (replace HTML-string formatters with Svelte components, remove `{@html row[column.key]}` from `DataTable.svelte` entirely) is the right long-term fix and is tracked as a follow-up — not in scope here.

### What landed

- New: `escapeHtml` + `safeImageUrl` helpers with 29 unit tests including the canonical attack payload.
- Fixed: 9 sinks that interpolated relay-controlled data into HTML.
- Added: `relays.formatters.test.ts` regression suite (6 tests) that imports the real formatters and asserts the canonical payload renders inert.
- Bonus: defensive hex-only guard on `profile.pubkey` before href interpolation, removed self-referencing URLs from `alt=""` attributes, fixed pre-existing `</div>` typos in name/description formatters surfaced during the audit.

### Verification

- 35/35 tests pass (29 unit + 6 regression).
- Canonical payload `http://x" onerror="alert(1)" x="` rejected to `''` by `safeImageUrl`; rendered output contains zero `<img>` tags and zero `onerror=` substrings.
- `svelte-check`: zero new errors (3 pre-existing errors in unrelated `relays.ts` paths remain — out of scope).
- Build: clean.

## Test plan

- [ ] `cd apps/gui && pnpm vitest run src/lib/utils/sanitize.test.ts src/lib/config/dataTable/relays.formatters.test.ts`
- [ ] Manual smoke: load a relay row whose NIP-11 has unusual characters in `icon` / `description` and confirm no JS executes, no broken markup.
- [ ] Confirm the `/relays/software/[softwareKey]` page still renders its formatted subtitle correctly (this is the one path that intentionally feeds HTML through DOMPurify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)