### PR TITLE
fix(rstate): mark package private to unblock release workflow

### DIFF
--- a/apps/rstate/package.json
+++ b/apps/rstate/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@nostr-watch/rstate",
   "version": "0.1.0",
+  "private": true,
   "description": "NIP-66 relay intelligence state machine with ContextVM and REST Enpoints.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

The release workflow at `.github/workflows/publish-package.yml` was failing because `pnpm changeset publish` attempted to publish `@nostr-watch/rstate@0.1.0` and got a 404 from npm — the package doesn't exist on the registry and shouldn't.

```
🦋  error '@nostr-watch/rstate@0.1.0' is not in this registry.
🦋  error npm error 404 Not Found - PUT https://registry.npmjs.org/@nostr-watch%2frstate
ELIFECYCLE  Command failed with exit code 1.
```

This blocked the entire release pipeline (failure run: https://github.com/sandwichfarm/nostr-watch/actions/runs/25278503294/job/74111977829).

## Why `ignore` in `.changeset/config.json` wasn't enough

`@nostr-watch/rstate` is already listed under `ignore` in `.changeset/config.json`. That setting only excludes a package from changeset version bumps — it does NOT prevent `changeset publish` from attempting to publish it. `changeset publish` walks the workspace and runs `npm publish` on every non-private package whose local version differs from npm.

## The fix

Add `"private": true` to `apps/rstate/package.json`. Matches the convention used by every other non-publishable package in the repo:

- `apps/gui/package.json` — private
- `internal/announce/package.json` — private
- `internal/publisher/package.json` — private
- `internal/seed/package.json` — private
- `internal/nwcache/package.json` — private
- `internal/redis/package.json` — private

`apps/rstate` was the only outlier.

## Test plan

- [ ] Merge to `next` and verify the next release run reaches the GUI deploy step (i.e. `pnpm changeset publish` no longer trips on rstate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)