### PR TITLE
security: close remaining XSS vectors in apps/gui (v2.5)

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,129 @@
+# nostr-watch
+
+## What This Is
+
+The nostr-watch platform monitors Nostr relay availability, performance, and conformance. It is a monorepo containing: the `@nostrwatch/auditor` conformance testing library, `relaymon` (relay monitoring daemon), `trawler` (relay discovery crawler), and shared libraries. The platform publishes NIP-66 monitoring events so relay operators and users can assess relay health across the network.
+
+## Core Value
+
+Anyone can run their own relay monitor — from watching a handful of personal relays to scanning the entire network — with a one-click install on self-hosted platforms.
+
+## Current State
+
+**Auditor (libraries/auditor):** v2.0 shipped (14 NIP suites, 3,387 LOC). v2.1 Test Profiles shelved at Phase 10 complete (taxonomy types shipped, classification/filtering/profiles pending).
+
+**RelayMon (apps/relaymon):** Deno app with 5 Docker stack variants (clearnet, VPN, multinet, trawler+clearnet, trawler+multinet). Supports clearnet, Tor, and I2P via hedproxy. Publishes Kind 1066 check results and Kind 30166 announcements. v2.4 shipped — NATO phonetic spam URLs purged from database with NIP-09 delete events broadcast; dedup startup migration and scheduled re-evaluation loop disabled (code preserved).
+
+**Trawler (apps/trawler):** Deno app that crawls nostr relay lists to discover relays. Writes to SQLite DB that relaymon reads as a seed source. v2.4 — NATO phonetic spam URLs purged at startup; nostrings library blocks NATO patterns before DB insertion.
+
+**Docker stacks:** Fully containerized with example configs and env files. Multi-arch Dockerfiles (debian-based, Deno runtime).
+
+**GUI (apps/gui):** SvelteKit 2 / Svelte 5 web app. v2.2 shipped — monitors listing page has accurate liveness counts, side-effect-free store chain, progressive reveal with per-monitor freshness indicator, and 23 unit tests.
+
+## Requirements
+
+### Validated
+
+- ✓ Auditor base architecture (Auditor → Suite → SuiteTest → Ingestor/Sampler pipeline) — v2.0
+- ✓ 14 NIP conformance test suites (01, 02, 09, 11, 13, 22, 40, 42, 45, 50, 65, 70, 77) — v2.0
+- ✓ RelayMon daemon with WebSocket checks (open, read, info, dns) — existing
+- ✓ Trawler relay discovery via relay list crawling — existing
+- ✓ Docker stacks for all deployment variants (clearnet, VPN, multinet, trawler combos) — existing
+- ✓ Hedproxy-based multinet routing (clearnet/.onion/.i2p URL detection) — existing
+- ✓ NIP-66 event publishing (Kind 1066 results, Kind 30166 announcements, Kind 20166 state changes) — existing
+- ✓ Configurable seeding (static config, events/relay lists, database, combinations) — existing
+- ✓ Exponential backoff retry strategy for failed relay connections — existing
+- ✓ Accurate relay liveness counts (online/offline/dead) reflecting cached Kind 30166 events — v2.2
+- ✓ Consistent liveness counts across sort/filter/interactions — v2.2
+- ✓ Inactive monitor detection using frequency * leniency threshold — v2.2
+- ✓ Progressive reveal with per-monitor freshness indicator — v2.2
+- ✓ Clean initialization sequence with loading/empty states — v2.2
+- ✓ Written root-cause diagnosis for relay dedup family-scope failure with reproducible runtime evidence — v2.3 (ROOT-01)
+- ✓ URL-path mutations of live relays are collapsed by dedup regardless of source (spam, typo, copy-paste, misconfig) — v2.3 (DEDUP-01)
+- ✓ Dedup identity is deterministic, independent of transient `online=1/0` state of sibling relays — v2.3 (DEDUP-02)
+- ✓ Legit path-only relays (e.g. `wss://haven.nostrfreedom.net/inbox/`) remain un-ignored when no matching-NIP-11 root sibling exists — v2.3 (DEDUP-03)
+- ✓ Fall-through paths in `relayHostnameDedup` do not silently un-ignore previously-ignored relays — v2.3 (DEDUP-04)
+- ✓ Previously-promoted `relay_status` rows are re-evaluated and corrected on monitor restart via idempotent startup migration — v2.3 (REMED-01)
+- ✓ Remediation run does not wrongly ignore any legit relay — enforced by construction (all decisions route through `relayHostnameDedup`) — v2.3 (REMED-02)
+- ✓ Unit test coverage for single/multi-segment path mutations, legit path-only relays, transient-sibling-offline — v2.3 (TEST-01/02/03)
+- ✓ Disabled rerunDedupForAllRowsMigration() and runDedupReevaluation() (code preserved) — v2.4 (CLEAN-01)
+- ✓ Migration identifies and deletes relay URLs ending with 1-3 NATO phonetic codes — v2.4 (PURGE-01/02)
+- ✓ Persistent list of deleted URLs saved for NIP-09 processing — v2.4 (PURGE-03)
+- ✓ NATO purge migration runs at startup in both trawler and relaymon — v2.4 (PURGE-04)
+- ✓ Kind 5 delete events published for every purged URL via existing publisher infrastructure — v2.4 (NIP09-01/02)
+- ✓ Trawler rejects NATO phonetic code URLs before database insertion via nostrings — v2.4 (BLOCK-01/02)
+
+### Active
+
+**Current Milestone: v2.5 GUI XSS Hardening**
+
+**Goal:** Close every remaining XSS vector in `apps/gui` so a malicious relay, kind:0 publisher, or Nostr event author cannot execute JavaScript, inject HTML, or break out of CSS context in a visitor's browser.
+
+**Target features:**
+- DOMPurify-always-on note/wiki rendering with URL-validated parseImages/parseVideos and escaped kind:0 names
+- `safeHttpUrl` helper validating NIP-11 `paymentsUrl` and other relay-controlled `<a>`/`<Button>` bindings
+- Structural fix to `CountCard` (text-bind by default) plus sanitized inputs in CardInsights / RelayFeeItem
+- `safeImageUrl(banner)` at three CSS `url('...')` sinks (data-view/table, lists/table, CardOperator)
+- Adversarial-input regression tests + structural test for `{@html}` removal in CountCard
+- Sanitization-contract dev note + follow-up decision on dataTable formatter migration
+
+### Out of Scope
+
+- Client-only NIPs (NIP-05, 06, 07, 19, 44, 46, etc.) — no relay behavior to test
+- Deprecated NIPs (NIP-04, NIP-08, NIP-26) — unrecommended
+- NIP-96 HTTP File Storage — separate protocol, not relay WebSocket
+
+### Shelved (v2.1 Test Profiles)
+
+- Impact/stress taxonomy types and `impactAllowed()` utility — Phase 10 complete
+- Retroactive classification of 37 SuiteTest subclasses — Phase 11 not started
+- Filtering infrastructure (maxImpact/allowStress in Suite.test()) — Phase 12 not started
+- Profile API and public surface (PROFILE_WEB/CLI/CVM constants) — Phase 13 not started
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| Revert PR #861 before fixing | The fix compounded existing problems — wrong counts, state resets, inconsistent data | ✓ Good — clean baseline enabled proper fixes |
+| Collapse monitors + monitorsSorted into single store | Dual store was redundant, caused side-effect cascade on sort/filter | ✓ Good — eliminated count resets |
+| Per-monitor freshness tied to liveness computation | isBootstrapped signal too slow (requires full sync:all); freshness should reflect actual data availability | ✓ Good — monitors transition to fresh within 10s |
+| v2.1 shelved, not abandoned | Auditor test profiles resumable; monorepo isolation means no conflict | — Pending |
+| v3.0 continues separately | Self-hosted distribution work is on feature/self-hosted branch (PR #874) | — Pending |
+| Disable dedup migration + loop, not delete | Code may be re-enabled after fixing deeper logic; purge-first approach clears spam faster | ✓ Good — unblocked NATO purge without losing dedup code |
+| NATO blocking in nostrings, not trawler sanitize.ts | sanitize.ts is dead code; trawler uses nostrings.sanitize.relayUrls() | ✓ Good — blocks at actual ingestion point |
+| Duplicate isNatoPhoneticSpam in db and nostrings | Keeps nostrings dependency-free; both use identical NATO code sets | — Pending (low drift risk) |
+| Encode-on-output at the sink (XSS) | Carries forward #899/#900 pattern — fixing at the sink is local, testable, survives upstream data-shape changes; package boundary stays clean | — Pending (v2.5) |
+| Text-bind-by-default for fallbacks | Mirrors #900 DataTable fallback fix — silent regression vector closes when missing formatters render as text instead of `{@html}` | — Pending (v2.5) |
+| Defer AUDIT-01 (formatter migration to Svelte components) to v2.6+ | v2.5 closed live vectors via encode-on-output discipline; dataTable formatters are encode-on-output safe today (verified by #899/#900 tests); migration touches 5+ formatter files + DataTable/PageHeader internals — too large for v2.5 scope | — Pending (v2.6+) |
+
+## Context
+
+- GUI is a SvelteKit 2 app (Svelte 5) at `apps/gui/`, statically built
+- Monitors page: `src/routes/monitors/+page.svelte` (listing), `src/routes/monitors/[pubkey]/+page.svelte` (detail)
+- Core store: `src/lib/stores/monitors.ts` — collapsed store chain with side-effect-free derivations
+- Data flows through Route66 library (`@nostrwatch/route66`) MonitorService → Svelte stores → components
+- NIP-66 events: Kind 10166 (monitor registration), Kind 30166 (relay checks), Kind 0 (profiles)
+- Liveness computation: `computeRelayLivenessFromCache()` queries cache adapter, classifies by timestamp, full-replaces counts each run
+- Leader/follower tab architecture for cross-tab state sync via StateManager (localStorage)
+- 23 unit tests covering leniency formula (12 store tests) and formatter states (11 formatter tests)
+
+## Evolution
+
+This document evolves at phase transitions and milestone boundaries.
+
+**After each phase transition** (via `/gsd:transition`):
+1. Requirements invalidated? → Move to Out of Scope with reason
+2. Requirements validated? → Move to Validated with phase reference
+3. New requirements emerged? → Add to Active
+4. Decisions to log? → Add to Key Decisions
+5. "What This Is" still accurate? → Update if drifted
+
+**After each milestone** (via `/gsd:complete-milestone`):
+1. Full review of all sections
+2. Core Value check — still the right priority?
+3. Audit Out of Scope — reasons still valid?
+4. Update Context with current state
+
+---
+---
+*Last updated: 2026-05-03 after starting v2.5 GUI XSS Hardening milestone*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -4,7 +4,9 @@
 
 - ✅ **v2.0 Wider NIP Support** - Phases 1-5 (shipped 2026-03-12)
 - ✅ **v2.2 Fix Monitors Page** - Phases 14-16 (shipped 2026-03-24)
-- 🚧 **v2.3 Relay Dedup Family Scope** - Phases 17-20 (started 2026-04-10)
+- ✅ **v2.3 Relay Dedup Family Scope** - Phases 17-20 (shipped 2026-04-11)
+- ✅ **v2.4 NATO Phonetic Spam Purge** - Phases 21-23 (shipped 2026-04-12)
+- 🚧 **v2.5 GUI XSS Hardening** - Phases 24-29 (started 2026-05-03)
 
 ## Phases
 
@@ -33,90 +35,131 @@ Phases 10-13 planned but shelved. Phase 10 (taxonomy types) shipped. Phases 11-1
 
 </details>
 
-### 🚧 v2.3 Relay Dedup Family Scope (In Progress)
+<details>
+<summary>✅ v2.3 Relay Dedup Family Scope (Phases 17-20) - SHIPPED 2026-04-11</summary>
 
-**Milestone Goal:** Eliminate the URL-path-mutation spam vector in `relay_status` without losing legit path-only relays, and harden dedup for performance and extensibility at 30k+ relay scale.
+4 phases, 12 plans completed. See MILESTONES.md and milestones/v2.3-ROADMAP.md for details.
 
-- [x] **Phase 17: Diagnose Dedup Family Scope Failure** - Reproduce the split-outcome behavior on a known-failing sample and produce a written root-cause diagnosis with reproducible evidence (completed 2026-04-10)
-- [x] **Phase 18: Fix Dedup Family Scope** - Apply the narrowest fix justified by Phase 17 evidence so dedup correctly collapses URL-path mutations without wrongly ignoring legit path-only relays (completed 2026-04-10)
-- [x] **Phase 19: Remediate Affected Rows** - Re-run dedup over already-promoted `relay_status` rows and verify legit path-only relays remain publishable (completed 2026-04-10)
-- [x] **Phase 20: Dedup Performance & Overrides** - Scope the one-shot dedup migration to online+unignored rows, skip live NIP-11 fetches against stale/offline relays in periodic re-evaluation, and introduce a modular override rule system for protecting known-good paths and special-cased hostnames (completed 2026-04-11)
+- [x] Phase 17: Diagnose Dedup Family Scope Failure (3/3 plans) — completed 2026-04-10
+- [x] Phase 18: Fix Dedup Family Scope (3/3 plans) — completed 2026-04-10
+- [x] Phase 19: Remediate Affected Rows (2/2 plans) — completed 2026-04-10
+- [x] Phase 20: Dedup Performance & Overrides (4/4 plans) — completed 2026-04-11
+
+</details>
+
+<details>
+<summary>✅ v2.4 NATO Phonetic Spam Purge (Phases 21-23) - SHIPPED 2026-04-12</summary>
+
+3 phases shipped. See MILESTONES.md and milestones/v2.4-ROADMAP.md for details.
+
+- [x] Phase 21: Disable Dedup Migration & Loop — completed 2026-04-12
+- [x] Phase 22: NATO URL Purge & NIP-09 Broadcast — completed 2026-04-12
+- [x] Phase 23: Trawler Block & Reintroduction Guard — completed 2026-04-12
+
+</details>
+
+### 🚧 v2.5 GUI XSS Hardening (In Progress)
+
+**Milestone Goal:** Close every remaining XSS vector in `apps/gui` so a malicious relay, kind:0 publisher, or Nostr event author cannot execute JavaScript, inject HTML, or break out of CSS context in a visitor's browser.
+
+- [x] **Phase 24: Sanitize Helper Surface** - Extend `apps/gui/src/lib/utils/sanitize.ts` with `safeHttpUrl` and tighten the URL/CSS-context contract so every later phase has one place to call. (completed 2026-05-03)
+- [x] **Phase 25: CSS Banner Sinks** - Apply `safeImageUrl` to the three remaining `style="background: url('${banner}')"` sinks and lock the single-quote breakout closed with regression tests. (completed 2026-05-03)
+- [x] **Phase 26: href Allowlist Sweep** - Validate NIP-11 `paymentsUrl` and every other relay/kind:0-controlled `<a href>` / `<Button href>` through `safeHttpUrl`. (completed 2026-05-03)
+- [x] **Phase 27: CountCard Structural Fix** - Text-bind `CountCard.svelte` by default and migrate `CardInsights` / `RelayFeeItem` to the safe rendering path. (completed 2026-05-03)
+- [x] **Phase 28: notes.ts Hardening** - Force DOMPurify on every feed/wiki render, validate `parseImages` / `parseVideos` URLs, HTML-escape kind:0 names, eliminate the `sanitize: false` opt-out. (completed 2026-05-03)
+- [x] **Phase 29: Adversarial Regression Sweep & Sanitization-Contract Doc** - Land the cross-cutting adversarial regression suite, the `CountCard` structural test, the AUDIT-01 follow-up decision, and the developer-facing sanitization-contract note. (completed 2026-05-03)
 
 ## Phase Details
 
-### Phase 17: Diagnose Dedup Family Scope Failure
-**Goal**: Produce a reproducible, written root-cause diagnosis that explains why dedup catches some URL-path mutations on a hostname and misses others on the same hostname, with enough specificity to select a targeted fix in Phase 18.
+### Phase 24: Sanitize Helper Surface
+**Goal**: Extend `apps/gui/src/lib/utils/sanitize.ts` so that every later phase has one centralized, test-locked helper to call when a URL crosses the trust boundary into an `href`, an attribute, or a CSS `url('…')` context. Foundation phase; smallest blast radius lands first.
 **Depends on**: Nothing (first phase of milestone)
-**Requirements**: ROOT-01
+**Requirements**: URL-01
 **Success Criteria** (what must be TRUE):
-  1. A written diagnosis document exists that names the exact mechanism causing the split outcome between `wss://relay.lumina.rocks/hotel` (caught) and `wss://relay.lumina.rocks/umbra-vertex` (missed), anchored in runtime evidence (family composition, NIP-11 hashes, dedup branch taken, sibling online state at the moment dedup ran)
-  2. The diagnosis reproduces the failure on at least two additional failing samples from STATE.md's failing-sample set and contrasts them with at least two succeeding samples from the control group
-  3. The diagnosis explicitly confirms or rules out the "red herring" framing of `hostnames.ts:328-331` as the actual defect site
-  4. The diagnosis identifies one or more candidate fixes whose scope is narrow enough to avoid the "mass-ignore legit path-only relays" risk, and names the evidence that would justify each
-  5. No production code in `apps/relaymon/src/utils/hostnames.ts` is modified in this phase — only instrumentation and investigation artifacts land
-**Plans:** 3/3 plans complete
+  1. A `safeHttpUrl(input)` function exported from `apps/gui/src/lib/utils/sanitize.ts` returns a safe `http://` or `https://` string and returns an empty string (or documented sentinel) for any input whose scheme parses as `javascript:`, `data:`, `vbscript:`, `file:`, or anything outside the http/https allowlist
+  2. `safeHttpUrl` strips or rejects attribute-breakout characters (`"`, `'`, `<`, `>`, backtick, raw whitespace, control chars) such that the canonical attack payload `http://x" onerror="alert(1)" x="` resolves to a value that cannot break out of a double-quoted HTML attribute
+  3. The CSS-context behavior of the URL helpers (`safeImageUrl` and/or a dedicated `safeCssUrl`) explicitly rejects single quotes and any other characters that escape from `url('…')`, with a unit test that fails on input shaped like `x'); position:fixed; top:0; …; url('y`
+  4. The helper module's JSDoc documents which helper to reach for at each sink type (text, attribute, URL `href`, CSS `url('…')`) and preserves the existing follow-up note about deleting the module once `{@html}` is gone
+  5. A failing-tests-first commit lands before the implementation commit, mirroring the #899 / #900 test-then-fix discipline; tests assert no `<script>`, no `onerror=`, no unescaped breakout characters, and no scheme outside the allowlist
+**Plans**: 1 plan
+- [x] 24-01-sanitize-helper-surface-PLAN.md — Add safeHttpUrl, factor isUrlBreakout, document sanitization contract, land CSS-context single-quote regression test (test-then-fix discipline; AUDIT-02 partial)
 
-Plans:
-- [x] 17-01-PLAN.md -- Instrument dedup with snapshot capture + reproduction harness
-- [x] 17-02-PLAN.md -- Hypothesis testing block covering family composition, hash stability, race
-- [x] 17-03-PLAN.md -- Write DIAGNOSIS.md with evidence cross-links and narrow candidate fixes
-
-### Phase 18: Fix Dedup Family Scope
-**Goal**: Apply the narrowest code change justified by Phase 17's diagnosis so dedup correctly identifies URL-path mutations as duplicates of their legit siblings regardless of transient sibling state, while leaving legit path-only relays untouched. Ship regression tests that lock the fix in.
-**Depends on**: Phase 17
-**Requirements**: DEDUP-01, DEDUP-02, DEDUP-03, DEDUP-04, TEST-01, TEST-02, TEST-03
+### Phase 25: CSS Banner Sinks
+**Goal**: Close the CSS-context breakout in the three banner-URL sinks that did not get the `PageHeader.svelte` fix, and prove via regression test that single-quote payloads can no longer break out of `style="background: url('${banner}')"`. Mechanical second phase that exercises the Phase 24 helper end-to-end.
+**Depends on**: Phase 24
+**Requirements**: CSS-01, CSS-02
 **Success Criteria** (what must be TRUE):
-  1. Every URL in the failing-sample set recorded in STATE.md is now recognized as a duplicate by `relayHostnameDedup` and marked `ignore=1` with a `parent` pointing at the legit sibling or root, verified by unit test
-  2. `wss://haven.nostrfreedom.net/inbox/` and every other legit path-only relay discovered during Phase 17 remains un-ignored and publishable, verified by unit test
-  3. Dedup produces the same ignore decision for a mutation URL whether its legit sibling is currently `online=1` or `online=0` in `relay_status`, verified by a dedicated transient-sibling-offline unit test
-  4. Fall-through paths in `relayHostnameDedup` never flip a previously-ignored `result.ignore` back to `false` without a positive matching heuristic, verified by unit test
-  5. The unit test suite for `relayHostnameDedup` runs green and covers single-segment path mutations, multi-segment path mutations, legit path-only relays, and the transient-sibling-offline case
-**Plans:** 3/3 plans complete
+  1. `apps/gui/src/lib/components/data-view/table/DataTable.svelte`, `apps/gui/src/lib/components/lists/table/DataTable.svelte`, and `apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardOperator.svelte` all pass `banner` through the Phase 24 URL-validation helper before interpolating into `style="background: url('${…}')"`
+  2. A relay returning a banner of `x'); position:fixed; top:0; left:0; width:100vw; height:100vh; background:url('y` renders as either an empty background or an inert escaped string — the surrounding `style` attribute remains exactly one well-formed `background: url('…')` declaration with no injected properties
+  3. Every CSS-context regression test for the three sinks asserts the rendered HTML contains no unescaped `'`, no injected `position:`, `top:`, `left:`, `width:`, or `height:` declarations, and no second `url('…')` segment
+  4. A grep over `apps/gui/src` for `background: url('${` (or equivalent template syntax) finds no remaining unguarded banner interpolations — every match either calls the safe helper or is a static asset path
+  5. Failing-tests-first commit lands before the fix commit; tests import the real component, feed it adversarial banner payloads, and assert the rendered DOM is safe
+**Plans**: 1 plan
+- [x] 25-01-css-banner-sinks-PLAN.md — Extract bannerStyleString helper, migrate 4 banner sinks (data-view DataTable, lists DataTable, CardOperator, PageHeader), CSS-context single-quote regression test (test-then-fix discipline; CSS-01 + CSS-02)
+**UI hint**: yes
 
-Plans:
-- [x] 18-01-PLAN.md -- Fix 1: close the no-relatives race via getRelaysByHostname + defensive-deny
-- [x] 18-02-PLAN.md -- Fix 2: stabilize createInfoHash via normalizeNip11 + one-shot rehash migration
-- [x] 18-03-PLAN.md -- Fix 3: canonicalize mURL and DB reads to close the normalizeURL trailing-slash bug
-
-### Phase 19: Remediate Affected Rows
-**Goal**: Correct the already-promoted `relay_status` rows via an idempotent startup migration (`rerunDedupForAllRowsMigration`) and verify no legit path-only relay is wrongly ignored.
-**Depends on**: Phase 18
-**Requirements**: REMED-01, REMED-02
+### Phase 26: href Allowlist Sweep
+**Goal**: Validate every relay-, NIP-11-, or kind:0-controlled URL that reaches an `<a href>` or `<Button href>` through `safeHttpUrl`, starting at the known-exploitable `paymentsUrl` sink in `CardFees.svelte` and finishing with an audit pass over the entire `apps/gui/src` tree.
+**Depends on**: Phase 24
+**Requirements**: URL-02, URL-03
 **Success Criteria** (what must be TRUE):
-  1. The re-evaluation run over affected `relay_status` rows completes and records before/after counts in structured JSON log
-  2. Every URL in the failing-sample set carries `ignore=1` and a non-empty `parent` in `relay_status` after the remediation run
-  3. Legit path-only relays without root siblings are left unchanged
-  4. Zero legit relays are newly ignored as a side effect of the remediation run
-**Plans:** 2/2 plans complete
+  1. The live path in `CardFees.svelte` (and any active dead-code clone) routes `paymentsUrl = $nip11?.paymentsUrl` through `safeHttpUrl` before binding it to `<Button href>` / `<a href>`; a relay returning `payments_url: "javascript:alert(document.cookie)"` produces no clickable `javascript:` link in the rendered DOM
+  2. An audit-pass document or commit message enumerates every `<a href={…}>` and `<Button href={…}>` in `apps/gui/src` whose value originates in relay aggregate data, NIP-11, or kind:0, and shows each one either calling `safeHttpUrl` or proven inert by construction (static literal, route-internal, or already-validated upstream)
+  3. A regression test feeds the canonical attack payloads (`javascript:alert(1)`, `data:text/html,<script>alert(1)</script>`, `vbscript:msgbox`, `file:///etc/passwd`, and `http://x" onerror="alert(1)" x="`) into the `CardFees` paymentsUrl path and asserts the rendered `href` is empty or a safe http(s) URL
+  4. Failing-tests-first commit lands before the fix commit; tests import the real component, feed it adversarial NIP-11 payloads, and assert the rendered HTML contains no `javascript:`, `data:`, or attribute-breakout `onerror=` strings
+**Plans**: 1 plan
+- [x] 26-01-href-allowlist-sweep-PLAN.md — Wrap CardFees.svelte paymentsUrl through safeHttpUrl + ship HREF-AUDIT.md (test-then-fix discipline; URL-02 + URL-03)
+**UI hint**: yes
 
-Plans:
-- [x] 19-01-PLAN.md -- Create rerunDedupForAllRowsMigration module + hook into initializeDB after rehashRelayInfoMigration
-- [x] 19-02-PLAN.md -- Add Phase 19 unit test block covering canonical mutation, legit path-only protection, philosophy case, already-ignored, idempotency, sentinel verification
-
-### Phase 20: Dedup Performance & Overrides
-**Goal**: Make relaymon startup and periodic re-evaluation scale to 30k+ relays without hours-long stalls, and provide a modular override rule system so known-good paths and hostname patterns can be protected from naive shortest-URL-wins dedup. Every override rule lives in its own file with its own isolated unit test.
-**Depends on**: Phase 19
-**Requirements**: PERF-01, PERF-02, OVERRIDE-01, OVERRIDE-02, OVERRIDE-03
+### Phase 27: CountCard Structural Fix
+**Goal**: Convert `CountCard.svelte` from `{@html}`-by-default to text-bound-by-default for unregistered/freeform input, mirroring the #900 `DataTable` fallback fix, then migrate the three callers that compose markup from relay aggregate data (`CardInsights`, `RelayFeeItem`, plus any caller surfaced during the migration) onto the safe rendering path.
+**Depends on**: Phase 24
+**Requirements**: CARD-01, CARD-02, CARD-03
 **Success Criteria** (what must be TRUE):
-  1. `rerunDedupForAllRowsMigration` restricts its row scan to rows with `online = 1 AND ignore = 0` at the SQL layer (the existing unconstrained `SELECT` is replaced), verified by a unit test against a seeded DB with mixed online/offline/ignored rows that asserts the migration touches only online+unignored rows
-  2. `getOnlineRelays()` is called at most once per `rerunDedupForAllRowsMigration` run rather than once per row, and the resulting online-relay map is passed into `relayHostnameDedup` rather than re-fetched inside, verified by a unit test that counts DB query calls on a mocked DB
-  3. `reevaluateAllDeduplication` does not make live `nocap.check` NIP-11 fetches against relays whose `checked_at` is older than a configurable inactivity threshold, and does not make fetches against rows already marked `ignore=1`, verified by a unit test that asserts zero `nocap.check` invocations for rows matching either skip condition
-  4. A modular override system exists at `apps/relaymon/src/utils/dedup-overrides/` where each override is a single file exporting a typed rule with the shape `{ name: string, test(url: URL): boolean, action: 'allow' | 'deny', reason: string }`, and the override list is loaded via an index file that collects all rules
-  5. `relayHostnameDedup` consults the override list before any of its existing case1–case8 branches and short-circuits to the override verdict when a rule matches, verified by a unit test
-  6. Each override file has its own isolated unit test file at `apps/relaymon/tests/unit/dedup-overrides/{override-name}.test.ts` that exercises only that rule
-  7. At least two initial overrides ship and pass unit tests: `allow-known-paths.ts` (always allows `/inbox` and `/outbox` to win over shorter spam siblings regardless of NIP-11 state) and `lang-relays-land.ts` (allows each `lang.relays.land/<two-letter-code>` path as an independent relay rather than a dedup child of a shorter sibling)
-  8. Regression: `wss://haven.nostrfreedom.net/inbox/` and every Phase 18 failing-sample test still passes after the override system is introduced — no pre-existing dedup behavior is broken
-**Plans:** 4/4 plans complete
-  - [x] 20-01-override-scaffold-PLAN.md — Create dedup-overrides/ directory with types, rules, evaluator, and isolated unit tests
-  - [x] 20-02-config-extension-PLAN.md — Extend DeduplicationConfig with nip11_stale_skip timestring field + default + conversion
-  - [x] 20-03-hostnames-integration-PLAN.md — Wire override evaluator into relayHostnameDedup + add DedupContext param + reevaluateAllDeduplication stale-skip + Phase 19 philosophy test lockstep update
-  - [x] 20-04-migration-scope-PLAN.md — Narrow rerunDedupForAllRowsMigration SQL scope + rename sentinel + cache getOnlineRelays + ctx plumbing
+  1. `CountCard.svelte` no longer contains `{@html topText}`, `{@html bottomText}`, or `{@html $value}` for unregistered / freeform input — the default branch text-binds, and any caller that genuinely needs markup must opt in via an explicit slot or a sanitized-string prop with a documented contract
+  2. `CardInsights.svelte` interpolations of `software` / `version` / `geocode` / `isp` reach `bottomText` either HTML-escaped or via the new safe rendering path; a relay returning `software: "<img src=x onerror=alert(1)>"` produces visible text, not an executing image tag
+  3. `RelayFeeItem.svelte` coerces `fee.amount` to a number (`Number(...)` or equivalent numeric-only path) before interpolating; a NIP-11 `fee.amount: "<img src=x onerror=alert(1)>"` either renders as `NaN` / `0` / inert text or is rejected — never reaches `{@html}` as raw markup
+  4. A regression test feeds adversarial NIP-11 input (HTML-laden `software`, `version`, `geocode`, `isp`, non-numeric `fee.amount`) through the real `CardInsights` and `RelayFeeItem` components and asserts the rendered DOM contains no `<script>`, no `onerror=`, no executing `<img>`
+  5. Failing-tests-first commit lands before each fix commit; the structural change to `CountCard` is committed separately from the caller migration so each step is independently revertible
+**Plans**: 1 plan
+- [x] 27-01-countcard-structural-fix-PLAN.md — RED + GREEN-A (CountCard slot API + safeHttpUrl link wrap) + GREEN-B (Counts/RelayFeeItem/CardInsights migration; dead CardFees import removal); 3-commit shape per success criterion 5 (CARD-01 + CARD-02 + CARD-03)
+**UI hint**: yes
+
+### Phase 28: notes.ts Hardening
+**Goal**: Eliminate the three compounding `notes.ts` bugs that put attacker-controlled Nostr event content into `{@html}`: (1) `parseNote` is called with `sanitize: false` at every call site, (2) `parseImages` / `parseVideos` interpolate raw URLs into `<img src>` / `<video src>` with a greedy `\S+` regex, (3) `replaceNip19` interpolates `user.name` raw. Largest-blast-radius phase; closes drive-by XSS via feed and wiki content.
+**Depends on**: Phase 24
+**Requirements**: FEED-01, FEED-02, FEED-03, FEED-04, FEED-05
+**Success Criteria** (what must be TRUE):
+  1. Nostr event content rendered through `feeds/FeedNoteContent.svelte`, `feeds/FeedNote.svelte`, `feeds/FeedMasonryNote.svelte`, `modal/Reader.svelte`, and the wiki route at `routes/relays/software/[softwareKey]/+page.svelte` passes through DOMPurify before reaching `{@html}` — proven by a regression test that feeds a kind:1 with `<script>alert(1)</script><img src=x onerror=alert(1)>` and asserts the rendered DOM contains neither
+  2. `parseImages` and `parseVideos` validate every matched URL through `safeImageUrl` (or reject it) before interpolating into `<img src>` / `<video src>`; the canonical breakout payload `https://x.png"<script>alert(1)</script><img src="https://y.png` does not produce an executing `<script>` tag in any feed component
+  3. `replaceNip19` HTML-escapes `user.name` before interpolating into the rendered `<a>` text; a kind:0 from `wss://purplepag.es` with `name: "<img src=x onerror=alert(1)>"` renders as visible text, not an executing image tag
+  4. The `sanitize: false` parser option is either removed from defaults or made structurally impossible to reach the unsafe `{@html}` path — verified by reading the call sites and by a unit test that demonstrates the option no longer disables sanitization at the `{@html}` boundary
+  5. Wiki content (kind:30818 from `wss://relay.wikifreedia.xyz`) rendered through `Reader.svelte` traverses the same sanitization path as kind:1 feed content; a regression test asserts attacker-controlled wiki HTML is sanitized
+  6. Failing-tests-first commits land before each fix commit; the parser-option fix, the URL-validation fix, and the `replaceNip19` escape fix are committed separately so each is independently revertible
+**Plans**: 1 plan
+- [x] 28-01-notes-ts-hardening-PLAN.md — Sequential pipeline + always-on DOMPurify + safeImageUrl-validated parseImages/parseVideos + escapeHtml-wrapped replaceNip19 user.name (test-then-fix discipline; FEED-01..05; 2-commit RED+GREEN shape)
+**UI hint**: yes
+
+### Phase 29: Adversarial Regression Sweep & Sanitization-Contract Doc
+**Goal**: Lock the milestone in. Cross-cut every fixed sink with adversarial input regression tests, ship the structural test that asserts `{@html}` removal in `CountCard`, deliver-or-defer the `sanitize.ts` JSDoc follow-up about replacing HTML-string formatters with Svelte components, and document the sanitization contract so a future contributor knows which helper to reach for at each sink type.
+**Depends on**: Phase 25, Phase 26, Phase 27, Phase 28
+**Requirements**: TEST-04, TEST-05, TEST-06, AUDIT-01, AUDIT-02
+**Success Criteria** (what must be TRUE):
+  1. Unit tests cover the canonical attack payload `http://x" onerror="alert(1)" x="` against `safeHttpUrl` and the updated CSS-context behavior of `safeImageUrl` (or `safeCssUrl`); each test asserts no `<script>`, no `onerror=`, and no unescaped breakout characters in the helper output
+  2. A regression test exists for every fixed sink — at minimum: `notes.ts` (`parseImages`, `parseVideos`, `replaceNip19`, full `parseNote`), `CardFees.svelte` `paymentsUrl`, `CardInsights.svelte` `bottomText` composition, `RelayFeeItem.svelte` `amount` coercion, and the three CSS banner sinks — each test imports the real component / formatter / parser and feeds it adversarial NIP-11 / kind:0 / kind:1 input
+  3. A structural test under `apps/gui/src/.../CountCard*.test.ts` (or equivalent location) reads `CountCard.svelte`'s source and asserts it no longer contains `{@html topText}`, `{@html bottomText}`, or `{@html $value}` for unregistered branches — mirroring the `DataTableFallback.test.ts` pattern from #900
+  4. The `sanitize.ts` JSDoc follow-up about replacing HTML-string formatters with Svelte components and dropping `{@html}` from `DataTable.svelte` / `PageHeader.svelte` is either delivered (with the migration shipping in this phase) or formally deferred via a tracked decision recorded in `PROJECT.md` Key Decisions and referenced from the JSDoc
+  5. A short developer-facing note (in `apps/gui/src/lib/utils/sanitize.ts` JSDoc and/or `apps/gui/README.md`) documents the sanitization contract: where data crosses the trust boundary into the GUI, which helper to reach for at each sink type (text → Svelte default text-bind, attribute → escapeHtml, URL `href` → `safeHttpUrl`, image `src` → `safeImageUrl`, CSS `url('…')` → `safeImageUrl` / `safeCssUrl`)
+**Plans**: 1 plan
+- [x] 29-01-adversarial-regression-sweep-PLAN.md — 3 new test files (TEST-05 smoke + TEST-06 walker + v2.5-xss-smoke canary) + sanitize.ts JSDoc expansion (AUDIT-02) + PROJECT.md AUDIT-01 formal defer + 4 caller cleanup; single GREEN commit (TEST-04, TEST-05, TEST-06, AUDIT-01, AUDIT-02)
 
 ## Progress
 
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
-| 17. Diagnose Dedup Family Scope Failure | 3/3 | Complete | 2026-04-10 |
-| 18. Fix Dedup Family Scope | 3/3 | Complete | 2026-04-10 |
-| 19. Remediate Affected Rows | 2/2 | Complete | 2026-04-10 |
-| 20. Dedup Performance & Overrides | 4/4 | Complete    | 2026-04-11 |
+| 24. Sanitize Helper Surface | 1/1 | Complete    | 2026-05-03 |
+| 25. CSS Banner Sinks | 1/1 | Complete    | 2026-05-03 |
+| 26. href Allowlist Sweep | 1/1 | Complete    | 2026-05-03 |
+| 27. CountCard Structural Fix | 1/1 | Complete    | 2026-05-03 |
+| 28. notes.ts Hardening | 1/1 | Complete    | 2026-05-03 |
+| 29. Adversarial Regression Sweep & Sanitization-Contract Doc | 1/1 | Complete   | 2026-05-03 |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,32 +1,42 @@
 ---
 gsd_state_version: 1.0
-milestone: v2.3
-milestone_name: Relay Dedup Family Scope
-status: Milestone complete
-stopped_at: Completed 20-04-migration-scope-PLAN.md
-last_updated: "2026-04-11T22:51:20.226Z"
+milestone: v2.5
+milestone_name: GUI XSS Hardening
+status: verifying
+stopped_at: Completed 29-01-adversarial-regression-sweep-PLAN.md (Phase 29 ready for verification — final v2.5 phase)
+last_updated: "2026-05-03T20:30:10.501Z"
+last_activity: 2026-05-03
 progress:
-  total_phases: 4
-  completed_phases: 1
-  total_plans: 12
-  completed_plans: 8
+  total_phases: 6
+  completed_phases: 6
+  total_plans: 6
+  completed_plans: 6
 ---
 
 # Project State
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-03-19)
+See: .planning/PROJECT.md (updated 2026-05-03)
 
 **Core value:** Anyone can run their own relay monitor — from watching a handful of personal relays to scanning the entire network — with a one-click install on self-hosted platforms.
-**Current focus:** Phase 20 — Dedup Performance & Overrides
+**Current focus:** Phase 29 — Adversarial Regression Sweep & Sanitization-Contract Doc
 
 ## Current Position
 
-Phase: 20
-Plan: Not started
+Phase: 29 (Adversarial Regression Sweep & Sanitization-Contract Doc) — EXECUTING
+Plan: 1 of 1
+Status: Phase complete — ready for verification
+Last activity: 2026-05-03
 
-Phases 17, 18, 19 complete on disk (artifacts under `.planning/phases/`). v2.3 roadmap entry added to ROADMAP.md in this commit to catch up documentation to shipped state.
+**Phase queue (v2.5):**
+
+1. Phase 24 — Sanitize Helper Surface (URL-01)
+2. Phase 25 — CSS Banner Sinks (CSS-01, CSS-02)
+3. Phase 26 — href Allowlist Sweep (URL-02, URL-03)
+4. Phase 27 — CountCard Structural Fix (CARD-01, CARD-02, CARD-03)
+5. Phase 28 — notes.ts Hardening (FEED-01..05)
+6. Phase 29 — Adversarial Regression Sweep & Sanitization-Contract Doc (TEST-04, TEST-05, TEST-06, AUDIT-01, AUDIT-02)
 
 ## Performance Metrics
 
@@ -59,6 +69,12 @@ Phases 17, 18, 19 complete on disk (artifacts under `.planning/phases/`). v2.3 r
 | Phase 20-dedup-performance-overrides P01 | 4min | 2 tasks | 8 files |
 | Phase 20 P03 | 9min | 2 tasks | 2 files |
 | Phase 20-dedup-performance-overrides P04 | 5min | 2 tasks | 2 files |
+| Phase 24-sanitize-helper-surface P01 | 3min | 2 tasks | 2 files |
+| Phase 25-css-banner-sinks P01 | 4min | 2 tasks | 7 files |
+| Phase 26-href-allowlist-sweep P01 | 3min | 2 tasks | 3 files |
+| Phase 27-countcard-structural-fix P01 | 6min | 3 tasks | 5 files |
+| Phase 28-notes.ts-hardening P01 | 4min | 2 tasks | 2 files |
+| Phase 29-adversarial-regression-sweep-&-sanitization-contract-doc P01 | 5min | 3 tasks | 9 files |
 
 ## Accumulated Context
 
@@ -88,6 +104,38 @@ Phases 17, 18, 19 complete on disk (artifacts under `.planning/phases/`). v2.3 r
 - [Phase 20-dedup-performance-overrides]: Plan 20-04: Migration sentinel renamed to rerun_dedup_online_unignored_v1 (Phase 19 v2 row stays as history); SQL-layer scope narrowing via WHERE online=1 AND ignore=0; cachedOnline snapshot passed via ctx.onlineUrls on every per-row relayHostnameDedup call
 - [Phase 20-dedup-performance-overrides]: Plan 20-04: Lockstep sentinel literal rename across 12 occurrences in hostname-dedup.test.ts — including the Plan-20-03-Task-2-inserted literal at line 2007 in the Phase 20 philosophy test block which 20-03 deliberately left unchanged pending this plan
 - [Phase 20-dedup-performance-overrides]: Plan 20-04: db.query monkey-patch + exact-SQL regex as the PERF-02 query-count assertion mechanism (mutable singleton pattern); try/finally guarantees originalQuery restored before subsequent tests
+- [v2.5]: Encode-on-output at the sink (extends `apps/gui/src/lib/utils/sanitize.ts`) — locked by audit on `security/xss-3` 2026-05-03; carries forward #899 / #900 pattern
+- [v2.5]: Text-bind-by-default for fallbacks — mirrors #900 DataTable fallback fix; `CountCard` is the next candidate
+- [v2.5]: No new runtime dependencies — DOMPurify already in `apps/gui` deps; v2.5 extends `sanitize.ts`, no new packages
+- [v2.5]: Test-then-fix discipline (#899 / #900 pattern) — failing-test commit lands before fix commit; tests import the real component / formatter / parser and feed it adversarial input
+- [v2.5]: `@nostrwatch` package boundary stays clean — sanitization is the GUI's responsibility at the sink; `libraries/` and `internal/` source contains no innerHTML / outerHTML / insertAdjacentHTML / document.write
+- [Phase 24-sanitize-helper-surface]: safeHttpUrl exported from apps/gui/src/lib/utils/sanitize.ts (http/https-only allowlist, rejects javascript:/data:/vbscript:/file:/mailto:/tel:/protocol-relative + breakout char set); on accept returns escapeHtml(input) for &amp; consistency with safeImageUrl
+- [Phase 24-sanitize-helper-surface]: Module-private isUrlBreakout factored as single source of truth — both safeHttpUrl and safeImageUrl call it; the regex literal /["'<>\n\r\\]/ now appears exactly once in sanitize.ts
+- [Phase 24-sanitize-helper-surface]: safeImageUrl stays dual-context (img src AND css url('…')) — does NOT split into safeImageUrl + safeCssUrl; documented in JSDoc helper-per-sink table
+- [Phase 24-sanitize-helper-surface]: AUDIT-02 sanitization-contract dev note authored in JSDoc header of sanitize.ts (trust boundary, helper-per-sink table, #899/#900 discipline) — Phase 29 AUDIT-02 becomes verification of the table, not authoring
+- [Phase 24-sanitize-helper-surface]: MIGR-01 FOLLOW-UP note (delete sanitize.ts module once {@html} is gone) preserved verbatim in JSDoc — its disappearance would be a regression
+- [Phase 25-css-banner-sinks]: Phase 25-01: bannerStyleString helper centralizes the dual-variant linear-gradient + url() banner CSS template across all 4 banner sinks (data-view DataTable, lists DataTable, CardOperator, PageHeader); helper internally gates via Phase 24's safeImageUrl, closing CSS-02 single-quote breakout at every sink
+- [Phase 25-css-banner-sinks]: Phase 25-01: detection regex revised to domain-specific /url\(\s*['"]\$\{[^}]*banner/i (case-insensitive) — original /background:\s*url\('\$\{/ was a false-pass (real sinks have linear-gradient between background: and url(); broader /url\(['"]\$\{/ would falsely flag the legitimate network-icon CSS in lib/config/dataTable/relays.ts
+- [Phase 25-css-banner-sinks]: Phase 25-01: structural test (banner-style-structural.test.ts) walks apps/gui/src/**/*.{svelte,ts}, runs the domain-specific regex with one whitelist (the test file itself) — turns future banner-injection regression into a build-fail event; pattern is reusable for Phase 29 cross-cutting sweeps over href/image/kind:0 sinks
+- [Phase 26-href-allowlist-sweep]: Wrap ONLY the known vuln (CardFees:60) — Nav/RelaySidebar/CountCard hrefs are safe-by-construction; defensive wrapping rejected (audit-pass doc gives evidence; saves runtime cost)
+- [Phase 26-href-allowlist-sweep]: HREF-AUDIT.md ships at .planning/phases/26-href-allowlist-sweep/HREF-AUDIT.md (force-added with git add -f to override the .planning/ gitignore; also mirrored to GREEN commit body for git log discoverability)
+- [Phase 26-href-allowlist-sweep]: Reactive-pair pattern: keep $: paymentsUrl reactive (source-truthy guard for {#if}) AND add sibling $: safePaymentsUrl = safeHttpUrl(paymentsUrl) (sanitized rendering) — separates concerns, smaller diff than collapsing into one reactive
+- [Phase 26-href-allowlist-sweep]: Comment-stripping helper /<!--[\s\S]*?-->/g excludes dead-code blocks from structural source scanning — reusable pattern for any Svelte component with HTML comment-wrapped legacy code (CardFees.svelte:84-138 dead block preserved byte-for-byte)
+- [Phase 27-countcard-structural-fix]: Slot-API + text-bound prop fallback for CountCard topText/bottomText/$value (mirrors #900 DataTable pattern); callers opt in via slot syntax for markup, plain-text props text-bind transparently via slot fallback
+- [Phase 27-countcard-structural-fix]: Reactive-pair safeLink/internalLink in CountCard — external URLs through Phase 24 safeHttpUrl allowlist; leading-single-slash internal routes via /^\/(?!\/)/ to block protocol-relative // bypass while preserving Counts.svelte /relays-style links
+- [Phase 27-countcard-structural-fix]: valueSentinel readable in RelayFeeItem keeps CountCard's value-display gate satisfied; default-slot content does the visible CARD-03 Number(amount) coercion in template text-bind position
+- [Phase 27-countcard-structural-fix]: CardFees.svelte dead CountCard import removed in GREEN-B (audit step from CONTEXT.md surfaced it); dead-code comment block lines 85-139 preserved byte-for-byte
+- [Phase 27-countcard-structural-fix]: RED test adversarial assertion uses /<\s*\w/ instead of literal onerror= substring — escapeHtml only neutralizes tag delimiters; substring onerror= survives entity encoding (and is inert without a live <...> around it). Structural test on migrated callers is what guarantees onerror= cannot reach a live tag context (Rule 1 deviation fixed before RED commit)
+- [Phase 28-notes.ts-hardening]: Sequential async pipeline (applyAsyncSequential) replaces broken parallel-on-same-input applyAsync; each transform's output feeds the next via for-await reduce
+- [Phase 28-notes.ts-hardening]: applySanitize is the LAST async step and always-on; the if(config.sanitize) gate is structurally removed at parseNote(), the field stays in ParseConfig as @deprecated for caller back-compat
+- [Phase 28-notes.ts-hardening]: parseImages/parseVideos: matched URL through safeImageUrl — on reject REMOVE from text; regex tightened from \S+ to [^\s"'<>]+ as defense-in-depth above safeImageUrl
+- [Phase 28-notes.ts-hardening]: DOMPurify ADD_TAGS:['iframe'] + ADD_ATTR includes 'src' (load-bearing — without it, iframe tag survives but src is stripped, breaking YouTube embeds); iframe src is regex-locked at replaceYoutubeLink (videoId=[a-zA-Z0-9_-]+) so no attacker input reaches it
+- [Phase 28-notes.ts-hardening]: vi.mock target literal-matching: '$lib/stores/services.js' with .js suffix is load-bearing — must match notes.ts:7 source import literal byte-for-byte; missing suffix silently bypasses interception and creates false security regression coverage
+- [Phase 28-notes.ts-hardening]: Test assertion correction (Rule 1 deviation, mirrors Phase 27): bare /onerror=/i substring assertion replaced with structural /<\s*img\b/ 'no live tag opener' — escapeHtml only neutralizes tag delimiters; substring onerror= survives entity encoding but is inert as visible text without surrounding live <...>
+- [Phase 29-adversarial-regression-sweep-&-sanitization-contract-doc]: Inventory floor adjusted from 13 to 12 LIVE sinks — planner's count included a commented-out {@html $readerContent} in Reader.svelte:110 inside dead-code block; walker correctly strips comments before counting (matches runtime surface)
+- [Phase 29-adversarial-regression-sweep-&-sanitization-contract-doc]: Behavioral parseNote test in v2.5-xss-smoke uses Phase 28 byte-for-byte assertion shape (not.toMatch /<script\b/i + /onerror=/i + not.toContain alert(1)) — DOMPurify keeps <img src="x">, so asserting not.toMatch /<img\b/i would falsely fail
+- [Phase 29-adversarial-regression-sweep-&-sanitization-contract-doc]: AUDIT-01 (formatter migration to Svelte components) FORMALLY DEFERRED to v2.6+ via PROJECT.md Key Decisions row; v2.5 closed live vectors via encode-on-output discipline + dataTable formatters are encode-on-output safe today (verified by #899/#900 + html-sink-audit canary)
+- [Phase 29-adversarial-regression-sweep-&-sanitization-contract-doc]: Sanitization contract dev note co-located in sanitize.ts JSDoc header (5 sections: Trust boundary, Helper-per-sink table, Test-then-fix discipline, v2.5 milestone summary, Deferred AUDIT-01) — no separate SECURITY.md or docs/security.md; lives with the helper that enforces the contract
 
 ### Pending Todos
 
@@ -96,9 +144,11 @@ None yet.
 ### Blockers/Concerns
 
 - Detail page (/monitors/[pubkey]) is out of scope — working acceptably, do not touch
+- AUDIT-01 follow-up (replace HTML-string formatters with Svelte components, drop `{@html}` from `DataTable.svelte` / `PageHeader.svelte`) is currently scoped as deliver-or-defer in Phase 29 — if the migration is large, defer with a tracked decision rather than blocking the milestone
 
 ## Session Continuity
 
-Last session: 2026-04-11T22:43:06.015Z
-Stopped at: Completed 20-04-migration-scope-PLAN.md
+Last session: 2026-05-03T20:30:10.498Z
+Stopped at: Completed 29-01-adversarial-regression-sweep-PLAN.md (Phase 29 ready for verification — final v2.5 phase)
 Resume file: None
+Next action: `/gsd:plan-phase 24` — plan Phase 24 Sanitize Helper Surface

--- a/.planning/phases/26-href-allowlist-sweep/HREF-AUDIT.md
+++ b/.planning/phases/26-href-allowlist-sweep/HREF-AUDIT.md
@@ -1,0 +1,44 @@
+# HREF Allowlist Audit — v2.5 Phase 26
+
+**Audited:** 2026-05-03
+**Scope:** every `<a href={…}>` and `<Button href={…}>` in `apps/gui/src` whose value originates in relay aggregate, NIP-11, or kind:0 data.
+**Goal:** prove that every dynamic href either passes through `safeHttpUrl` (Phase 24) or is inert by construction.
+
+## Audit Results
+
+| Location | Binding | Value Source | Verdict | Rationale |
+|---|---|---|---|---|
+| apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardFees.svelte:60 | `<Button href={safePaymentsUrl}>` | NIP-11 `payments_url` (relay-controlled) | **WRAPPED** | Phase 26 wraps via `safeHttpUrl` → `$: safePaymentsUrl = safeHttpUrl(paymentsUrl)` |
+| apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardFees.svelte:132 | `<Button href={paymentUrl}>` | dead-code HTML comment block (lines 84-138) | **DEAD CODE** | Inside `<!-- … -->` — not rendered. Tech-debt cleanup deferred (out of scope for v2.5). |
+| apps/gui/src/lib/components/layout/Nav.svelte:44 | `<a href={link.href}>` | `navLinks` prop default (hardcoded literals: `/preferences`, etc.) | **SAFE** | All callers pass static literals — no relay/kind:0 path reaches this binding. |
+| apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/RelaySidebar.svelte:29 | `<Button href={item?.href ? item.href : "#"}>` | `generateRelayPathFromUrl(relayUrl)` (route-internal path) | **SAFE** | `relayUrl` is path-validated by SvelteKit routing; `generateRelayPathFromUrl` produces a route-internal `/relays/...` path. No `javascript:` shape reachable. |
+| apps/gui/src/routes/(components)/CountCard.svelte:42 | `<a href={link}>` | caller-supplied prop | **SAFE TODAY** | All current callers (`Counts.svelte`: `/relays`, `/monitors`, etc.; `CardInsights` uses `goto`, not `link`) pass hardcoded literals. Phase 27 (CountCard Structural Fix) MAY revisit if it widens the prop contract. |
+| apps/gui/src/routes/+error.svelte:14 | `<Button href="/">` | static literal | **SAFE** | Hardcoded `/`. |
+| apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardNips.svelte:74,87 | `<a href="https://github.com/nostr-protocol/nips/blob/master/{nipLeadingZero(nip)}.md">` | static prefix + numeric segment | **SAFE** | Static `https://github.com/...` prefix; `nipLeadingZero(nip)` returns a numeric string (e.g. `01`, `42`). No relay-controlled segment reaches this binding. |
+| apps/gui/src/routes/relays/software/[softwareKey]/+page.svelte:208 | `<a href="/relays/{generateRelayPathFromUrl(check.relay)}">` | route-internal | **SAFE** | Static `/relays/` prefix; `generateRelayPathFromUrl` produces a path-shaped fragment. |
+| apps/gui/src/routes/note/[id]/+page.svelte:118 | `<a href="/relays/{generateRelayPathFromUrl(relayUrl)}">` | route-internal | **SAFE** | Same pattern as above. |
+| apps/gui/src/routes/monitors/[pubkey]/+page.svelte:564 | `href="/relays/wss/{formatRelayUrl(relay.url)}"` | route-internal | **SAFE** | Static `/relays/wss/` prefix; `formatRelayUrl` strips scheme. |
+| apps/gui/src/lib/components/partials/OperatorRelay.svelte:31 | `<a href="/reload/relays/{generateRelayPathFromUrl(event.relay)}">` | route-internal | **SAFE** | Static `/reload/relays/` prefix; same path-derivation pattern. |
+| apps/gui/src/lib/components/feeds/FeedNote.svelte:104 / FeedMasonryNote.svelte:88 / modal/Reader.svelte:91 | `<a href="https://njump.me/{note.reference}">` | kind:1 / kind:30818 reference | **DEFERRED** | Phase 28 (notes.ts Hardening) territory — `parseNote`/`replaceNip19` audit covers this surface. |
+| apps/gui/src/lib/components/feeds/FeedNote.svelte:115,124,133 / FeedMasonryNote.svelte:99,110,121 | `<a href="">` | static empty placeholder | **SAFE** | Empty `href=""` — no value to validate. UI placeholders for unwired actions. |
+| apps/gui/src/lib/components/partials/NoteZap.svelte:56 / PubkeyZap.svelte:54 / data-view/filters/DataViewFilters.svelte:755,806 / lists/table/Filters.svelte:728,779 | `<a href="#">` | static fragment | **SAFE** | Hardcoded `#` — no value to validate. |
+| apps/gui/src/routes/monitors/[pubkey]/+page.svelte:249 / lib/components/data-view/map/MapBasic.svelte:53 | `<a href="...">` inside JS string literal (Leaflet attribution) | static | **SAFE** | Hardcoded OpenStreetMap attribution string. Not a Svelte binding. |
+
+## Other Sink Categories (checked, none found)
+
+| Sink | Status |
+|---|---|
+| `<iframe src={…}>` from relay/kind:0 data | None found in `apps/gui/src`. |
+| `<form action={…}>` from relay/kind:0 data | None found. |
+| `<link href={…}>` from relay/kind:0 data | None found. |
+| `<script src={…}>` from relay/kind:0 data | None found. |
+
+## Verdict
+
+**URL-02 closed:** the live `paymentsUrl` sink in `CardFees.svelte:60` is wrapped via `safeHttpUrl`.
+**URL-03 closed:** every dynamic `href` in `apps/gui/src` is either WRAPPED, SAFE (inert by construction), SAFE TODAY (caller contract is hardcoded), or DEFERRED (Phase 28 owns the feed/note rendering surface).
+
+**Follow-ups tracked elsewhere:**
+- Phase 27 (CountCard Structural Fix) MAY widen the `link` prop contract — if so, defensively wrap inside CountCard at that time.
+- Phase 28 (notes.ts Hardening) owns `replaceNip19` / `parseNote` href emission — audit folds into FEED-01..05.
+- Dead-code block at `CardFees.svelte:84-138` is a tech-debt cleanup task; deferred from v2.5.

--- a/.planning/phases/29-adversarial-regression-sweep-&-sanitization-contract-doc/29-01-adversarial-regression-sweep-SUMMARY.md
+++ b/.planning/phases/29-adversarial-regression-sweep-&-sanitization-contract-doc/29-01-adversarial-regression-sweep-SUMMARY.md
@@ -1,0 +1,201 @@
+---
+phase: 29-adversarial-regression-sweep-&-sanitization-contract-doc
+plan: 01
+subsystem: testing
+tags: [vitest, dompurify, xss, security, svelte, sanitize]
+
+# Dependency graph
+requires:
+  - phase: 24-sanitize-helper-surface
+    provides: safeHttpUrl, safeImageUrl, escapeHtml, isUrlBreakout module-private factor; JSDoc base sections (Trust boundary, Helper-per-sink table, Test-then-fix discipline)
+  - phase: 25-css-banner-sinks
+    provides: bannerStyleString helper; banner-sink walker pattern in banner-style-structural.test.ts
+  - phase: 26-href-allowlist-sweep
+    provides: CardFees safePaymentsUrl reactive pair; stripHtmlComments helper convention
+  - phase: 27-countcard-structural-fix
+    provides: CountCard slot-API + text-bind fallback; CardInsights / RelayFeeItem migration
+  - phase: 28-notes.ts-hardening
+    provides: parseNote always-on DOMPurify; ParseConfig.sanitize @deprecated field; vi.mock services.js pattern
+provides:
+  - v2.5 milestone canary test (one assertion per attack vector across Phases 24-28)
+  - Cross-cutting {@html} audit walker (whitelist-driven, fails on unknown sinks)
+  - Function-level CardInsights/RelayFeeItem adversarial smoke
+  - Expanded sanitize.ts JSDoc (5 sections — adds v2.5 milestone summary + Deferred AUDIT-01)
+  - Formal AUDIT-01 deferral in PROJECT.md Key Decisions
+  - 4 caller cleanups (sanitize:false stripped — Phase 28 made it a no-op)
+affects: future v2.6+ AUDIT-01 (formatter migration); any future {@html} sink addition
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "v2.5 milestone canary — one consolidated test file with one assertion per attack vector across all phase fixes"
+    - "Cross-cutting {@html} audit walker — whitelist patterns + offenders array + clear failure message hint"
+    - "Inventory-floor assertion — toBeGreaterThanOrEqual on raw sink count locks against silent shrinkage"
+    - "Co-located dev-note discipline — sanitization contract lives in JSDoc of the helper module that enforces it (no separate SECURITY.md)"
+
+key-files:
+  created:
+    - apps/gui/src/lib/utils/v2.5-xss-smoke.test.ts
+    - apps/gui/src/lib/utils/html-sink-audit.test.ts
+    - apps/gui/src/lib/utils/cardinsights-relayfeeitem-adversarial.test.ts
+    - .planning/phases/29-adversarial-regression-sweep-&-sanitization-contract-doc/deferred-items.md
+  modified:
+    - apps/gui/src/lib/utils/sanitize.ts
+    - .planning/PROJECT.md
+    - apps/gui/src/lib/components/feeds/FeedNoteContent.svelte
+    - apps/gui/src/lib/components/feeds/FeedNote.svelte
+    - apps/gui/src/lib/components/feeds/FeedMasonryNote.svelte
+    - apps/gui/src/lib/components/modal/Reader.svelte
+
+key-decisions:
+  - "Inventory floor adjusted from 13 to 12 LIVE sinks — the planner's 13-count included a commented-out {@html $readerContent} in Reader.svelte:110 inside <!-- ... --> Dialog dead-code; the walker (correctly) strips comments before counting, matching the runtime surface. The $readerContent whitelist entry stays in case the dead block is re-enabled."
+  - "Whitelist regex for $NIP_11_LIMITATIONS uses optional fallback group `(\\s*\\|\\|\\s*['\"][^'\"]*['\"])?` to match the actual `{@html $NIP_11_LIMITATIONS?.[key] || ''}` shape at CardLimitation.svelte:114."
+  - "Coverage of behavioral parseNote test in v2.5-xss-smoke uses Phase 28's literal assertion shape (`not.toMatch(/<script\\b/i)` + `not.toMatch(/onerror=/i)` + `not.toContain('alert(1)')`) — DOMPurify keeps `<img src=\"x\">`, so asserting `not.toMatch(/<img\\b/i)` would falsely fail."
+  - "Pre-existing playwright spec failures (relay-detail*.spec.ts) documented in deferred-items.md as out-of-scope infrastructure issue; vitest unit-test pass count is 274/274 across all v2.5 tests."
+
+patterns-established:
+  - "One-file-per-attack-vector milestone canary — runs in <1s, locks every fix in the milestone"
+  - "Whitelist-driven {@html} walker — adding a new sink requires either matching an existing whitelist pattern or extending the whitelist with security justification in code review"
+  - "stripHtmlComments before structural assertion — keeps walkers focused on live runtime surface, ignores commented-out dead code"
+
+requirements-completed:
+  - TEST-04
+  - TEST-05
+  - TEST-06
+  - AUDIT-01
+  - AUDIT-02
+
+# Metrics
+duration: ~5min
+completed: 2026-05-03
+---
+
+# Phase 29 Plan 01: Adversarial Regression Sweep & Sanitization-Contract Doc Summary
+
+**Locked v2.5 GUI XSS Hardening posture via 3 canary test files (21 new cases) + expanded sanitize.ts JSDoc + formal AUDIT-01 deferral; total v2.5 vitest count now 274/274 green.**
+
+## Performance
+
+- **Duration:** ~5 min
+- **Started:** 2026-05-03T20:22:29Z
+- **Completed:** 2026-05-03T20:27:54Z
+- **Tasks:** 3
+- **Files modified:** 9 (3 created tests, 1 deferred-items.md, 5 source edits)
+
+## Accomplishments
+
+- Shipped 3 new test files (21 assertions total) that lock the v2.5 security posture against regression: helper-level + structural + behavioral coverage across Phases 24-28
+- Expanded `sanitize.ts` JSDoc into the canonical 5-section dev note for the v2.5 sanitization contract (Trust boundary, Helper-per-sink table, Test-then-fix discipline, v2.5 milestone summary, Deferred AUDIT-01)
+- Recorded formal AUDIT-01 deferral to v2.6+ in `PROJECT.md` Key Decisions with verbatim rationale from CONTEXT.md
+- Stripped now-no-op `sanitize: false` literal from 4 caller files (cosmetic — Phase 28 made it inert; `ParseConfig.sanitize` stays `@deprecated`)
+
+## Task Commits
+
+All 3 tasks shipped in a single atomic GREEN commit (per plan — no RED needed; the security work landed in Phases 24-28):
+
+1. **Task 1+2+3: v2.5 milestone close** — `721e0075` (feat)
+
+## Files Created/Modified
+
+### Created
+
+- `apps/gui/src/lib/utils/v2.5-xss-smoke.test.ts` (161 LOC) — Consolidated milestone canary covering Phase 24 URL-01 (helper-level), Phase 25 CSS-01/02 (banner-sink imports), Phase 26 URL-02/03 (CardFees safeHttpUrl + paymentsUrl), Phase 27 CARD-01..03 (CountCard structural), Phase 28 FEED-01..05 (parseNote behavioral)
+- `apps/gui/src/lib/utils/html-sink-audit.test.ts` (131 LOC) — Cross-cutting walker over `apps/gui/src/**/*.svelte` asserting every `{@html EXPR}` matches a 7-pattern whitelist; second test locks the 12-sink LIVE inventory floor
+- `apps/gui/src/lib/utils/cardinsights-relayfeeitem-adversarial.test.ts` (83 LOC) — Function-level smoke for CARD-02/03 contracts (Number coercion + escapeHtml + slot-bound bottomText structural)
+- `.planning/phases/29-adversarial-regression-sweep-&-sanitization-contract-doc/deferred-items.md` — Records pre-existing Playwright spec failures as out-of-scope
+
+### Modified
+
+- `apps/gui/src/lib/utils/sanitize.ts` — JSDoc-only expansion: added `# v2.5 milestone summary` and `# Deferred AUDIT-01 (formatter migration)` sections; replaced final FOLLOW-UP paragraph with pointer to those sections + PROJECT.md. Helper code (isUrlBreakout, escapeHtml, safeImageUrl, safeHttpUrl) byte-for-byte unchanged
+- `.planning/PROJECT.md` — Inserted AUDIT-01 deferral row after the existing v2.5 "Text-bind-by-default" Key Decisions row, verbatim per CONTEXT.md `<specifics>`
+- `apps/gui/src/lib/components/feeds/FeedNoteContent.svelte` — Removed `sanitize: false,` from `parserOptions`
+- `apps/gui/src/lib/components/feeds/FeedNote.svelte` — Removed `sanitize: false,` from `defaultParserOptions`
+- `apps/gui/src/lib/components/feeds/FeedMasonryNote.svelte` — Removed `sanitize: false,` from inline `parseNote(...)` config arg
+- `apps/gui/src/lib/components/modal/Reader.svelte` — Removed `sanitize: false,` from `parserOptions`
+
+## Test Coverage Final Tally
+
+**v2.5 milestone — total vitest cases across all 6 phases:**
+
+| Phase | Test File | Cases |
+|-------|-----------|-------|
+| 24 | `apps/gui/src/lib/utils/sanitize.test.ts` | 52 |
+| 25 | `apps/gui/src/lib/utils/style-helpers.test.ts` | 22 |
+| 25 | `apps/gui/src/lib/utils/banner-style-structural.test.ts` | 5 |
+| 26 | `apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardFees.test.ts` | 10 |
+| 27 | `apps/gui/src/routes/(components)/CountCard.test.ts` | 22 |
+| 28 | `apps/gui/src/lib/utils/notes.test.ts` | 15 |
+| 29 | `apps/gui/src/lib/utils/v2.5-xss-smoke.test.ts` | 12 |
+| 29 | `apps/gui/src/lib/utils/html-sink-audit.test.ts` | 2 |
+| 29 | `apps/gui/src/lib/utils/cardinsights-relayfeeitem-adversarial.test.ts` | 7 |
+| **Phase 29 subtotal** | | **21** |
+| **v2.5 grand total (helpers/structural/behavioral)** | | **147** |
+
+Full `pnpm test` in `apps/gui`: **274 passing** vitest cases (147 v2.5 + 127 pre-existing). 2 pre-existing Playwright spec failures (out of scope — see `deferred-items.md`).
+
+## Decisions Made
+
+- **Inventory floor adjusted to 12 LIVE sinks (from planner's 13 expectation).** The original interfaces table counted a commented-out `{@html $readerContent}` at Reader.svelte:110 (inside an `<!-- ... -->` Dialog dead-code block). The walker strips HTML comments before counting (matches the runtime-rendered surface), giving 12 live sinks. The `$readerContent` whitelist entry stays in case the dead block is re-enabled. JSDoc on the test file documents this discrepancy explicitly.
+- **Whitelist regex shape locked to actual code.** The CardLimitation pattern `^\$NIP_11_LIMITATIONS\?\.\[key\](\s*\|\|\s*['"][^'"]*['"])?$` matches the real source `{@html $NIP_11_LIMITATIONS?.[key] || ''}` with the optional fallback. Tightening this further would break on legitimate fallback patterns; loosening would let arbitrary `||` expressions through.
+- **Behavioral assertion in v2.5-xss-smoke mirrors notes.test.ts:101-106 byte-for-byte.** DOMPurify sanitizes `<img src=x onerror=alert(1)>` to `<img src="x">` (keeps the element, strips the handler). The plan-time assertion `not.toMatch(/<img\b/i)` would falsely fail; we use the Phase 28 proven shape (`not.toMatch(/<script\b/i)` + `not.toMatch(/onerror=/i)` + `not.toContain('alert(1)')`).
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Inventory floor adjusted from 13 to 12 live sinks**
+
+- **Found during:** Task 1 (initial vitest run of html-sink-audit.test.ts)
+- **Issue:** Plan asserted `>= 13` based on raw grep count. The walker (correctly) strips HTML comments before counting, so the third Reader.svelte sink (line 110, inside `<!-- ... -->` dead code) is excluded — live count is 12.
+- **Fix:** Lowered the inventory floor to `>= 12`, updated the inline JSDoc to explain the discrepancy and clarify the design intent (count LIVE runtime surface, not dead-code grep matches).
+- **Files modified:** `apps/gui/src/lib/utils/html-sink-audit.test.ts` (test assertion + JSDoc clarification)
+- **Verification:** Re-ran `pnpm vitest run src/lib/utils/html-sink-audit.test.ts` — 2/2 green.
+- **Committed in:** 721e0075 (Phase 29 single GREEN commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 bug — planning-time inventory miscount).
+**Impact on plan:** No security/scope impact — the floor adjustment reflects the live runtime surface. Inventory test still locks against silent shrinkage of the canary surface, which is its design intent.
+
+## Issues Encountered
+
+- **Pre-existing Playwright spec failures.** `apps/gui/tests/relay-detail.spec.ts` and `relay-detail-debug.spec.ts` fail under vitest's transform (Playwright/Vitest version conflict). Documented in `deferred-items.md` as out-of-scope; predates v2.5. All 274 vitest unit tests pass (147 v2.5 + 127 pre-existing).
+- **`git stash --keep-index` round-trip during verification.** A `git stash --keep-index` was used to confirm a baseline state, but with no staged changes it reverted everything; `git stash pop` restored cleanly. No data lost.
+
+## Pointers
+
+- **Sanitization contract dev note:** `apps/gui/src/lib/utils/sanitize.ts` JSDoc header (5 sections — Trust boundary, Helper-per-sink table, Test-then-fix discipline, v2.5 milestone summary, Deferred AUDIT-01).
+- **AUDIT-01 deferral:** `.planning/PROJECT.md` Key Decisions row "Defer AUDIT-01 (formatter migration to Svelte components) to v2.6+".
+- **Cross-cutting `{@html}` walker:** `apps/gui/src/lib/utils/html-sink-audit.test.ts` — runs on every `pnpm test`, fails loudly on unknown sinks.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+v2.5 is **ready for `/gsd:audit-milestone` and `/gsd:complete-milestone v2.5`**. All 6 phases are complete:
+
+1. Phase 24 — Sanitize Helper Surface (URL-01) — shipped
+2. Phase 25 — CSS Banner Sinks (CSS-01, CSS-02) — shipped
+3. Phase 26 — href Allowlist Sweep (URL-02, URL-03) — shipped
+4. Phase 27 — CountCard Structural Fix (CARD-01, CARD-02, CARD-03) — shipped
+5. Phase 28 — notes.ts Hardening (FEED-01..05) — shipped
+6. Phase 29 — Adversarial Regression Sweep & Sanitization-Contract Doc (TEST-04, TEST-05, TEST-06, AUDIT-01, AUDIT-02) — shipped
+
+The cross-cutting `html-sink-audit.test.ts` walker is the ongoing canary that catches new `{@html}` sinks added without going through one of the v2.5 helpers. AUDIT-01 (formatter migration) is formally deferred to v2.6+ with rationale recorded.
+
+---
+*Phase: 29-adversarial-regression-sweep-&-sanitization-contract-doc*
+*Completed: 2026-05-03*
+
+## Self-Check: PASSED
+
+All claimed files exist on disk. Commit `721e0075` exists in git log. All required content markers verified:
+- 5 created files found (3 tests + deferred-items.md + this SUMMARY.md)
+- 6 modified files found (sanitize.ts, PROJECT.md, 4 callers)
+- PROJECT.md contains AUDIT-01 deferral row
+- sanitize.ts JSDoc contains v2.5 milestone summary + Deferred AUDIT-01 sections
+- All 4 callers no longer contain `sanitize: false`
+- ParseConfig.sanitize `@deprecated` field preserved in notes.ts

--- a/.planning/phases/29-adversarial-regression-sweep-&-sanitization-contract-doc/deferred-items.md
+++ b/.planning/phases/29-adversarial-regression-sweep-&-sanitization-contract-doc/deferred-items.md
@@ -1,0 +1,15 @@
+# Phase 29 Deferred Items
+
+## Pre-existing Playwright spec failures (out of scope)
+
+**Files:**
+- `apps/gui/tests/relay-detail-debug.spec.ts`
+- `apps/gui/tests/relay-detail.spec.ts`
+
+**Symptom:** Vitest runs these Playwright specs (because they end in `.spec.ts`) and fails on `test.describe()` because Playwright Test refuses to be invoked from vitest's transform pipeline.
+
+**Why deferred:** Pre-existing infrastructure issue, not caused by Phase 29's changes. Both files predate v2.5 (last touched in commit 05638ea9). The Playwright/Vitest conflict is unrelated to the v2.5 GUI XSS Hardening milestone scope.
+
+**Vitest unit-test pass count:** 274 / 274 (Phases 24-28 cases + Phase 29's 21 new cases all green).
+
+**Suggested fix (future):** Add a `vitest.config.ts` `exclude` entry for `tests/**/*.spec.ts` so vitest skips Playwright e2e specs. Alternatively, rename the files to `*.e2e.spec.ts` and pattern-exclude. Out of scope for Phase 29.

--- a/apps/gui/src/lib/components/data-view/table/DataTable.svelte
+++ b/apps/gui/src/lib/components/data-view/table/DataTable.svelte
@@ -19,6 +19,7 @@
     import * as Tabs from "$lib/components/ui/tabs";
 	import type { DataTableConfig } from './DataTableTypes';
 	import { darkMode, isBootstrapped } from '$lib/stores/app';
+	import { bannerStyleString } from '$utils/style-helpers';
 	import type { DataViewColumns } from '../DataTableTypes';
 	import Loading from '$lib/components/partials/Loading.svelte';
 	import RelayLivenessCounts from '$lib/components/partials/RelayLivenessCounts.svelte';
@@ -305,23 +306,13 @@
         <Table.Body>
             {#each tableInstance?.rows as row, rowIndex (`${row.id ?? ''}:${rowIndex}`)}
             <!-- {(console.log('row data', row?.active, row?.enabled, $config.tableRowStyler(row)))} -->
-                <Table.Row 
-                    class="{$config.tableRowStyler(row)} flash-record {$recordChanged.get(row.id) ? 'animate-flash' : ''}" 
-                    style="{
+                <Table.Row
+                    class="{$config.tableRowStyler(row)} flash-record {$recordChanged.get(row.id) ? 'animate-flash' : ''}"
+                    style={
                         $config.rowBannerEnabled !== false && row.banner && row.banner !== ''
-                            ? 
-                                $darkMode
-                                    ? 
-                                        `background: linear-gradient(rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.8)),  url('${row.banner}'); 
-                                        background-repeat: no-repeat; 
-                                        background-size: cover;`
-                                    :
-                                        `background: linear-gradient(rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.8)),  url('${row.banner}'); 
-                                        background-repeat: no-repeat; 
-                                        background-size: cover;`
-                                
+                            ? bannerStyleString(row.banner, { darkMode: $darkMode, opacity: 0.8 })
                             : ''
-                    }"
+                    }
                     >
                     {#if actionsComponent}
                         <svelte:component this={actionsComponent} data={row} />

--- a/apps/gui/src/lib/components/feeds/FeedMasonryNote.svelte
+++ b/apps/gui/src/lib/components/feeds/FeedMasonryNote.svelte
@@ -43,7 +43,6 @@
             videos: true,
             truncate: true,
             truncateLength: 100,
-            sanitize: false,
             replaceAmpersand: true,
         });
     }

--- a/apps/gui/src/lib/components/feeds/FeedNote.svelte
+++ b/apps/gui/src/lib/components/feeds/FeedNote.svelte
@@ -44,7 +44,6 @@
         images: true,
         videos: true,
         truncate: true,
-        sanitize: false,
         replaceAmpersand: true
     }   
   

--- a/apps/gui/src/lib/components/feeds/FeedNoteContent.svelte
+++ b/apps/gui/src/lib/components/feeds/FeedNoteContent.svelte
@@ -16,7 +16,6 @@
         videos: true,
         truncate: true,
         truncateLength: 100,
-        sanitize: false,
         replaceAmpersand: true,
     };
 

--- a/apps/gui/src/lib/components/layout/PageHeader.svelte
+++ b/apps/gui/src/lib/components/layout/PageHeader.svelte
@@ -2,6 +2,7 @@
 
     import { clickToCopy } from "$utils/ux";
     import { safeImageUrl } from "$utils/sanitize";
+    import { bannerStyleString } from "$utils/style-helpers";
     import * as DOMPurify from "dompurify";
 
     export let title: string;
@@ -13,10 +14,12 @@
 
     const noop=()=>{}
 
-    // Validate the relay-controlled banner URL before interpolating it into a
-    // CSS `url('...')` value. safeImageUrl rejects any URL containing the
-    // attribute/CSS breakout characters and entity-encodes the result.
-    $: safeBanner = safeImageUrl(banner);
+    // Build the banner CSS style string via the shared helper. The helper gates
+    // the relay-controlled banner URL through safeImageUrl (rejecting CSS-context
+    // breakout characters) before interpolating it into the gradient + url('...')
+    // template. Returns '' when banner is missing or rejected, which Svelte
+    // renders as no `style` attribute applied.
+    $: bannerStyle = bannerStyleString(banner, { opacity: bgOpacity });
 
     // Validate the relay-controlled icon URL before binding it to <img src>.
     $: safeIcon = safeImageUrl(icon);
@@ -32,9 +35,7 @@
 <header
   id="relay-header"
   class="relative bg-center bg-cover bg-no-repeat px-3 pb-10 gradient-purple pt-24"
-  style={safeBanner ? `background: linear-gradient(rgba(0, 0, 0, ${bgOpacity}), rgba(0, 0, 0, ${bgOpacity})), url('${safeBanner}');
-    background-repeat: no-repeat;
-    background-size: cover;` : ''}
+  style={bannerStyle}
 >
   <!-- Absolute positioned slot for overlays like maps -->
   <slot name="absolute" />

--- a/apps/gui/src/lib/components/lists/table/DataTable.svelte
+++ b/apps/gui/src/lib/components/lists/table/DataTable.svelte
@@ -20,6 +20,7 @@
 	import Button from '../../ui/button/button.svelte';
 	import type { DataTableConfig } from './DataTableTypes';
 	import { darkMode } from '$lib/stores/theme';
+	import { bannerStyleString } from '$utils/style-helpers';
 	import { randomLoadingMessage } from '$utils/ux';
 	import Loading from '$lib/components/partials/Loading.svelte';
 
@@ -331,23 +332,13 @@
                     </Table.Header>
                     <Table.Body>
                         {#each tableInstance?.rows as row, rowIndex (`${row.id ?? ''}:${rowIndex}`)}
-                            <Table.Row 
-                                class="{$rowStyles.get(row.pubkey)}" 
-                                style="{
+                            <Table.Row
+                                class="{$rowStyles.get(row.pubkey)}"
+                                style={
                                     $config.rowBannerEnabled !== false && row.banner
-                                        ? 
-                                            $darkMode
-                                                ? 
-                                                    `background: linear-gradient(rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.8)),  url('${row.banner}'); 
-                                                    background-repeat: no-repeat; 
-                                                    background-size: cover;`
-                                                :
-                                                    `background: linear-gradient(rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.8)),  url('${row.banner}'); 
-                                                    background-repeat: no-repeat; 
-                                                    background-size: cover;`
-                                            
+                                        ? bannerStyleString(row.banner, { darkMode: $darkMode, opacity: 0.8 })
                                         : ''
-                                }"
+                                }
                                 >
                                 {#if actionsComponent}
                                     <svelte:component this={actionsComponent} data={row} />

--- a/apps/gui/src/lib/components/modal/Reader.svelte
+++ b/apps/gui/src/lib/components/modal/Reader.svelte
@@ -23,7 +23,6 @@
         videos: true,
         truncate: true,
         truncateLength: 100,
-        sanitize: false,
         replaceAmpersand: true,
     };
     

--- a/apps/gui/src/lib/utils/banner-style-structural.test.ts
+++ b/apps/gui/src/lib/utils/banner-style-structural.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { resolve, join } from 'path';
+
+// apps/gui/src — resolved relative to this file (apps/gui/src/lib/utils/...)
+const APPS_GUI_SRC = resolve(__dirname, '../..');
+
+const BANNER_SINK_FILES = [
+    'lib/components/data-view/table/DataTable.svelte',
+    'lib/components/lists/table/DataTable.svelte',
+    'routes/relays/[protocol]/[...relay]/(components)/cards/CardOperator.svelte',
+    'lib/components/layout/PageHeader.svelte',
+];
+
+// Detection regex — domain-specific: matches `url('${…banner…}')` interpolations
+// (case-insensitive, so `row.banner`, `$profile.banner`, AND `safeBanner` all match).
+// The original narrower `/background:\s*url\('\$\{/` was a false-pass — real sinks
+// always have `linear-gradient(...)` between `background:` and `url(`, so the
+// narrower regex matched 0 hits even before the fix. A broader `/url\(\s*['"]\$\{/`
+// would falsely flag the legitimate network-icon CSS in lib/config/dataTable/relays.ts:340
+// (which uses internal `iconPath` + allowlist-validated `safeNetwork`). The
+// domain-specific shape below targets the actual vulnerability class — banner-named
+// interpolations in CSS url() declarations — with no false positives.
+const RAW_BANNER_INTERPOLATION_RE = /url\(\s*['"]\$\{[^}]*banner/i;
+
+// The structural test file itself contains the regex source (which mentions `banner`
+// and `url(`/`${`). Whitelist this single file from cross-tree scanning. The helper
+// file does NOT need whitelisting — it interpolates `${safe}`, not `${banner}`, so
+// RAW_BANNER_INTERPOLATION_RE does not match. sanitize.test.ts:144 also does NOT need
+// whitelisting — its placeholder is `${...}`, no `banner` keyword.
+const WHITELIST_RE = /lib\/utils\/banner-style-structural\.test\.ts$/;
+
+function walkSourceFiles(dir: string, ext: RegExp): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        const st = statSync(full);
+        if (st.isDirectory()) {
+            if (entry === 'node_modules' || entry === '.svelte-kit') continue;
+            out.push(...walkSourceFiles(full, ext));
+        } else if (ext.test(entry)) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+describe('banner sink structural', () => {
+    // -------------------------------------------------------------------------
+    // Per-file checks: each of the 4 banner sinks imports + calls bannerStyleString,
+    // and contains zero `url('${…banner…}')` interpolations.
+    // -------------------------------------------------------------------------
+
+    BANNER_SINK_FILES.forEach((rel) => {
+        it(`${rel} imports + calls bannerStyleString and has no banner-named url() interpolation`, () => {
+            const full = join(APPS_GUI_SRC, rel);
+            const source = readFileSync(full, 'utf8');
+
+            // (a) The helper is referenced by name (covers both import and call site).
+            expect(source).toContain('bannerStyleString');
+
+            // (b) At least one CALL site (not just an import).
+            const callMatches = source.match(/bannerStyleString\s*\(/g) ?? [];
+            expect(callMatches.length).toBeGreaterThanOrEqual(1);
+
+            // (c) No `url('${…banner…}')` interpolation remains in this file
+            // (case-insensitive — covers row.banner, $profile.banner, safeBanner).
+            expect(source).not.toMatch(RAW_BANNER_INTERPOLATION_RE);
+
+            // (d) Import path is `$utils/style-helpers` (the project alias for
+            // apps/gui/src/lib/utils, per svelte.config.js + vite.config.ts).
+            expect(source).toMatch(/from\s+['"]\$utils\/style-helpers['"]/);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Cross-tree check: zero banner-named url() interpolations anywhere in
+    // apps/gui/src outside the structural test file itself.
+    // -------------------------------------------------------------------------
+
+    it('apps/gui/src has zero banner-named url() interpolations outside the structural test', () => {
+        const allFiles = walkSourceFiles(APPS_GUI_SRC, /\.(svelte|ts)$/);
+        const candidates = allFiles.filter((f) => !WHITELIST_RE.test(f));
+        const offenders: string[] = [];
+        for (const file of candidates) {
+            const src = readFileSync(file, 'utf8');
+            if (RAW_BANNER_INTERPOLATION_RE.test(src)) offenders.push(file);
+        }
+        expect(
+            offenders,
+            `unguarded banner interpolation in: ${offenders.join(', ')}`
+        ).toEqual([]);
+    });
+});

--- a/apps/gui/src/lib/utils/cardinsights-relayfeeitem-adversarial.test.ts
+++ b/apps/gui/src/lib/utils/cardinsights-relayfeeitem-adversarial.test.ts
@@ -1,0 +1,83 @@
+/**
+ * CardInsights / RelayFeeItem adversarial-input smoke — TEST-05.
+ *
+ * Function-level + structural tests that lock the Phase 27 migration
+ * contract for the two highest-risk callers of CountCard:
+ *   - CardInsights (CARD-02): software / version / geocode / isp reach
+ *     bottomText via slot-bound interpolation, never via `{@html}`.
+ *   - RelayFeeItem (CARD-03): fee.amount is coerced via Number(...) before
+ *     it can reach a render context, neutralizing non-numeric NIP-11 input.
+ *
+ * Mirrors the function-level coercion-contract assertions already in
+ * CountCard.test.ts but co-locates them in `lib/utils/` for canary
+ * discoverability — a future contributor running just the helpers test
+ * suite (`vitest run src/lib/utils/`) sees these regression locks.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { escapeHtml } from './sanitize';
+
+// apps/gui/src — resolved relative to this file (apps/gui/src/lib/utils/...)
+const APPS_GUI_SRC = resolve(__dirname, '../..');
+const RELAY_FEE_ITEM_PATH = resolve(
+    APPS_GUI_SRC,
+    'routes/relays/[protocol]/[...relay]/(components)/partials/RelayFeeItem.svelte'
+);
+const CARD_INSIGHTS_PATH = resolve(
+    APPS_GUI_SRC,
+    'routes/relays/[protocol]/[...relay]/(components)/cards/CardInsights.svelte'
+);
+
+/**
+ * Strip HTML comment blocks so structural assertions only inspect LIVE code.
+ * Mirrors Phase 26/27.
+ */
+function stripHtmlComments(source: string): string {
+    return source.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+describe('RelayFeeItem CARD-03 — Number coercion contract', () => {
+    it('Number("<img src=x onerror=alert(1)>") is NaN', () => {
+        expect(Number.isNaN(Number('<img src=x onerror=alert(1)>'))).toBe(true);
+    });
+
+    it('Number(undefined) is NaN', () => {
+        expect(Number.isNaN(Number(undefined))).toBe(true);
+    });
+
+    it('Number(1500) is 1500', () => {
+        expect(Number(1500)).toBe(1500);
+    });
+
+    it('source contains Number(amount) or Number(fee.amount)', () => {
+        const live = stripHtmlComments(readFileSync(RELAY_FEE_ITEM_PATH, 'utf8'));
+        expect(live).toMatch(/Number\s*\(\s*(amount|fee\.amount)\s*\)/);
+    });
+});
+
+describe('CardInsights CARD-02 — slot-bound bottomText contract', () => {
+    it('escapeHtml on adversarial software field produces no live tag', () => {
+        // Mirror the Phase 27 Rule 1 deviation pattern: assert /<\s*\w/ does NOT
+        // match — escapeHtml only neutralizes tag delimiters, but once the
+        // surrounding `<...>` is gone, any `onerror=` substring is inert text.
+        const out = escapeHtml('<img src=x onerror=alert(1)>');
+        expect(out).not.toMatch(/<\s*\w/);
+        expect(out).toContain('&lt;');
+        expect(out).toContain('&gt;');
+    });
+
+    it('source contains <svelte:fragment slot="bottomText"> at least 4 times', () => {
+        // CardInsights has 4 CountCard call sites: software, version, geocode, isp.
+        const live = stripHtmlComments(readFileSync(CARD_INSIGHTS_PATH, 'utf8'));
+        const fragMatches = live.match(/<svelte:fragment\s+slot=["']bottomText["']/g) ?? [];
+        expect(fragMatches.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('source contains zero bottomText template-literal HTML strings', () => {
+        const live = stripHtmlComments(readFileSync(CARD_INSIGHTS_PATH, 'utf8'));
+        // bottomText={`...<tag...`} — template literal containing an HTML tag.
+        expect(live).not.toMatch(/bottomText=\{`[^`]*<[a-z]/i);
+    });
+});

--- a/apps/gui/src/lib/utils/html-sink-audit.test.ts
+++ b/apps/gui/src/lib/utils/html-sink-audit.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Cross-cutting {@html} audit — TEST-06.
+ *
+ * Walks every .svelte file in apps/gui/src and asserts every `{@html EXPR}`
+ * matches a known-safe whitelist pattern. A new `{@html}` sink that doesn't
+ * fit one of the whitelisted shapes fails this test loudly with a clear
+ * "must be added to whitelist with security justification" message.
+ *
+ * The whitelist is INTENTIONALLY narrow. Adding an entry requires a written
+ * security justification in code review. The whitelist should shrink, not
+ * grow, as MIGR-01 (formatter migration to Svelte components, deferred to
+ * v2.6+ as AUDIT-01) progresses.
+ *
+ * Inventory at v2.5 close (12 LIVE sinks; HTML comments stripped before walk):
+ *   - PageHeader: safeSubtitle (Phase 24)                                — 1
+ *   - 4 feed components: $content (Phase 28 DOMPurify)                    — 4
+ *     (FeedNoteContent, FeedNote, FeedMasonryNote, Reader x1)
+ *   - Reader: $content (second sink)                                      — 1
+ *   - CardLimitation: $NIP_11_LIMITATIONS?.[key] (static dict)            — 1
+ *   - JsonHighlighter: highlightedHtml (local escapeHtml)                 — 1
+ *   - 2 DataTables: $config.tableFormatters[column.key](...) (#899/#900)  — 2
+ *   - 2 Filters: $config.filterFormatters[filter.key](value) (#899/#900)  — 2
+ *
+ * Note: a third Reader `{@html $readerContent}` exists at Reader.svelte:110
+ * but is wrapped in an `<!-- ... -->` comment block (dead Dialog code, lines
+ * 101-115). The walker strips HTML comments before counting, matching the
+ * live runtime surface — 12 sinks. The `$readerContent` whitelist entry stays
+ * in case the dead-code block is re-enabled in the future.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { resolve, join, relative } from 'path';
+
+// apps/gui/src — resolved relative to this file (apps/gui/src/lib/utils/...)
+const APPS_GUI_SRC = resolve(__dirname, '../..');
+
+// Capture the EXPR inside `{@html EXPR}`. `[^}]+` is fine — Svelte `{@html}`
+// cannot contain a literal `}` in the expression because it terminates the
+// directive.
+const HTML_SINK_RE = /\{@html\s+([^}]+)\}/g;
+
+const WHITELIST_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
+    { pattern: /^safeSubtitle$/, reason: 'PageHeader — wrapped via Phase 24 safe* helper' },
+    { pattern: /^\$content$/, reason: 'parseNote-produced store — Phase 28 always-on DOMPurify' },
+    { pattern: /^\$readerContent$/, reason: 'Reader alt path — same parseNote sanitization' },
+    {
+        pattern: /^\$NIP_11_LIMITATIONS\?\.\[key\](\s*\|\|\s*['"][^'"]*['"])?$/,
+        reason: 'CardLimitation — static dictionary lookup, no relay input',
+    },
+    { pattern: /^highlightedHtml$/, reason: 'JsonHighlighter — local escapeHtml on every value' },
+    {
+        pattern: /^\$config\.tableFormatters\[column\.key\]\(row\[column\.key\],\s*row\)$/,
+        reason: 'DataTable cells — registered formatters, encode-on-output safe (#899/#900)',
+    },
+    {
+        pattern: /^\$config\.filterFormatters\[filter\.key\]\(value\)$/,
+        reason: 'Filters — registered formatters, encode-on-output safe (#899/#900)',
+    },
+];
+
+function walkSourceFiles(dir: string, ext: RegExp): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        const st = statSync(full);
+        if (st.isDirectory()) {
+            if (entry === 'node_modules' || entry === '.svelte-kit') continue;
+            out.push(...walkSourceFiles(full, ext));
+        } else if (ext.test(entry)) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+describe('html-sink audit', () => {
+    it('every {@html EXPR} across apps/gui/src/**/*.svelte matches a known-safe whitelist', () => {
+        const allSvelte = walkSourceFiles(APPS_GUI_SRC, /\.svelte$/);
+        const offenders: Array<{ file: string; expr: string }> = [];
+
+        for (const fullPath of allSvelte) {
+            const source = readFileSync(fullPath, 'utf8');
+            // Strip HTML comments so commented-out `{@html ...}` examples / dead
+            // code blocks don't trigger the walker.
+            const live = source.replace(/<!--[\s\S]*?-->/g, '');
+            HTML_SINK_RE.lastIndex = 0; // reset regex state across files
+            let match: RegExpExecArray | null;
+            while ((match = HTML_SINK_RE.exec(live)) !== null) {
+                const trimmed = match[1].trim();
+                const ok = WHITELIST_PATTERNS.some(({ pattern }) => pattern.test(trimmed));
+                if (!ok) {
+                    offenders.push({ file: relative(APPS_GUI_SRC, fullPath), expr: trimmed });
+                }
+            }
+        }
+
+        expect(
+            offenders,
+            `Unknown {@html} sinks (must be added to whitelist with security justification):\n${offenders
+                .map((o) => `  ${o.file}: ${o.expr}`)
+                .join('\n')}`
+        ).toEqual([]);
+    });
+
+    it('v2.5 inventory contains at least 12 live {@html} sinks', () => {
+        // Locks the LIVE inventory floor at v2.5 close. HTML comments are
+        // stripped before counting (matches the runtime surface — dead-code
+        // sinks like Reader.svelte:110 inside <!-- ... --> are not rendered).
+        //
+        // A future contributor REMOVING a live sink (shrinking the canary
+        // surface) will fail this test, prompting an explicit decision to
+        // lower the floor. ADDING a new sink without whitelist coverage is
+        // still caught by the first test above.
+        //
+        // The plan-time inventory listed 13 (counting the commented-out
+        // $readerContent at Reader.svelte:110). Live count is 12.
+        const allSvelte = walkSourceFiles(APPS_GUI_SRC, /\.svelte$/);
+        let totalSinkCount = 0;
+
+        for (const fullPath of allSvelte) {
+            const source = readFileSync(fullPath, 'utf8');
+            const live = source.replace(/<!--[\s\S]*?-->/g, '');
+            HTML_SINK_RE.lastIndex = 0;
+            const matches = live.match(HTML_SINK_RE);
+            if (matches) totalSinkCount += matches.length;
+        }
+
+        expect(totalSinkCount).toBeGreaterThanOrEqual(12);
+    });
+});

--- a/apps/gui/src/lib/utils/notes.test.ts
+++ b/apps/gui/src/lib/utils/notes.test.ts
@@ -138,11 +138,22 @@ describe('parseNote — replaceNip19 user.name injection (FEED-03)', () => {
         const out = await drain(parseNote(input, CALLER_CONFIG));
         // The attacker's <img> tag must NOT appear as a live tag in output.
         expect(out).not.toMatch(/<img\b/i);
-        expect(out).not.toMatch(/onerror=/i);
         // Visible-text form (entity-encoded) is acceptable. The <a> wrapper
         // itself MAY survive — that's the legitimate replaceNip19 output.
         // Contract: the user.name interpolation is HTML-escaped so the payload
         // renders as visible text, not as a live <img>.
+        //
+        // We do NOT assert on bare `onerror=` substring: escapeHtml only
+        // neutralizes tag delimiters; once the surrounding `<...>` is gone,
+        // the substring is inert text. This mirrors Phase 27's documented
+        // finding (STATE.md decisions): "escapeHtml only neutralizes tag
+        // delimiters; substring onerror= survives entity encoding (and is
+        // inert without a live <...> around it)." The /<img\b/ assertion
+        // above (no live tag opener) is what actually locks the security
+        // contract — there can be no event-handler attribute without a live
+        // tag context. The structural pattern below also locks "no live tag
+        // opener anywhere in the output's user.name region."
+        expect(out).not.toMatch(/<\s*img\b/i);
     });
 });
 

--- a/apps/gui/src/lib/utils/notes.test.ts
+++ b/apps/gui/src/lib/utils/notes.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi } from 'vitest';
+import { tick } from 'svelte';
+import { get, writable, type Readable } from 'svelte/store';
+import { nip19 } from 'nostr-tools';
+
+// ---------------------------------------------------------------------------
+// UserService mock — hoisted by vitest BEFORE notes.ts imports.
+//
+// CRITICAL: vi.mock target MUST match the source import literal — notes.ts:7
+// imports from `$lib/stores/services.js` (with .js suffix; matches existing
+// repo convention, e.g. monitors.test.ts:4). If we mock `$lib/stores/services`
+// (no .js), Vitest does NOT intercept the import; the real `userService`
+// writable (null by default in jsdom) is used; replaceNip19's npub branch
+// exits at `if (!service) return { original, replacement: encoded }` — the
+// attacker user.name payload is NEVER reached and FEED-03's attack-vector
+// assertion would pass at HEAD AND at GREEN (false security regression
+// coverage). The .js suffix is load-bearing.
+//
+// notes.ts:7 imports `userService` from `$lib/stores/services.js`. The npub
+// branch of `replaceNip19` reads `get(userService)`, calls `userFromPubkey(data)`,
+// awaits `user.ready()`, and interpolates `user.name` — that interpolation is
+// FEED-03's LIVE vuln. The stub returns an attacker-controlled `name` so the
+// test can assert the GREEN escapeHtml wrap closes the vector.
+//
+// The stub User is intentionally minimal — only the fields replaceNip19
+// touches. Every other field is undefined so accidental new dependencies
+// surface as test failures rather than silent passes.
+// ---------------------------------------------------------------------------
+vi.mock('$lib/stores/services.js', () => {
+    const stubUser = {
+        name: '<img src=x onerror=alert(1)>',
+        ready: () => Promise.resolve(),
+    };
+    const stubService = {
+        userFromPubkey: (_pubkey: string) => stubUser,
+    };
+    return {
+        userService: writable(stubService),
+        feedService: writable(null),
+    };
+});
+
+// notes.ts MUST be imported AFTER the vi.mock call (vitest hoists the mock,
+// but explicit ordering documents intent).
+import { parseNote, type ParseConfig } from './notes';
+
+/**
+ * Drain the parseNote pipeline. The pipeline is async (markdown via marked,
+ * replaceNip19 via service.ready(), applySanitize after Phase 28). Wait for:
+ *   - one Svelte tick (microtask flush)
+ *   - one 50ms macrotask (marked parse + DOMPurify wrap)
+ *   - one more Svelte tick (subscriber update)
+ * CONTEXT.md decisions section approves this pattern.
+ */
+async function drain<T>(store: Readable<T>): Promise<T> {
+    await tick();
+    await new Promise((r) => setTimeout(r, 50));
+    await tick();
+    return get(store);
+}
+
+/**
+ * The 4 caller files all pass this exact shape (with minor truncate
+ * differences). Mirroring the literal makes the assertions reflect production.
+ */
+const CALLER_CONFIG: ParseConfig = {
+    removeHashtags: true,
+    nip19: true,
+    markdown: true,
+    images: true,
+    videos: true,
+    truncate: false,
+    sanitize: false,         // <-- Phase 28 makes this a no-op
+    replaceAmpersand: true,
+};
+
+// Reader.svelte calls with markdown:false for wiki content (kind:30818).
+// FEED-04: same pipeline must reach applySanitize.
+const WIKI_CONFIG: ParseConfig = {
+    ...CALLER_CONFIG,
+    markdown: false,
+};
+
+// ===========================================================================
+// Attack-vector describes — every assertion below MUST FAIL at HEAD.
+// ===========================================================================
+
+describe('parseNote — XSS hardening — bare attack payloads (FEED-01)', () => {
+    it('strips bare <script> from raw input', async () => {
+        const out = await drain(parseNote('<script>alert(1)</script>', CALLER_CONFIG));
+        expect(out).not.toMatch(/<script\b/i);
+        expect(out).not.toContain('alert(1)');
+    });
+
+    it('strips event-handler <img> injection', async () => {
+        const out = await drain(parseNote('<img src=x onerror=alert(1)>', CALLER_CONFIG));
+        expect(out).not.toMatch(/onerror=/i);
+        expect(out).not.toContain('alert(1)');
+    });
+
+    it('strips combined script + event-handler payload (ROADMAP criterion 1)', async () => {
+        const payload = '<script>alert(1)</script><img src=x onerror=alert(1)>';
+        const out = await drain(parseNote(payload, CALLER_CONFIG));
+        expect(out).not.toMatch(/<script\b/i);
+        expect(out).not.toMatch(/onerror=/i);
+    });
+});
+
+describe('parseNote — parseImages breakout (FEED-02)', () => {
+    it('rejects parseImages URL with attribute-breakout chars', async () => {
+        // Canonical breakout per ROADMAP criterion 2:
+        // \S+ greedy-matches the whole `https://x.png"<script>...<img src="https://y.png`
+        // segment, so naive interpolation produces `<img src="https://x.png"<script>...">`.
+        // The new regex [^\s"'<>]+ + safeImageUrl belt-and-suspenders MUST close it.
+        const payload = 'https://x.png"<script>alert(1)</script><img src="https://y.png';
+        const out = await drain(parseNote(payload, CALLER_CONFIG));
+        expect(out).not.toMatch(/<script\b/i);
+        // Defense: even if marked turns it into something unexpected, the FINAL
+        // applySanitize step strips the script tag.
+    });
+
+    it('preserves a safe HTTPS image URL', async () => {
+        const out = await drain(parseNote('https://example.com/cat.png', CALLER_CONFIG));
+        expect(out).toMatch(/<img\b[^>]*\bsrc=/i);
+        // Either the raw URL or the entity-encoded form (DOMPurify may re-encode)
+        // is acceptable — the contract is "the safe URL survives the pipeline."
+        expect(out).toMatch(/example\.com\/cat\.png/);
+    });
+});
+
+describe('parseNote — replaceNip19 user.name injection (FEED-03)', () => {
+    it('escapes attacker-controlled kind:0 name in rendered <a>', async () => {
+        // 32-byte hex pubkey -> npub1... via real nip19. The npub branch reads
+        // user.name from the mocked service (attacker-controlled HTML payload).
+        const pubkey = '00'.repeat(32);
+        const npub = nip19.npubEncode(pubkey);
+        const input = `nostr:${npub}`;
+        const out = await drain(parseNote(input, CALLER_CONFIG));
+        // The attacker's <img> tag must NOT appear as a live tag in output.
+        expect(out).not.toMatch(/<img\b/i);
+        expect(out).not.toMatch(/onerror=/i);
+        // Visible-text form (entity-encoded) is acceptable. The <a> wrapper
+        // itself MAY survive — that's the legitimate replaceNip19 output.
+        // Contract: the user.name interpolation is HTML-escaped so the payload
+        // renders as visible text, not as a live <img>.
+    });
+});
+
+describe('parseNote — sanitize:false is a no-op (FEED-05)', () => {
+    it('strips <script> even when caller passes sanitize:false', async () => {
+        // Every existing caller passes `sanitize: false`. Phase 28 makes the
+        // option a no-op so the 4 callers transparently get sanitized output.
+        const out = await drain(parseNote('<script>alert(1)</script>', { sanitize: false }));
+        expect(out).not.toMatch(/<script\b/i);
+        expect(out).not.toContain('alert(1)');
+    });
+
+    it('strips <script> with explicit sanitize:true (control case)', async () => {
+        const out = await drain(parseNote('<script>alert(1)</script>', { sanitize: true }));
+        expect(out).not.toMatch(/<script\b/i);
+    });
+});
+
+describe('parseNote — markdown autolink javascript: (FEED-01 markdown path)', () => {
+    it('strips javascript: href from markdown autolink', async () => {
+        // marked produces `<a href="javascript:alert(1)">click me</a>` from
+        // `[click me](javascript:alert(1))`. DOMPurify default config strips
+        // `javascript:` from href. After Phase 28's always-on applySanitize
+        // this MUST hold for every caller config.
+        const out = await drain(parseNote('[click me](javascript:alert(1))', CALLER_CONFIG));
+        expect(out).not.toMatch(/href=["']javascript:/i);
+        expect(out).not.toMatch(/javascript:alert/i);
+    });
+});
+
+describe('parseNote — wiki content path (FEED-04)', () => {
+    it('strips <script> in markdown:false wiki path (broader WIKI_CONFIG)', async () => {
+        // Broader-shape coverage: WIKI_CONFIG spreads CALLER_CONFIG, so all
+        // image/video/nip19/etc. transforms are also enabled. Proves the
+        // applySanitize step closes <script> regardless of which sync/async
+        // transforms ran before it.
+        const payload = '<script>alert(1)</script>some wiki content';
+        const out = await drain(parseNote(payload, WIKI_CONFIG));
+        expect(out).not.toMatch(/<script\b/i);
+        expect(out).toContain('some wiki content');
+    });
+
+    it('strips <script> with literal {markdown: false} (production wiki call shape)', async () => {
+        // routes/relays/software/[softwareKey]/+page.svelte:88 calls
+        // parseNote(input, {markdown: false}) — LITERAL, no spread. All other
+        // config fields are undefined → falsy → those pipeline steps skip
+        // (no images, no videos, no nip19, no removeHashtags, no replaceAmpersand,
+        // no truncate). This test mirrors the production call shape exactly,
+        // proving the applySanitize step still runs even when every other
+        // transform is disabled. WIKI_CONFIG case above provides broader coverage.
+        const payload = '<script>alert(1)</script>some wiki content';
+        const out = await drain(parseNote(payload, { markdown: false }));
+        expect(out).not.toMatch(/<script\b/i);
+        expect(out).toContain('some wiki content');
+    });
+});
+
+// ===========================================================================
+// Positive-case describe — locks GREEN preservation contract.
+// ===========================================================================
+
+describe('parseNote — preserves valid content', () => {
+    it('renders a valid YouTube link as <iframe src=...>', async () => {
+        const out = await drain(parseNote('https://youtu.be/dQw4w9WgXcQ', CALLER_CONFIG));
+        // YouTube embed survival contract: <iframe src="https://www.youtube.com/embed/<videoId>">
+        // MUST survive DOMPurify. A loose `toContain('dQw4w9WgXcQ')` would pass
+        // whether the iframe survives, falls back to <a>, or renders as raw text —
+        // production embed could silently break and tests would still pass. We
+        // lock the contract by asserting the iframe shape with src=.
+        //
+        // GREEN constraint: applySanitize's ADD_ATTR list MUST include 'src'
+        // so DOMPurify preserves the iframe src attribute (default config
+        // strips <iframe> entirely; ADD_TAGS:['iframe'] re-allows the tag,
+        // but src is then stripped unless explicitly added to ADD_ATTR).
+        // The iframe src is locked by replaceYoutubeLink's regex
+        // (videoId = [a-zA-Z0-9_-]+) so no attacker input can reach it.
+        expect(out).toMatch(/<iframe\b[^>]*\bsrc=["']https:\/\/www\.youtube\.com\/embed\/dQw4w9WgXcQ/);
+    });
+
+    it('renders a valid nostr:nevent1... reference as <a href=njump.me>', async () => {
+        const id = 'aa'.repeat(32);
+        const author = '00'.repeat(32);
+        const nevent = nip19.neventEncode({ id, relays: [], author });
+        const out = await drain(parseNote(`nostr:${nevent}`, CALLER_CONFIG));
+        expect(out).toContain('njump.me/nevent1');
+        expect(out).toContain('View Attached Event');
+    });
+});
+
+// ===========================================================================
+// Sanity describes — pass at HEAD; document the contracts.
+// ===========================================================================
+
+describe('parseNote — pipeline composition contract (sanity)', () => {
+    it('returns a Writable<string> store synchronously', () => {
+        const store = parseNote('hi', CALLER_CONFIG);
+        expect(typeof (store as unknown as { subscribe: unknown }).subscribe).toBe('function');
+    });
+
+    it('initial store value is the raw input synchronously', () => {
+        // Phase 28 must preserve the synchronous initial value — callers
+        // (FeedNote.svelte etc.) bind to the store and rely on the first emit
+        // being the raw input. After applySync runs, the value is updated;
+        // after the async pipeline drains, the final value is sanitized.
+        const store = parseNote('hi', CALLER_CONFIG);
+        // Subscribe synchronously — first callback fires with current value.
+        let first: string | undefined;
+        const unsub = store.subscribe((v) => {
+            if (first === undefined) first = v;
+        });
+        unsub();
+        expect(first).toBe('hi');
+    });
+});

--- a/apps/gui/src/lib/utils/notes.ts
+++ b/apps/gui/src/lib/utils/notes.ts
@@ -1,13 +1,63 @@
-import { marked, type MarkedOptions } from "marked";
+import { marked, type MarkedOptions } from 'marked';
 import * as DOMPurify from 'dompurify';
-import { writable, type Writable } from 'svelte/store';
-import { nip19 } from "nostr-tools";
-import { get } from 'svelte/store';
-import type { UserService } from "$lib/services/UserService";
+import { writable, get, type Writable } from 'svelte/store';
+import { nip19 } from 'nostr-tools';
+import type { UserService } from '$lib/services/UserService';
 import { userService } from '$lib/stores/services.js';
+import { escapeHtml, safeImageUrl } from '$lib/utils/sanitize';
+
+/**
+ * Nostr event content parser — sequential async pipeline with always-on
+ * DOMPurify at the LAST step. Closes FEED-01..05 from v2.5 GUI XSS Hardening.
+ *
+ * # Security contract
+ *
+ * Every async transform runs in order; each transform's output feeds the
+ * next. applySanitize is the LAST async step and runs UNCONDITIONALLY —
+ * the `config.sanitize` field is preserved for back-compat with the 4
+ * caller files (FeedNoteContent, FeedNote, FeedMasonryNote, Reader) that
+ * literally pass `sanitize: false`, but the field is now a NO-OP and the
+ * applySanitize step always appends. Stripping the option from the 4
+ * callers is a Phase 29 AUDIT-01 cosmetic follow-up.
+ *
+ * Belt-and-suspenders per-step hardening:
+ *   - parseImages / parseVideos: every matched URL passes through
+ *     safeImageUrl (Phase 24); rejected URLs are REMOVED from the text;
+ *     URL regex tightened from `\S+` to `[^\s"'<>]+` (defense-in-depth
+ *     above safeImageUrl). Closes FEED-02.
+ *   - replaceNip19: user.name passes through escapeHtml before
+ *     interpolation; encoded npub/nevent etc. also pass through escapeHtml
+ *     in href positions (paranoid consistency — bech32 chars are
+ *     [a-z0-9] so already safe). Closes FEED-03.
+ *   - applyMarkdown: marked output flows into the final applySanitize
+ *     step; no special-casing.
+ *   - applySanitize: DOMPurify.sanitize(text) — strips <script>,
+ *     event handlers, javascript: URLs, etc. Closes FEED-01 / FEED-04 /
+ *     FEED-05.
+ *
+ * # YouTube iframe survival
+ *
+ * DOMPurify's default config strips <iframe>. replaceYoutubeLink emits an
+ * <iframe> shape; we extend ALLOWED_TAGS at the applySanitize step to
+ * preserve YouTube embeds. The src attribute is locked by the
+ * replaceYoutubeLink regex (videoId = `[a-zA-Z0-9_-]+`) so no attacker
+ * input can reach the iframe.
+ *
+ * # Pipeline order (CONTEXT.md locked decision)
+ *
+ *   parseImages (sync)          [safeImageUrl-validated]
+ *   -> parseVideos (sync)       [safeImageUrl-validated]
+ *   -> removeHashtags (sync)
+ *   -> truncate (sync, optional)
+ *   -> replaceAmpersand (sync)
+ *   -> replaceYoutubeLink (sync)
+ *   -> replaceNip19 (async)     [escapeHtml-wrapped user.name]
+ *   -> applyMarkdown (async)    [marked]
+ *   -> applySanitize (async, ALWAYS-ON, LAST)  [DOMPurify]
+ */
 
 type SyncTransform = (input: string) => string;
-type AsyncTransform = (input: string, update: (output: string) => void) => Promise<void>;
+type AsyncTransform = (input: string) => Promise<string>;
 
 export type ParseConfig = {
   removeHashtags?: boolean;
@@ -18,9 +68,16 @@ export type ParseConfig = {
   videos?: boolean;
   truncate?: boolean;
   truncateLength?: number;
+  /**
+   * @deprecated Phase 28 (v2.5 GUI XSS Hardening) made this field a no-op.
+   * applySanitize always runs as the final pipeline step regardless of
+   * this value. Field preserved for back-compat with the 4 caller files
+   * that literally pass `sanitize: false`. A future cleanup phase
+   * (Phase 29 AUDIT-01) may strip the field entirely.
+   */
   sanitize?: boolean;
   replaceAmpersand?: boolean;
-}
+};
 
 const defaultConfig: ParseConfig = {
   removeHashtags: true,
@@ -35,6 +92,14 @@ const defaultConfig: ParseConfig = {
   replaceAmpersand: true,
 };
 
+/**
+ * Sequential pipeline. Each async transform receives the prior transform's
+ * output as input and returns the next text-state Promise. The previous
+ * `Parser.applyAsync` ran every transform on the SAME input in parallel —
+ * a race where the final store value was whichever callback fired last.
+ * That bug is the structural reason DOMPurify never saw the markdown output
+ * even when sanitize:true was set. Fixed here.
+ */
 class Parser {
   private syncTransforms: SyncTransform[] = [];
   private asyncTransforms: AsyncTransform[] = [];
@@ -51,28 +116,68 @@ class Parser {
     return this.syncTransforms.reduce((acc, transform) => transform(acc), input);
   }
 
-  applyAsync(input: string, update: (output: string) => void): void {
-    this.asyncTransforms.forEach(transform => {
-      transform(input, update).catch(err => console.error('Async transform error:', err));
-    });
+  async applyAsyncSequential(input: string): Promise<string> {
+    let current = input;
+    for (const transform of this.asyncTransforms) {
+      try {
+        current = await transform(current);
+      } catch (err) {
+        console.error('Async transform error:', err);
+        // Fail-closed: keep the prior text-state. The applySanitize
+        // step at the end still runs, so a thrown earlier transform
+        // cannot leak un-sanitized HTML.
+      }
+    }
+    return current;
   }
 }
-
 
 function removeHashtags(input: string): string {
   return input.replace(/#[\w\-]+/g, '');
 }
 
+/**
+ * FEED-02: parseImages with safeImageUrl validation.
+ *
+ * Regex tightened from `\S+` to `[^\s"'<>]+` — defense-in-depth so the
+ * captured URL cannot contain attribute-breakout chars even before
+ * safeImageUrl runs. safeImageUrl additionally rejects the same set
+ * (and protocol-disallowlisted schemes), returning '' on reject.
+ *
+ * Rejected URLs are REMOVED from the text (per CONTEXT.md decision —
+ * cleaner UX than leaving a malformed URL as visible text).
+ */
 function parseImages(text: string): string {
-  return text.replace(/https?:\/\/\S+\.(png|gif|jpg|jpeg|webp|svg|bmp)\b/gi, (match) => `<img src="${match}" alt="Image" class="my-2" />`);
+  return text.replace(
+    /https?:\/\/[^\s"'<>]+\.(png|gif|jpg|jpeg|webp|svg|bmp)\b/gi,
+    (match) => {
+      const safe = safeImageUrl(match);
+      if (!safe) return ''; // Reject -> remove from text.
+      return `<img src="${safe}" alt="Image" class="my-2" />`;
+    },
+  );
 }
 
+/**
+ * FEED-02: parseVideos with safeImageUrl validation.
+ *
+ * Same shape as parseImages. safeImageUrl is the right helper for video
+ * src too — the allowlist (http(s):// or data:image/) excludes
+ * data:video/mp4 (rare, and we'd rather not allow it without an explicit
+ * helper). CONTEXT.md decides "use safeImageUrl for both; revisit if a
+ * future phase needs a safeMediaUrl with video-specific schemes."
+ */
 function parseVideos(text: string): string {
   let videoHTML = '';
-  const updatedText = text.replace(/https?:\/\/\S+\.mp4\b/gi, (match) => {
-    videoHTML += `<video controls src="${match}" type="video/mp4">Your browser does not support the video tag.</video><br>`;
-    return '';
-  });
+  const updatedText = text.replace(
+    /https?:\/\/[^\s"'<>]+\.mp4\b/gi,
+    (match) => {
+      const safe = safeImageUrl(match);
+      if (!safe) return ''; // Reject -> remove (do NOT emit raw URL as text).
+      videoHTML += `<video controls src="${safe}" type="video/mp4">Your browser does not support the video tag.</video><br>`;
+      return '';
+    },
+  );
   return videoHTML + updatedText;
 }
 
@@ -83,148 +188,160 @@ function truncateText(str: string, max: number = 10): string {
 }
 
 function replaceAmpersand(text: string): string {
+  // Out of scope per CONTEXT.md (dead-ish code; future cleanup).
   return text.replace(/&;/g, `'`);
 }
 
-function hasNip19(text: string): boolean {
-  const NIP19_REGEX = /nostr:(nevent|nprofile|naddr|nrelay|npub|note)[\w\d]+/gi;
-  return NIP19_REGEX.test(text);
-}
-
 function replaceYoutubeLink(text: string): string {
-    const youtubeRegex = /(https?:\/\/(?:www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]+))/g;
-
-    if (!youtubeRegex.test(text)) {
-        return text;
-    }
-
-    return text.replace(youtubeRegex, (match, url, domain, videoId) => {
-        return `<iframe 
-                    width="100%" 
-                    height="auto" 
-                    src="https://www.youtube.com/embed/${videoId}" 
-                    frameborder="0" 
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
-                    allowfullscreen>
-                </iframe>`;
-    });
+  const youtubeRegex = /(https?:\/\/(?:www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]+))/g;
+  if (!youtubeRegex.test(text)) return text;
+  // videoId is restricted to [a-zA-Z0-9_-]+ at the regex level — safe by
+  // construction. Still passes through DOMPurify at the final step (which
+  // is configured to allow <iframe> with a tight attribute allowlist).
+  return text.replace(youtubeRegex, (_match, _url, _domain, videoId) => {
+    return `<iframe width="100%" height="auto" src="https://www.youtube.com/embed/${videoId}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`;
+  });
 }
 
-
-async function replaceNip19(text: string, update: (output: string) => void): Promise<void> {
+/**
+ * FEED-03: replaceNip19 with escapeHtml-wrapped user.name.
+ *
+ * The npub branch reads kind:0 metadata via UserService. user.name is
+ * attacker-controlled (any kind:0 publisher on wss://purplepag.es /
+ * wss://user.kindpag.es). Wrap through escapeHtml before interpolating
+ * into the <a> text position.
+ *
+ * encoded (the bech32 string) is also wrapped in escapeHtml in href
+ * positions for paranoid consistency — bech32 chars are [a-z0-9] so
+ * the helper is a no-op in practice; the wrap protects against a
+ * future regression in the bech32 encoder.
+ */
+async function replaceNip19(text: string): Promise<string> {
   try {
     const NIP19_REGEX = /nostr:(nevent|nprofile|naddr|nrelay|npub|note)[\w\d]+/gi;
     const matches = [...text.matchAll(NIP19_REGEX)];
-    if (matches.length === 0) return;
+    if (matches.length === 0) return text;
 
-    const replacements = await Promise.all(matches.map(async (m) => {
-      const original = m[0];
-      let replacement = original;
-      try {
-        
-        const encoded = original.replace('nostr:', '');
-        const { type, data } = nip19.decode(encoded);
-        const classes = "inline-block px-2 py-1 rounded-sm bg-black/20 text-white/70 hover:text-white/80 hover:bg-black/10"
+    const replacements = await Promise.all(
+      matches.map(async (m) => {
+        const original = m[0];
+        let replacement = original;
+        try {
+          const encoded = original.replace('nostr:', '');
+          const safeEncoded = escapeHtml(encoded); // Paranoid wrap.
+          const { type, data } = nip19.decode(encoded);
+          const classes =
+            'inline-block px-2 py-1 rounded-sm bg-black/20 text-white/70 hover:text-white/80 hover:bg-black/10';
 
-        if (type === 'npub') {
-          const service: UserService | null = get(userService);
-          if (!service) {
-            return { original, replacement: encoded };
+          if (type === 'npub') {
+            const service: UserService | null = get(userService);
+            if (!service) {
+              return { original, replacement: encoded };
+            }
+            const user = service.userFromPubkey(data as string);
+            await user.ready();
+            // FEED-03 LIVE FIX: escape attacker-controlled user.name
+            // before interpolating into the <a> text position.
+            const safeName = escapeHtml(user.name ?? '');
+            replacement = `<a href="https://njump.me/${safeEncoded}" class="${classes}">${safeName}</a>`;
+          } else if (type === 'nevent') {
+            replacement = `<a href="https://njump.me/${safeEncoded}" class="${classes} block mt-3">View Attached Event</a>`;
+          } else if (type === 'naddr') {
+            replacement = `<a href="https://njump.me/${safeEncoded}" class="${classes} block mt-3">View Attached Event</a>`;
+          } else if (type === 'nprofile') {
+            replacement = `<a href="https://njump.me/${safeEncoded}" class="${classes} block mt-3">View Attached Profile</a>`;
+          } else if (type === 'note') {
+            replacement = `<a href="https://njump.me/${safeEncoded}" class="${classes} block mt-3">View Attached Note</a>`;
           }
-          const user = service.userFromPubkey(data);
-          await user.ready();
-          replacement = `<a href="https://njump.me/${encoded}" class="${classes}">${user.name}</a>`;
-        } else if (type === 'nevent') {
-          replacement = `<a href="https://njump.me/${encoded}" class="${classes} block mt-3">View Attached Event</a>`;
-        } else if (type === 'naddr') {
-          replacement = `<a href="https://njump.me/${encoded}" class="${classes} block mt-3">View Attached Event</a>`;
-        } else if (type === 'nprofile') {
-          replacement = `<a href="https://njump.me/${encoded}" class="${classes} block mt-3">View Attached Profile</a>`;
-        } else if (type === 'note'){
-          replacement = `<a href="https://njump.me/${encoded}" class="${classes} block mt-3">View Attached Note</a>`;
+        } catch (e) {
+          console.error('Error in replaceNip19:', e);
         }
-      }
-      catch(e){
-        console.error('Error in replaceNip19:', e);
-      }
+        return { original, replacement };
+      }),
+    );
 
-      ////console.log('nip19', { original, replacement });
-
-      return { original, replacement };
-    }));
-
-    replacements.forEach(({ original, replacement }) => {
-      ////console.log("Replacing:", original, "with:", replacement);
-      text = text.replace(original, replacement);
-    });
-
-    update(text);
-  } catch(e: any){
+    let out = text;
+    for (const { original, replacement } of replacements) {
+      out = out.replace(original, replacement);
+    }
+    return out;
+  } catch (e: unknown) {
     console.error('Error in replaceNip19:', e);
+    return text;
   }
 }
 
-
-async function applyMarkdown(text: string, update: (output: string) => void, options: MarkedOptions): Promise<void> {
+async function applyMarkdown(text: string, options: MarkedOptions): Promise<string> {
   const html = await marked(text, options);
-  update(html);
+  return typeof html === 'string' ? html : String(html);
 }
 
-function applySanitize(text: string, update: (output: string) => void): void {
-  const sanitized = DOMPurify.sanitize(text);
-  update(sanitized);
+/**
+ * FEED-01 / FEED-04 / FEED-05: applySanitize is the FINAL async step
+ * and runs UNCONDITIONALLY. DOMPurify's default config strips <script>,
+ * event handlers (onerror, onclick, ...), and javascript: / data:text/html
+ * URLs from href / src.
+ *
+ * <iframe> survival: ADD_TAGS includes 'iframe' so replaceYoutubeLink's
+ * embed survives. ADD_ATTR includes 'src' (in addition to 'allow',
+ * 'allowfullscreen', 'frameborder', 'scrolling') so DOMPurify preserves
+ * the src attribute on the iframe — without it, DOMPurify allows the
+ * <iframe> tag but strips src, breaking the embed. The iframe src is
+ * locked by replaceYoutubeLink's regex (videoId = [a-zA-Z0-9_-]+) so no
+ * attacker input can reach the iframe. ALLOW_TAGS is NOT used (would
+ * replace the default allowlist); ADD_TAGS / ADD_ATTR extend it.
+ */
+function applySanitize(text: string): string {
+  // DOMPurify's CommonJS shape: in some bundler setups DOMPurify is the
+  // default export; in others it's the module namespace. The current
+  // codebase uses `import * as DOMPurify` — the .sanitize is on the
+  // namespace OR on .default depending on bundler. Defensive lookup.
+  const purify =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (DOMPurify as any).sanitize ?? (DOMPurify as any).default?.sanitize;
+  return purify(text, {
+    ADD_TAGS: ['iframe'],
+    ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder', 'scrolling', 'src'],
+  });
 }
 
 export function parseNote(input: string, config: ParseConfig = defaultConfig): Writable<string> {
   const store = writable<string>(input);
-
   const parser = new Parser();
 
-  if (config.images) {
-    parser.addSync(parseImages);
-  }
-
-  if (config.videos) {
-    parser.addSync(parseVideos);
-  }
-
-  if (config.removeHashtags) {
-    parser.addSync(removeHashtags);
-  }
-
-  if (config.truncate) {
-    parser.addSync((input: string) => truncateText(input, config.truncateLength!));
-  }
-
-  if (config.replaceAmpersand) {
-    parser.addSync(replaceAmpersand);
-  }
-
+  // ---- Sync stage (in CONTEXT.md-locked order) ----
+  if (config.images) parser.addSync(parseImages);
+  if (config.videos) parser.addSync(parseVideos);
+  if (config.removeHashtags) parser.addSync(removeHashtags);
+  if (config.truncate) parser.addSync((s: string) => truncateText(s, config.truncateLength!));
+  if (config.replaceAmpersand) parser.addSync(replaceAmpersand);
   parser.addSync(replaceYoutubeLink);
 
-  let content = parser.applySync(input);
-  store.set(content);
+  const syncOut = parser.applySync(input);
+  store.set(syncOut);
 
+  // ---- Async stage (sequential composition) ----
   if (config.nip19) {
     parser.addAsync(replaceNip19);
   }
-
-  if (config.sanitize) {
-    parser.addAsync((text: string, update: (output: string) => void) => {
-      applySanitize(text, update);
-      return Promise.resolve();
-    });
-  }
-
   if (config.markdown) {
-    parser.addAsync(async (text: string, update: (output: string) => void) => {
-      await applyMarkdown(text, update, config.markdownOptions!);
-    });
+    parser.addAsync((text: string) => applyMarkdown(text, config.markdownOptions ?? {}));
   }
 
-  parser.applyAsync(content, (updatedContent) => {
-    store.set(updatedContent);
-  });
+  // FEED-05: applySanitize ALWAYS runs as the LAST async step. The
+  // config.sanitize field is preserved for back-compat (the 4 callers
+  // literally pass `sanitize: false`) but it is now a no-op — the
+  // pipeline always appends applySanitize.
+  parser.addAsync(async (text: string) => applySanitize(text));
+
+  // Drain the sequential pipeline; emit on the writable store.
+  parser
+    .applyAsyncSequential(syncOut)
+    .then((finalText) => store.set(finalText))
+    .catch((err) => {
+      console.error('parseNote pipeline error:', err);
+      // Fail-closed: leave store at last-good (the sync output).
+    });
 
   return store;
 }

--- a/apps/gui/src/lib/utils/sanitize.test.ts
+++ b/apps/gui/src/lib/utils/sanitize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { escapeHtml, safeImageUrl } from './sanitize';
+import { escapeHtml, safeImageUrl, safeHttpUrl } from './sanitize';
 
 describe('escapeHtml', () => {
     it('escapes <script> tags', () => {
@@ -137,5 +137,122 @@ describe('safeImageUrl', () => {
     it('rejects URLs containing < or >', () => {
         expect(safeImageUrl('https://x.com/<script>')).toBe('');
         expect(safeImageUrl('https://x.com/>foo')).toBe('');
+    });
+
+    it('rejects the canonical CSS-context single-quote breakout payload', () => {
+        // Payload shape from Phase 24 CONTEXT: x'); position:fixed; top:0; ...; url('y
+        // If interpolated raw into style="background: url('${...}')", an unguarded ' closes
+        // the url() and injects new declarations.
+        const payload =
+            "x'); position:fixed; top:0; left:0; width:100vw; height:100vh; background:url('y";
+        expect(safeImageUrl(payload)).toBe('');
+    });
+});
+
+describe('safeHttpUrl', () => {
+    // --- Positive cases ---
+    it('accepts a valid https URL', () => {
+        expect(safeHttpUrl('https://example.com/page')).toBe(
+            'https://example.com/page'
+        );
+    });
+
+    it('accepts a valid http URL', () => {
+        expect(safeHttpUrl('http://example.com/page')).toBe(
+            'http://example.com/page'
+        );
+    });
+
+    it('encodes ampersands in query strings', () => {
+        expect(safeHttpUrl('https://example.com/p?a=1&b=2')).toBe(
+            'https://example.com/p?a=1&amp;b=2'
+        );
+    });
+
+    // --- Scheme-rejection cases (URL-01: HTTP/HTTPS-only allowlist) ---
+    it('rejects javascript: URLs', () => {
+        expect(safeHttpUrl('javascript:alert(1)')).toBe('');
+    });
+
+    it('rejects data: URLs (any subtype)', () => {
+        expect(safeHttpUrl('data:text/html,<script>alert(1)</script>')).toBe('');
+        expect(safeHttpUrl('data:image/png;base64,iVBORw0KGgo')).toBe('');
+    });
+
+    it('rejects vbscript: URLs', () => {
+        expect(safeHttpUrl('vbscript:msgbox')).toBe('');
+    });
+
+    it('rejects file: URLs', () => {
+        expect(safeHttpUrl('file:///etc/passwd')).toBe('');
+    });
+
+    it('rejects mailto: URLs', () => {
+        expect(safeHttpUrl('mailto:a@b.com')).toBe('');
+    });
+
+    it('rejects tel: URLs', () => {
+        expect(safeHttpUrl('tel:+15551234')).toBe('');
+    });
+
+    it('rejects protocol-relative URLs', () => {
+        expect(safeHttpUrl('//example.com/page')).toBe('');
+    });
+
+    it('rejects bare strings without scheme', () => {
+        expect(safeHttpUrl('example.com/page')).toBe('');
+        expect(safeHttpUrl('not a url')).toBe('');
+    });
+
+    // --- Attribute-breakout cases (URL-01: shared breakout char set) ---
+    it('rejects the canonical attack payload (double-quote breakout)', () => {
+        expect(safeHttpUrl('http://x" onerror="alert(1)" x="')).toBe('');
+    });
+
+    it('rejects a single-quote breakout payload', () => {
+        expect(safeHttpUrl("http://x' onerror='alert(1)")).toBe('');
+    });
+
+    it('rejects URLs containing < or >', () => {
+        expect(safeHttpUrl('http://x.com/<script>')).toBe('');
+        expect(safeHttpUrl('http://x.com/>foo')).toBe('');
+    });
+
+    it('rejects URLs containing newline characters', () => {
+        expect(safeHttpUrl('https://x.com/\n<script>')).toBe('');
+        expect(safeHttpUrl('https://x.com/\rfoo')).toBe('');
+    });
+
+    it('rejects URLs containing backslashes', () => {
+        expect(safeHttpUrl('https://x.com/\\foo')).toBe('');
+    });
+
+    // --- Boundary / type cases ---
+    it('returns empty string for empty string', () => {
+        expect(safeHttpUrl('')).toBe('');
+    });
+
+    it('returns empty string for null', () => {
+        expect(safeHttpUrl(null)).toBe('');
+    });
+
+    it('returns empty string for undefined', () => {
+        expect(safeHttpUrl(undefined)).toBe('');
+    });
+
+    it('returns empty string for numeric input', () => {
+        expect(safeHttpUrl(42)).toBe('');
+    });
+
+    it('returns empty string for objects', () => {
+        expect(safeHttpUrl({})).toBe('');
+    });
+
+    // --- Anti-assertion: assert what cannot be in the output, never the unsafe shape ---
+    it('canonical breakout payload cannot break out of a double-quoted attribute', () => {
+        const out = safeHttpUrl('http://x" onerror="alert(1)" x="');
+        expect(out).not.toMatch(/onerror=/);
+        expect(out).not.toMatch(/"/);
+        expect(out).toBe(''); // current contract: reject — change this assertion only if the contract changes
     });
 });

--- a/apps/gui/src/lib/utils/sanitize.ts
+++ b/apps/gui/src/lib/utils/sanitize.ts
@@ -37,6 +37,52 @@
  * The canonical attack payload `http://x" onerror="alert(1)" x="` is
  * exercised against every URL helper and must resolve to `''`.
  *
+ * # v2.5 milestone summary
+ *
+ * The v2.5 GUI XSS Hardening milestone closed every known live XSS vector
+ * in `apps/gui`. Fixes shipped across Phases 24-28; Phase 29 is the wrap.
+ *
+ * | Phase | Requirement(s)            | Fix                                                                                                          |
+ * |-------|---------------------------|--------------------------------------------------------------------------------------------------------------|
+ * | 24    | URL-01                    | `safeHttpUrl` exported; module-private `isUrlBreakout` factored                                              |
+ * | 25    | CSS-01, CSS-02            | `bannerStyleString` helper migrated 4 banner sinks; structural test locks regression                         |
+ * | 26    | URL-02, URL-03            | `paymentsUrl` wrapped via `safeHttpUrl` in `CardFees.svelte`; HREF audit pass                                 |
+ * | 27    | CARD-01, CARD-02, CARD-03 | `CountCard.svelte` text-bind by default; CardInsights / RelayFeeItem migrated                                |
+ * | 28    | FEED-01..05               | `parseNote` always-on DOMPurify; `parseImages`/`parseVideos` URL-validated; `replaceNip19` escapes `user.name` |
+ * | 29    | TEST-04..06, AUDIT-01/02  | Adversarial-input regression sweep + cross-cutting `{@html}` walker + this dev note                          |
+ *
+ * Test canaries that lock these fixes against regression:
+ *   - `apps/gui/src/lib/utils/sanitize.test.ts`                                — 52 helper-level cases
+ *   - `apps/gui/src/lib/utils/banner-style-structural.test.ts`                 — banner-sink walker
+ *   - `apps/gui/src/lib/utils/style-helpers.test.ts`                           — bannerStyleString unit tests
+ *   - `apps/gui/src/routes/relays/.../CardFees.test.ts`                        — paymentsUrl regression
+ *   - `apps/gui/src/routes/(components)/CountCard.test.ts`                     — CountCard structural
+ *   - `apps/gui/src/lib/utils/notes.test.ts`                                   — parseNote / parseImages / replaceNip19
+ *   - `apps/gui/src/lib/utils/v2.5-xss-smoke.test.ts`                          — milestone canary (one assertion per attack vector)
+ *   - `apps/gui/src/lib/utils/html-sink-audit.test.ts`                         — cross-cutting `{@html}` walker
+ *   - `apps/gui/src/lib/utils/cardinsights-relayfeeitem-adversarial.test.ts`   — function-level CARD-02/03 smoke
+ *
+ * # Deferred AUDIT-01 (formatter migration)
+ *
+ * AUDIT-01 — replace the HTML-string formatters in
+ * `apps/gui/src/lib/config/dataTable/*.ts` with Svelte components and drop
+ * `{@html}` from `DataTable.svelte` and `PageHeader.svelte` — is FORMALLY
+ * DEFERRED to v2.6+. v2.5 closed every live vector via encode-on-output
+ * discipline; the dataTable formatters are encode-on-output safe today
+ * (verified by #899/#900 tests + the html-sink-audit canary). Migration to
+ * Svelte components is a larger refactor (5+ formatter files, hundreds of
+ * HTML-string emissions per file, plus DataTable / PageHeader internals);
+ * the right time is when there's a separate UI/styling milestone that
+ * touches DataTable anyway.
+ *
+ * The deferral is recorded in `.planning/PROJECT.md` Key Decisions:
+ *   "Defer AUDIT-01 (formatter migration to Svelte components) to v2.6+"
+ *
+ * When AUDIT-01 lands, this entire `sanitize.ts` module can be deleted.
+ * Until then, the cross-cutting `{@html}` walker (html-sink-audit.test.ts)
+ * is the canary that catches new sinks added without going through one
+ * of these helpers.
+ *
  * # Module exports
  *
  *   - `escapeHtml`     — entity-encodes a string for safe interpolation into
@@ -55,10 +101,9 @@
  * Use these helpers at every {@html} sink that interpolates relay-controlled
  * data. The intent is encode-on-output at the formatter, not at the data layer.
  *
- * FOLLOW-UP (out of scope here): replace the HTML-string formatters in
- * `apps/gui/src/lib/config/dataTable/*.ts` with Svelte components and remove
- * `{@html ...}` from `DataTable.svelte` and `PageHeader.svelte`. Once that
- * lands, this module can be deleted.
+ * FOLLOW-UP: see "# Deferred AUDIT-01 (formatter migration)" above and
+ * the corresponding row in `.planning/PROJECT.md` Key Decisions. Once
+ * AUDIT-01 lands in v2.6+, this entire module can be deleted.
  */
 
 // Module-private: single source of truth for the URL/CSS attribute breakout

--- a/apps/gui/src/lib/utils/sanitize.ts
+++ b/apps/gui/src/lib/utils/sanitize.ts
@@ -1,20 +1,56 @@
 /**
- * Encode-on-output mitigation for relay-controlled NIP-11 / kind-0 fields.
+ * Encode-on-output mitigation for relay-controlled NIP-11 / kind-0 / kind-1 fields.
+ *
+ * # Trust boundary
+ *
+ * Data crosses the trust boundary into the GUI render whenever a NIP-11 field,
+ * kind:0 metadata field, kind:1 note content, or any other relay-controlled
+ * string reaches a Svelte template. Encode at the sink, not at the data layer.
  *
  * The DataTable layer renders cell contents via `{@html ...}` (see
  * apps/gui/src/lib/components/data-view/table/DataTable.svelte). Many of the
  * formatters in `apps/gui/src/lib/config/dataTable/*.ts` build HTML strings
  * that interpolate fields a relay operator controls (icon, banner, name,
- * description, photo, pubkey). Without escaping, a malicious relay can break
- * out of an attribute or CSS context and execute arbitrary JS.
+ * description, photo, pubkey, paymentsUrl). Without escaping, a malicious
+ * relay can break out of an attribute or CSS context and execute arbitrary JS.
  *
- * This module exports two pure helpers:
+ * # Helper-per-sink table
+ *
+ * | Sink                                        | Helper                              |
+ * |---------------------------------------------|-------------------------------------|
+ * | Element text                                | Svelte `{}` text-bind (no helper)   |
+ * | HTML attribute (alt, title, class, id, ...) | `escapeHtml`                        |
+ * | `<a href>` / `<Button href>`                | `safeHttpUrl`                       |
+ * | `<img src>`                                 | `safeImageUrl`                      |
+ * | CSS `url('…')`                              | `safeImageUrl` (dual-context)       |
+ *
+ * `safeImageUrl` is intentionally dual-context: it rejects single quotes
+ * (and the rest of `["'<>\n\r\\]`) so the same helper is safe in both
+ * `<img src="…">` and CSS `url('…')` interpolations.
+ *
+ * # Test-then-fix discipline (#899 / #900 pattern)
+ *
+ * Every change to this module follows the #899 / #900 test-then-fix pattern:
+ * the failing-test commit lands BEFORE the implementation commit. Tests
+ * assert the safe output (no `<script>`, no `onerror=`, no unescaped
+ * breakout chars, no scheme outside the allowlist) — never the unsafe shape.
+ * The canonical attack payload `http://x" onerror="alert(1)" x="` is
+ * exercised against every URL helper and must resolve to `''`.
+ *
+ * # Module exports
+ *
  *   - `escapeHtml`     — entity-encodes a string for safe interpolation into
  *                        either element-text or double-quoted-attribute
  *                        contexts.
- *   - `safeImageUrl`   — allowlists `http(s)://` and `data:image/...` URLs and
- *                        rejects any URL containing attribute/CSS breakout
- *                        characters (`"`, `'`, `<`, `>`, `\n`, `\r`, `\\`).
+ *   - `safeImageUrl`   — allowlists `http(s)://` and `data:image/...` URLs
+ *                        and rejects any URL containing attribute/CSS
+ *                        breakout characters. Safe in both `<img src="…">`
+ *                        and CSS `url('…')` contexts.
+ *   - `safeHttpUrl`    — allowlists `http://` and `https://` ONLY (no
+ *                        `data:`, no protocol-relative `//`, no
+ *                        `mailto:` / `tel:` / etc.) and rejects the same
+ *                        breakout char set as `safeImageUrl`. Use at
+ *                        `<a href>` / `<Button href>` sinks.
  *
  * Use these helpers at every {@html} sink that interpolates relay-controlled
  * data. The intent is encode-on-output at the formatter, not at the data layer.
@@ -24,6 +60,13 @@
  * `{@html ...}` from `DataTable.svelte` and `PageHeader.svelte`. Once that
  * lands, this module can be deleted.
  */
+
+// Module-private: single source of truth for the URL/CSS attribute breakout
+// character set. Both safeHttpUrl and safeImageUrl consume this so the reject
+// set never drifts between helpers.
+function isUrlBreakout(s: string): boolean {
+    return /["'<>\n\r\\]/.test(s);
+}
 
 /**
  * Escape a string for safe interpolation into HTML element-text or
@@ -51,24 +94,63 @@ export function escapeHtml(input: unknown): string {
  *   - `data:image/...`
  *
  * Reject any URL containing characters that would break out of an attribute
- * or CSS context (`"`, `'`, `<`, `>`, `\n`, `\r`, `\\`). Reject
- * `javascript:`, `vbscript:`, `file:`, `data:text/html`, etc.
+ * or CSS context (`"`, `'`, `<`, `>`, `\n`, `\r`, `\\`) — see `isUrlBreakout`.
+ * Reject `javascript:`, `vbscript:`, `file:`, `data:text/html`, etc.
  *
  * On accept: returns the URL passed through `escapeHtml(...)` so query-string
  * `&` becomes `&amp;` (safe in both attribute and CSS `url('...')` contexts;
  * modern browsers accept `&amp;` in those positions).
  *
  * On reject: returns ''. Caller decides fallback. Never throws, never logs.
+ *
+ * Safe in both `<img src="…">` and CSS `url('…')` contexts (single quotes
+ * are in the breakout reject set — see helper-per-sink table in module JSDoc).
  */
 export function safeImageUrl(input: unknown): string {
     if (typeof input !== 'string' || input.length === 0) return '';
     // Reject any breakout characters before any other check.
-    if (/["'<>\n\r\\]/.test(input)) return '';
+    if (isUrlBreakout(input)) return '';
     // Allowlist: http://, https://, or data:image/...
     const isHttp = /^https?:\/\//i.test(input);
     const isDataImage = /^data:image\//i.test(input);
     if (!isHttp && !isDataImage) return '';
     // Encode entities (notably & in query strings) so the value is safe in
     // both `src=""` attribute context and CSS `url('...')` context.
+    return escapeHtml(input);
+}
+
+/**
+ * Validate and entity-encode an `http(s)` URL for safe interpolation into an
+ * HTML `href=""` attribute (typical sinks: `<a href>`, `<Button href>`).
+ *
+ * Allowlist:
+ *   - `http://...`
+ *   - `https://...`
+ *
+ * Rejects every other scheme — `javascript:`, `data:` (any subtype, including
+ * `data:image/`), `vbscript:`, `file:`, `mailto:`, `tel:`, protocol-relative
+ * `//...`, and bare strings without a scheme. `data:image/` is `safeImageUrl`'s
+ * job, not this helper's; this is `<a href>`-shaped.
+ *
+ * Reject any URL containing characters that would break out of an attribute
+ * context (`"`, `'`, `<`, `>`, `\n`, `\r`, `\\`) — same set as `safeImageUrl`,
+ * via the shared module-private `isUrlBreakout` helper.
+ *
+ * On accept: returns the URL passed through `escapeHtml(...)` so query-string
+ * `&` becomes `&amp;`, matching `safeImageUrl`'s shape for consistency.
+ *
+ * On reject: returns ''. Caller decides fallback (typical pattern:
+ * `safeHttpUrl(x) || ''` or `safeHttpUrl(x) || fallback`). Never throws,
+ * never logs.
+ */
+export function safeHttpUrl(input: unknown): string {
+    if (typeof input !== 'string' || input.length === 0) return '';
+    // Reject any breakout characters before any other check.
+    if (isUrlBreakout(input)) return '';
+    // Allowlist: http:// or https:// ONLY. No data:, no protocol-relative //,
+    // no mailto:, no tel:, no file:, no javascript:, no vbscript:.
+    if (!/^https?:\/\//i.test(input)) return '';
+    // Encode entities (notably & in query strings) so the value is safe in
+    // a double-quoted href="" attribute context.
     return escapeHtml(input);
 }

--- a/apps/gui/src/lib/utils/style-helpers.test.ts
+++ b/apps/gui/src/lib/utils/style-helpers.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { bannerStyleString } from './style-helpers';
+
+describe('bannerStyleString', () => {
+    // -------------------------------------------------------------------------
+    // Happy-path acceptance — dark variant (default)
+    // -------------------------------------------------------------------------
+
+    it('returns the dark gradient + url() string for a valid http banner', () => {
+        const out = bannerStyleString('https://example.com/banner.png');
+        expect(out).toContain("url('https://example.com/banner.png')");
+        expect(out).toContain('linear-gradient(rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.8))');
+        expect(out).toContain('background-repeat: no-repeat');
+        expect(out).toContain('background-size: cover');
+    });
+
+    it('returns the dark gradient + url() string for a valid https banner', () => {
+        const out = bannerStyleString('https://example.com/x.jpg', { darkMode: true });
+        expect(out).toContain("url('https://example.com/x.jpg')");
+        expect(out).toContain('rgba(0, 0, 0, 0.8)');
+    });
+
+    // -------------------------------------------------------------------------
+    // Happy-path acceptance — light variant
+    // -------------------------------------------------------------------------
+
+    it('returns the light gradient when darkMode is false', () => {
+        const out = bannerStyleString('https://example.com/x.png', { darkMode: false });
+        expect(out).toContain(
+            'linear-gradient(rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.8))'
+        );
+        expect(out).toContain("url('https://example.com/x.png')");
+        expect(out).not.toContain('rgba(0, 0, 0,');
+    });
+
+    // -------------------------------------------------------------------------
+    // Opacity prop (PageHeader bgOpacity pattern)
+    // -------------------------------------------------------------------------
+
+    it('honors the opacity option in the dark gradient', () => {
+        const out = bannerStyleString('https://x.com/b.png', { opacity: 0.2 });
+        expect(out).toContain('linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2))');
+    });
+
+    it('honors the opacity option in the light gradient', () => {
+        const out = bannerStyleString('https://x.com/b.png', { darkMode: false, opacity: 0.5 });
+        expect(out).toContain(
+            'linear-gradient(rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.5))'
+        );
+    });
+
+    it('defaults opacity to 0.8 when option omitted', () => {
+        const out = bannerStyleString('https://x.com/b.png');
+        expect(out).toContain('rgba(0, 0, 0, 0.8)');
+    });
+
+    // -------------------------------------------------------------------------
+    // Ampersand encoding pass-through (delegates to safeImageUrl which delegates
+    // to escapeHtml)
+    // -------------------------------------------------------------------------
+
+    it('encodes ampersands in banner query strings via safeImageUrl', () => {
+        const out = bannerStyleString('https://example.com/b.png?a=1&b=2');
+        expect(out).toContain("url('https://example.com/b.png?a=1&amp;b=2')");
+    });
+
+    // -------------------------------------------------------------------------
+    // CSS-context breakout regression (CSS-02 — canonical payload from CONTEXT)
+    // -------------------------------------------------------------------------
+
+    it('rejects the canonical CSS-context single-quote breakout payload (CSS-02)', () => {
+        const payload =
+            "x'); position:fixed; top:0; left:0; width:100vw; height:100vh; background:url('y";
+        expect(bannerStyleString(payload)).toBe('');
+    });
+
+    it('returns empty (no style) when banner contains a single quote', () => {
+        expect(bannerStyleString("https://x.com/b'.png")).toBe('');
+    });
+
+    it('returns empty when banner contains a double quote', () => {
+        expect(bannerStyleString('https://x.com/b".png')).toBe('');
+    });
+
+    // -------------------------------------------------------------------------
+    // Scheme rejection (delegated to safeImageUrl)
+    // -------------------------------------------------------------------------
+
+    it('rejects javascript: schemes', () => {
+        expect(bannerStyleString('javascript:alert(1)')).toBe('');
+    });
+
+    it('rejects data:text/html (non-image data: subtypes)', () => {
+        expect(bannerStyleString('data:text/html,<script>alert(1)</script>')).toBe('');
+    });
+
+    it('accepts data:image/ subtypes', () => {
+        const out = bannerStyleString('data:image/png;base64,iVBORw0KGgo');
+        expect(out).toContain("url('data:image/png;base64,iVBORw0KGgo')");
+    });
+
+    it('rejects file: URLs', () => {
+        expect(bannerStyleString('file:///etc/passwd')).toBe('');
+    });
+
+    it('rejects vbscript: URLs', () => {
+        expect(bannerStyleString('vbscript:msgbox')).toBe('');
+    });
+
+    // -------------------------------------------------------------------------
+    // Boundary / type cases
+    // -------------------------------------------------------------------------
+
+    it('returns empty for empty string', () => {
+        expect(bannerStyleString('')).toBe('');
+    });
+
+    it('returns empty for null', () => {
+        expect(bannerStyleString(null)).toBe('');
+    });
+
+    it('returns empty for undefined', () => {
+        expect(bannerStyleString(undefined)).toBe('');
+    });
+
+    it('returns empty for numeric input', () => {
+        expect(bannerStyleString(42)).toBe('');
+    });
+
+    it('returns empty for objects', () => {
+        expect(bannerStyleString({})).toBe('');
+    });
+
+    // -------------------------------------------------------------------------
+    // Anti-assertion (CSS-02 / ROADMAP success criterion 2)
+    // -------------------------------------------------------------------------
+
+    it('rejected payloads cannot inject position/top/left/width/height declarations', () => {
+        const payload =
+            "x'); position:fixed; top:0; left:0; width:100vw; height:100vh; background:url('y";
+        const out = bannerStyleString(payload);
+        expect(out).not.toMatch(/position:/);
+        expect(out).not.toMatch(/top:/);
+        expect(out).not.toMatch(/left:/);
+        expect(out).not.toMatch(/width:/);
+        expect(out).not.toMatch(/height:/);
+        expect(out).toBe('');
+    });
+
+    it('accepted banners produce exactly one url(...) declaration', () => {
+        const out = bannerStyleString('https://example.com/b.png');
+        const matches = out.match(/url\(/g) ?? [];
+        expect(matches.length).toBe(1);
+    });
+});

--- a/apps/gui/src/lib/utils/style-helpers.ts
+++ b/apps/gui/src/lib/utils/style-helpers.ts
@@ -1,0 +1,52 @@
+/**
+ * CSS style-string helpers for banner-URL sinks.
+ *
+ * Centralizes the `background: linear-gradient(...), url('...'); ...` template
+ * shared by PageHeader, the two DataTable variants, and CardOperator. All four
+ * sinks pre-Phase-25 inlined the template literal — three of them did so without
+ * gating the relay-controlled banner through `safeImageUrl`, leaving a CSS-context
+ * single-quote breakout open. This helper closes that vector at every sink and
+ * makes regression a build-fail event (see banner-style-structural.test.ts).
+ *
+ * See apps/gui/src/lib/utils/sanitize.ts for the trust-boundary statement and
+ * helper-per-sink table; CSS `url('…')` sinks delegate to `safeImageUrl`.
+ */
+
+import { safeImageUrl } from './sanitize';
+
+export interface BannerStyleOptions {
+    /** Dark gradient overlay (rgba(0, 0, 0, ...)). Defaults to `true`. */
+    darkMode?: boolean;
+    /** Gradient opacity, 0..1. Defaults to `0.8` (matches DataTable/CardOperator sinks). */
+    opacity?: number;
+}
+
+/**
+ * Build a safe `background: linear-gradient(...), url('...'); ...` string from
+ * a relay-controlled banner URL. The banner is validated via `safeImageUrl`
+ * (which rejects `["'<>\n\r\\]` — closing the CSS-context single-quote breakout
+ * from CSS-02) before being interpolated.
+ *
+ * @param banner Relay-controlled banner URL (typically NIP-11 `banner` or kind:0
+ *               `banner`). May be any value — non-strings are rejected and
+ *               produce `''`.
+ * @param opts   `darkMode` (default `true` — dark gradient overlay) and
+ *               `opacity` (default `0.8`).
+ * @returns The full style declaration string when banner is accepted; `''` when
+ *          banner is missing, non-string, or rejected by `safeImageUrl`. Caller
+ *          binds the result directly to `style={...}` (Svelte renders `''` as
+ *          no style attribute applied).
+ */
+export function bannerStyleString(
+    banner: unknown,
+    opts: BannerStyleOptions = {}
+): string {
+    const safe = safeImageUrl(banner);
+    if (safe === '') return '';
+    const darkMode = opts.darkMode !== false; // default true
+    const opacity = typeof opts.opacity === 'number' ? opts.opacity : 0.8;
+    const overlay = darkMode
+        ? `rgba(0, 0, 0, ${opacity}), rgba(0, 0, 0, ${opacity})`
+        : `rgba(255, 255, 255, ${opacity}), rgba(255, 255, 255, ${opacity})`;
+    return `background: linear-gradient(${overlay}), url('${safe}'); background-repeat: no-repeat; background-size: cover;`;
+}

--- a/apps/gui/src/lib/utils/v2.5-xss-smoke.test.ts
+++ b/apps/gui/src/lib/utils/v2.5-xss-smoke.test.ts
@@ -1,0 +1,161 @@
+/**
+ * v2.5 GUI XSS Hardening — milestone canary.
+ *
+ * One file, one assertion per attack vector across Phases 24-28. If this
+ * test file fails, something regressed in v2.5's security posture and
+ * a future contributor should hunt down WHICH structural / behavioral
+ * fix was undone before doing anything else.
+ *
+ * Coverage map:
+ *   - Phase 24 (URL-01)        — helper-level safeHttpUrl + safeImageUrl
+ *   - Phase 25 (CSS-01/02)     — banner-sink files import bannerStyleString
+ *   - Phase 26 (URL-02/03)     — CardFees imports safeHttpUrl + no raw paymentsUrl href
+ *   - Phase 27 (CARD-01..03)   — CountCard has no {@html} on topText/bottomText/$value
+ *   - Phase 28 (FEED-01..05)   — parseNote DOMPurifies <script> + <img onerror>
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { tick } from 'svelte';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { get, writable, type Readable } from 'svelte/store';
+import { safeHttpUrl, safeImageUrl } from './sanitize';
+
+// UserService mock — see notes.test.ts:9-41 for full rationale. The .js suffix
+// is load-bearing: notes.ts:7 imports `userService` from `$lib/stores/services.js`.
+// The stub is harmless here because test case 9 below uses a payload that does
+// NOT trigger the npub branch — but mocking keeps the import resolution clean.
+vi.mock('$lib/stores/services.js', () => {
+    const stubUser = {
+        name: 'safe-name',
+        ready: () => Promise.resolve(),
+    };
+    const stubService = {
+        userFromPubkey: (_pubkey: string) => stubUser,
+    };
+    return {
+        userService: writable(stubService),
+        feedService: writable(null),
+    };
+});
+
+// notes.ts MUST be imported AFTER the vi.mock call (vitest hoists, but explicit
+// ordering documents intent — mirrors notes.test.ts:43-45).
+import { parseNote } from './notes';
+
+// apps/gui/src — resolved relative to this file (apps/gui/src/lib/utils/...)
+const APPS_GUI_SRC = resolve(__dirname, '../..');
+const COUNT_CARD_PATH = resolve(APPS_GUI_SRC, 'routes/(components)/CountCard.svelte');
+const CARD_FEES_PATH = resolve(
+    APPS_GUI_SRC,
+    'routes/relays/[protocol]/[...relay]/(components)/cards/CardFees.svelte'
+);
+const BANNER_SINK_FILES = [
+    'lib/components/data-view/table/DataTable.svelte',
+    'lib/components/lists/table/DataTable.svelte',
+    'routes/relays/[protocol]/[...relay]/(components)/cards/CardOperator.svelte',
+    'lib/components/layout/PageHeader.svelte',
+];
+
+/**
+ * Strip HTML comment blocks so structural assertions only inspect LIVE code.
+ * Mirrors Phase 26/27 helper.
+ */
+function stripHtmlComments(source: string): string {
+    return source.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+/**
+ * Drain the parseNote pipeline (mirrors notes.test.ts:55-60). The pipeline is
+ * async — wait for tick + 50ms macrotask + tick to let DOMPurify, marked, and
+ * service.ready() flush.
+ */
+async function drain<T>(store: Readable<T>): Promise<T> {
+    await tick();
+    await new Promise((r) => setTimeout(r, 50));
+    await tick();
+    return get(store);
+}
+
+describe('v2.5 XSS milestone canary', () => {
+    // -------------------------------------------------------------------------
+    // Phase 24 (URL-01) — helper-level URL allowlist
+    // -------------------------------------------------------------------------
+
+    it('safeHttpUrl rejects javascript: scheme', () => {
+        expect(safeHttpUrl('javascript:alert(1)')).toBe('');
+    });
+
+    it('safeHttpUrl rejects the canonical attribute-breakout payload', () => {
+        expect(safeHttpUrl('http://x" onerror="alert(1)" x="')).toBe('');
+    });
+
+    it('safeImageUrl rejects CSS single-quote breakout', () => {
+        expect(
+            safeImageUrl(
+                `x'); position:fixed; top:0; left:0; width:100vw; height:100vh; background:url('y`
+            )
+        ).toBe('');
+    });
+
+    it('safeImageUrl rejects javascript: scheme', () => {
+        expect(safeImageUrl('javascript:alert(1)')).toBe('');
+    });
+
+    // -------------------------------------------------------------------------
+    // Phase 27 (CARD-01..03) — CountCard structural
+    // -------------------------------------------------------------------------
+
+    it('CountCard.svelte has zero {@html topText|bottomText|$value} patterns', () => {
+        const live = stripHtmlComments(readFileSync(COUNT_CARD_PATH, 'utf8'));
+        expect(live.match(/\{@html\s+topText\b/g)).toBeNull();
+        expect(live.match(/\{@html\s+bottomText\b/g)).toBeNull();
+        expect(live.match(/\{@html\s+\$value\b/g)).toBeNull();
+    });
+
+    // -------------------------------------------------------------------------
+    // Phase 26 (URL-02/03) — CardFees imports safeHttpUrl, never binds raw paymentsUrl
+    // -------------------------------------------------------------------------
+
+    it('CardFees.svelte imports safeHttpUrl', () => {
+        const source = readFileSync(CARD_FEES_PATH, 'utf8');
+        expect(source).toMatch(
+            /import\s*\{[^}]*\bsafeHttpUrl\b[^}]*\}\s*from\s*['"]\$utils\/sanitize['"]/
+        );
+    });
+
+    it('CardFees.svelte does not bind raw paymentsUrl to href', () => {
+        const live = stripHtmlComments(readFileSync(CARD_FEES_PATH, 'utf8'));
+        // Negative anchor: raw `href={paymentsUrl}` (with optional surrounding quotes
+        // for Svelte's string-interpolation form `href="{paymentsUrl}"`) must NOT match.
+        expect(live).not.toMatch(/href\s*=\s*["']?\{paymentsUrl\}/);
+        // Positive anchor: the safe wrapper `safePaymentsUrl` MUST appear in href context.
+        // Real binding shape at CardFees.svelte:61 is `href="{safePaymentsUrl}"`.
+        expect(live).toMatch(/href\s*=\s*["']?\{safePaymentsUrl\}/);
+    });
+
+    // -------------------------------------------------------------------------
+    // Phase 25 (CSS-01/02) — banner-sink files reach bannerStyleString
+    // -------------------------------------------------------------------------
+
+    BANNER_SINK_FILES.forEach((rel) => {
+        it(`${rel} imports bannerStyleString`, () => {
+            const source = readFileSync(resolve(APPS_GUI_SRC, rel), 'utf8');
+            expect(source).toMatch(/bannerStyleString/);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Phase 28 (FEED-01..05) — parseNote always-on DOMPurify
+    // -------------------------------------------------------------------------
+
+    it('parseNote(<script>...) strips <script> + onerror handler', async () => {
+        const payload = '<script>alert(1)</script><img src=x onerror=alert(1)>';
+        const rendered = await drain(parseNote(payload));
+        // Mirror notes.test.ts:101-106 literally — DOMPurify keeps `<img src="x">`
+        // (strips the handler, keeps the element). Do NOT assert /<img\b/i missing.
+        expect(rendered).not.toMatch(/<script\b/i);
+        expect(rendered).not.toMatch(/onerror=/i);
+        expect(rendered).not.toContain('alert(1)');
+    });
+});

--- a/apps/gui/src/routes/(components)/CountCard.svelte
+++ b/apps/gui/src/routes/(components)/CountCard.svelte
@@ -4,6 +4,7 @@
 import { onMount } from "svelte";
 	import { writable, type Readable, type Writable } from "svelte/store";
 	import { fly, fade } from "svelte/transition";
+	import { safeHttpUrl } from "$utils/sanitize";
 
 	export let topText: string | undefined = undefined;
 	export let value: Readable<string | number | null>;
@@ -15,46 +16,58 @@ import { onMount } from "svelte";
     export let index: number = 0;
 	export let innerClass: string | undefined = undefined;
 
+    // Defensive wrap (CARD-01): closes a future regression vector. External
+    // URLs route through Phase 24's safeHttpUrl allowlist (http/https only,
+    // rejects javascript:/data:/breakout chars). Internal app routes
+    // (`/relays`, `/monitors`, ...) bind directly because safeHttpUrl rejects
+    // them (no scheme). The `(?!\/)` lookahead rejects protocol-relative
+    // `//evil.com` paths — those would otherwise let an attacker control the
+    // host through a leading-slash bypass.
+    $: safeLink = safeHttpUrl(link);
+    $: internalLink = (typeof link === 'string' && /^\/(?!\/)/.test(link)) ? link : '';
+
     let show: Writable<boolean> =  writable(false);
 
     onMount(() => {
         setTimeout(() => {
             show.set(true);
         }, 50*index);
-    })  
+    })
 </script>
 
 <div class="{$$restProps.class || ''} grid hp-card-wrapper">
 	<AlwaysSquare>
 	<div class="hp-card {innerClass? innerClass: 'bg-white/10 dark:bg-black/10'}">
-		
+
 		{#if $show && (($value !== null && $value !== undefined) || (display === 'donut' && donutPercent !== null && donutPercent !== undefined))}
 			<div class="content" in:fade>
                 <div in:fly={{ y: 20, duration: 300 }}>
-					{#if topText}
-                    <div class="label text-center">{@html topText}</div>
+					{#if topText || $$slots.topText}
+                    <div class="label text-center"><slot name="topText">{topText ?? ''}</slot></div>
 					{/if}
                     <div class="value text-7xl font-bold text-center">
 						{#if display === 'donut' && donutPercent !== null && donutPercent !== undefined}
 							<DonutRing percent={donutPercent} title={donutTitle} />
 						{:else}
-							{#if link}
-								<a href={link}>{@html $value}</a>
+							{#if internalLink}
+								<a href={internalLink}><slot>{$value ?? ''}</slot></a>
+							{:else if safeLink}
+								<a href={safeLink}><slot>{$value ?? ''}</slot></a>
 							{:else}
-								{@html $value}
+								<slot>{$value ?? ''}</slot>
 							{/if}
 						{/if}
-                        
+
                     </div>
-					{#if bottomText}
-                    <div class="label text-center px-4">{@html bottomText}</div>
+					{#if bottomText || $$slots.bottomText}
+                    <div class="label text-center px-4"><slot name="bottomText">{bottomText ?? ''}</slot></div>
 					{/if}
                 </div>
 			</div>
 		{/if}
 	</div>
 	</AlwaysSquare>
-	
+
 </div>
 
 <style lang="postcss">
@@ -63,13 +76,13 @@ import { onMount } from "svelte";
 	}
 
 	.hp-card {
-		@apply 
+		@apply
 			flex
-			border-white/5 border-[2px] 
-			 hover:bg-white/15 
+			border-white/5 border-[2px]
+			 hover:bg-white/15
 			rounded-md
 			items-center justify-center
-			shadow-start hover:shadow-end transition-shadow duration-200 
+			shadow-start hover:shadow-end transition-shadow duration-200
 			drop-shadow-[0_25px_25px_rgba(255,255,255,0.35)]
             min-h-[240px]
 			h-full;

--- a/apps/gui/src/routes/(components)/CountCard.test.ts
+++ b/apps/gui/src/routes/(components)/CountCard.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { escapeHtml } from '$utils/sanitize';
+
+// Resolved relative to this file:
+// apps/gui/src/routes/(components)/CountCard.test.ts
+const COUNT_CARD_PATH = resolve(__dirname, 'CountCard.svelte');
+const COUNTS_PATH = resolve(__dirname, 'Counts.svelte');
+const RELAY_FEE_ITEM_PATH = resolve(
+    __dirname,
+    '../relays/[protocol]/[...relay]/(components)/partials/RelayFeeItem.svelte'
+);
+const CARD_INSIGHTS_PATH = resolve(
+    __dirname,
+    '../relays/[protocol]/[...relay]/(components)/cards/CardInsights.svelte'
+);
+
+/**
+ * Strip HTML comment blocks so structural assertions only inspect LIVE code.
+ * Mirrors Phase 26's CardFees.test.ts helper. CountCard / callers have no
+ * known dead-code blocks, but the helper keeps assertions resilient to any
+ * future commented-out reference shape.
+ */
+function stripHtmlComments(source: string): string {
+    return source.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+describe('CountCard structural', () => {
+    it('imports safeHttpUrl from $utils/sanitize', () => {
+        const source = readFileSync(COUNT_CARD_PATH, 'utf8');
+        expect(source).toMatch(
+            /import\s*\{[^}]*\bsafeHttpUrl\b[^}]*\}\s*from\s*['"]\$utils\/sanitize['"]/
+        );
+    });
+
+    it('declares $: safeLink = safeHttpUrl(link)', () => {
+        const source = readFileSync(COUNT_CARD_PATH, 'utf8');
+        expect(source).toMatch(/\$:\s*safeLink\s*=\s*safeHttpUrl\s*\(\s*link\s*\)/);
+    });
+
+    it('binds <a href> to safeLink, never raw link', () => {
+        const live = stripHtmlComments(readFileSync(COUNT_CARD_PATH, 'utf8'));
+        expect(live).toMatch(/href\s*=\s*\{\s*safeLink\s*\}/);
+        // \b after `link` so we don't accidentally match `safeLink`.
+        expect(live).not.toMatch(/href\s*=\s*\{\s*link\b/);
+    });
+
+    it('contains zero {@html topText} occurrences', () => {
+        const live = stripHtmlComments(readFileSync(COUNT_CARD_PATH, 'utf8'));
+        expect(live.match(/\{@html\s+topText\b/g)).toBeNull();
+    });
+
+    it('contains zero {@html bottomText} occurrences', () => {
+        const live = stripHtmlComments(readFileSync(COUNT_CARD_PATH, 'utf8'));
+        expect(live.match(/\{@html\s+bottomText\b/g)).toBeNull();
+    });
+
+    it('contains zero {@html $value} occurrences', () => {
+        const live = stripHtmlComments(readFileSync(COUNT_CARD_PATH, 'utf8'));
+        expect(live.match(/\{@html\s+\$value\b/g)).toBeNull();
+    });
+
+    it('declares slot for topText', () => {
+        const source = readFileSync(COUNT_CARD_PATH, 'utf8');
+        expect(source).toMatch(/<slot\s+name=["']topText["']/);
+    });
+
+    it('declares slot for bottomText', () => {
+        const source = readFileSync(COUNT_CARD_PATH, 'utf8');
+        expect(source).toMatch(/<slot\s+name=["']bottomText["']/);
+    });
+
+    it('declares a default (unnamed) slot whose fallback references $value', () => {
+        const source = readFileSync(COUNT_CARD_PATH, 'utf8');
+        // Default slot — `<slot>` with no `name=`, fallback contains `$value`.
+        expect(source).toMatch(/<slot(?![^>]*\sname=)[^>]*>[^<]*\$value/);
+    });
+});
+
+describe('CountCard caller migration — Counts.svelte', () => {
+    it('passes plain-text props (no readable() with HTML markup)', () => {
+        const live = stripHtmlComments(readFileSync(COUNTS_PATH, 'utf8'));
+        expect(live).not.toMatch(/value=\{readable\([^)]*<[a-z]/i);
+    });
+});
+
+describe('CountCard caller migration — RelayFeeItem.svelte', () => {
+    it('coerces fee.amount via Number(...) before interpolation (CARD-03)', () => {
+        const live = stripHtmlComments(readFileSync(RELAY_FEE_ITEM_PATH, 'utf8'));
+        expect(live).toMatch(/Number\s*\(\s*(amount|fee\.amount)\s*\)/);
+    });
+
+    it('does not pass HTML-string-as-value (no readable(`...<span...`))', () => {
+        const live = stripHtmlComments(readFileSync(RELAY_FEE_ITEM_PATH, 'utf8'));
+        expect(live).not.toMatch(/value=\{readable\([^)]*<[a-z]/i);
+    });
+
+    it('uses CountCard with default-slot content (closing </CountCard> tag present)', () => {
+        const live = stripHtmlComments(readFileSync(RELAY_FEE_ITEM_PATH, 'utf8'));
+        expect(live).toMatch(/<\/CountCard>/);
+    });
+
+    it('retains a value= prop or valueSentinel reactive (locks CountCard gate-satisfying contract)', () => {
+        // Phase 27 locked decision: RelayFeeItem must keep CountCard's value-display
+        // gate satisfied. The default slot does the visible CARD-03 coercion, but
+        // CountCard's `{#if $value !== null && $value !== undefined ...}` gate
+        // requires a defined `value` prop. Lock in either `value=` (any form) or
+        // a `valueSentinel` reactive name so a future refactor cannot silently
+        // drop the prop and break the gate.
+        const live = stripHtmlComments(readFileSync(RELAY_FEE_ITEM_PATH, 'utf8'));
+        expect(live).toMatch(/\bvalue\s*=|\bvalueSentinel\b/);
+    });
+});
+
+describe('CountCard caller migration — CardInsights.svelte', () => {
+    it('has zero bottomText template-literal HTML strings (CARD-02)', () => {
+        const live = stripHtmlComments(readFileSync(CARD_INSIGHTS_PATH, 'utf8'));
+        // bottomText={`...<tag...`} — template literal containing an HTML tag.
+        expect(live).not.toMatch(/bottomText=\{`[^`]*<[a-z]/i);
+    });
+
+    it('uses <svelte:fragment slot="bottomText"> at every CountCard call site', () => {
+        const live = stripHtmlComments(readFileSync(CARD_INSIGHTS_PATH, 'utf8'));
+        const fragMatches = live.match(/<svelte:fragment\s+slot=["']bottomText["']/g) ?? [];
+        // CardInsights has 4 CountCard call sites (software, version, geocode, isp).
+        expect(fragMatches.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('has 4+ CountCard closing tags (slot-using form)', () => {
+        const live = stripHtmlComments(readFileSync(CARD_INSIGHTS_PATH, 'utf8'));
+        const closeMatches = live.match(/<\/CountCard>/g) ?? [];
+        expect(closeMatches.length).toBeGreaterThanOrEqual(4);
+    });
+});
+
+describe('CountCard adversarial NIP-11 behavior — Number coercion (CARD-03)', () => {
+    it('Number("<img src=x onerror=alert(1)>") is NaN', () => {
+        expect(Number.isNaN(Number('<img src=x onerror=alert(1)>'))).toBe(true);
+    });
+
+    it('String(NaN) contains no executable HTML', () => {
+        expect(String(NaN)).not.toMatch(/<script|<img|onerror=/i);
+    });
+
+    it('a numeric input round-trips through Number()', () => {
+        expect(Number(1500)).toBe(1500);
+    });
+});
+
+describe('CountCard adversarial NIP-11 behavior — text-bind escapes HTML (CARD-02)', () => {
+    it('escapeHtml on adversarial software field produces no executable markup', () => {
+        const out = escapeHtml('<img src=x onerror=alert(1)>');
+        // Security contract: angle-brackets are entity-encoded so the browser
+        // cannot parse this as an HTML tag. Tag-shaped patterns (`<img`, `<script`,
+        // and any `<\w` opener) MUST NOT appear unescaped in the output. We do not
+        // assert on bare `onerror=` because escapeHtml only neutralizes the tag
+        // delimiters — once the surrounding `<...>` is gone, the substring is
+        // inert text. The structural test above (CardInsights bottomText migration)
+        // is what guarantees `onerror=` never reaches a render context as part of
+        // a live tag. This assertion locks the helper-level "no live tag" contract.
+        expect(out).not.toMatch(/<\s*\w/);
+        expect(out).toContain('&lt;');
+        expect(out).toContain('&gt;');
+    });
+
+    it('escapeHtml on a benign software string passes through entity-encoded', () => {
+        // Sanity check — the "happy path" produces visible-text output.
+        const out = escapeHtml('strfry');
+        expect(out).toBe('strfry');
+    });
+});

--- a/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/RelayOperatorMiniFeed.svelte
+++ b/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/RelayOperatorMiniFeed.svelte
@@ -20,7 +20,6 @@
         videos: false,
         truncate: true,
         truncateLength: 500,
-        sanitize: false,
         nip19: true,
     }
 

--- a/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardFees.svelte
+++ b/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardFees.svelte
@@ -7,6 +7,7 @@
 	import { get, readable, type Readable } from 'svelte/store';
 	import { generateRelayUrlFromPath } from '$utils/routing';
 	import RelayFeeItem from '../partials/RelayFeeItem.svelte';
+    import { safeHttpUrl } from '$utils/sanitize';
 
     type FeesObject = Record<string, FeesArray[]>
     type FeesArray = {
@@ -35,6 +36,7 @@
 
 
     $: paymentsUrl = $nip11?.paymentsUrl || undefined;
+    $: safePaymentsUrl = safeHttpUrl(paymentsUrl);
     $: type = Array.isArray(fees) ? 'array' : typeof $fees;
     $: feeKeys = type === 'object' && $fees? Object.keys($fees || {}): [];
     $: keysLength = feeKeys.length;
@@ -57,7 +59,7 @@
                 <Button 
                     size="lg"
                     class="text-lg py-1.5 font-mono inline-block gradient-orange" 
-                    href="{paymentsUrl}" 
+                    href="{safePaymentsUrl}"
                     target="_blank">
                     purchase access
                 </Button>

--- a/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardFees.svelte
+++ b/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardFees.svelte
@@ -2,7 +2,6 @@
     import Button from '$lib/components/ui/button/button.svelte';
     import * as Card from '$lib/components/ui/card';
     import { formatSeconds } from "$lib/utils/time.js"
-	import CountCard from '$routes/(components)/CountCard.svelte';
 	import { relayFees$, relayNip11$ } from '$stores/helpers/helpers-nip11s';
 	import { get, readable, type Readable } from 'svelte/store';
 	import { generateRelayUrlFromPath } from '$utils/routing';

--- a/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardFees.test.ts
+++ b/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardFees.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { safeHttpUrl } from '$utils/sanitize';
+
+// Resolved relative to this file:
+// apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardFees.test.ts
+const CARD_FEES_PATH = resolve(__dirname, 'CardFees.svelte');
+
+/**
+ * Strip every HTML comment block (<!-- ... -->) from the source so the
+ * structural assertions only inspect LIVE code. The dead-code commented
+ * block at CardFees.svelte:84-138 is intentionally out of scope for Phase 26
+ * (see 26-CONTEXT.md Deferred Ideas).
+ *
+ * Uses the [\s\S] pattern to match across newlines and a non-greedy quantifier
+ * so adjacent comment blocks aren't merged.
+ */
+function stripHtmlComments(source: string): string {
+    return source.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+describe('CardFees href sink', () => {
+    // ---------------------------------------------------------------------
+    // Structural assertions: read the LIVE source (comment-stripped) and
+    // prove the wiring. Mirrors Phase 25's banner-style-structural.test.ts.
+    // ---------------------------------------------------------------------
+
+    it('imports safeHttpUrl from $utils/sanitize', () => {
+        const source = readFileSync(CARD_FEES_PATH, 'utf8');
+        expect(source).toMatch(
+            /import\s*\{[^}]*\bsafeHttpUrl\b[^}]*\}\s*from\s*['"]\$utils\/sanitize['"]/
+        );
+    });
+
+    it('has zero raw paymentsUrl interpolations at href= bindings (live code only)', () => {
+        const liveSource = stripHtmlComments(readFileSync(CARD_FEES_PATH, 'utf8'));
+        // Match either `href="{paymentsUrl}"` (current vuln shape) or
+        // `href={paymentsUrl}` (alternative shape). The `\b` after `paymentsUrl`
+        // ensures we don't accidentally match `safePaymentsUrl`.
+        expect(liveSource).not.toMatch(/href\s*=\s*["{]\s*\{?\s*paymentsUrl\b/);
+    });
+
+    it('calls safeHttpUrl(paymentsUrl) at least once in live code', () => {
+        const liveSource = stripHtmlComments(readFileSync(CARD_FEES_PATH, 'utf8'));
+        expect(liveSource).toMatch(/safeHttpUrl\s*\(\s*paymentsUrl\s*\)/);
+    });
+
+    it('binds <Button href> to a safe* identifier (the wrapped value), not raw paymentsUrl', () => {
+        const liveSource = stripHtmlComments(readFileSync(CARD_FEES_PATH, 'utf8'));
+        // The dynamic href in the live code must reference a `safe*` identifier
+        // (case-insensitive: safePaymentsUrl, safePaymentUrl, paymentsUrlSafe — all OK).
+        expect(liveSource).toMatch(/href\s*=\s*["{]\s*\{?\s*safe[A-Za-z]*\b/i);
+        // And no raw paymentsUrl at any href= binding.
+        expect(liveSource).not.toMatch(/href\s*=\s*["{]\s*\{?\s*paymentsUrl\b/);
+    });
+
+    // ---------------------------------------------------------------------
+    // Behavior assertions: direct safeHttpUrl invocation. Phase 24's
+    // sanitize.test.ts exhaustively tests safeHttpUrl; these 6 cases prove
+    // the imported helper still rejects every canonical attack payload and
+    // accepts the safe one — i.e. the wiring imports the right helper.
+    // ---------------------------------------------------------------------
+
+    it('rejects javascript: scheme', () => {
+        expect(safeHttpUrl('javascript:alert(1)')).toBe('');
+    });
+    it('rejects data: scheme', () => {
+        expect(safeHttpUrl('data:text/html,<script>alert(1)</script>')).toBe('');
+    });
+    it('rejects vbscript: scheme', () => {
+        expect(safeHttpUrl('vbscript:msgbox')).toBe('');
+    });
+    it('rejects file: scheme', () => {
+        expect(safeHttpUrl('file:///etc/passwd')).toBe('');
+    });
+    it('rejects attribute-breakout payload', () => {
+        expect(safeHttpUrl('http://x" onerror="alert(1)" x="')).toBe('');
+    });
+    it('accepts safe https URL', () => {
+        expect(safeHttpUrl('https://relay.example/pay')).toBe('https://relay.example/pay');
+    });
+});

--- a/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardInsights.svelte
+++ b/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardInsights.svelte
@@ -107,55 +107,67 @@
             mt-1 pb-4 text-black/90 dark:text-white/90 text-xl min-h-96">
 
             {#if software}
-                <CountCard 
-                    topText="" 
+                <CountCard
+                    topText=""
                     display={$relayInsightsCardView === 'chart' ? 'donut' : 'text'}
                     donutPercent={usagePercentageSoftware}
                     donutTitle={usagePercentageSoftware == null || !readableSoftware ? undefined : `${usagePercentageSoftware}% of relays use ${readableSoftware}`}
-                    value={readable($relayInsightsCardView === 'count'? `${usageCountSoftware}`: `${usagePercentageSoftware}%`)} 
-                    bottomText={`${$relayInsightsCardView === 'count'? '': 'of '}relays use ${readableSoftware}`} 
-                    index={0} 
+                    value={readable($relayInsightsCardView === 'count'? `${usageCountSoftware}`: `${usagePercentageSoftware}%`)}
+                    index={0}
                     innerClass="gradient-purple"
-                    />
+                    >
+                    <svelte:fragment slot="bottomText">
+                        {$relayInsightsCardView === 'count' ? '' : 'of '}relays use {readableSoftware}
+                    </svelte:fragment>
+                </CountCard>
             {/if}
 
             {#if software && version}
-                <CountCard 
-                    topText="" 
+                <CountCard
+                    topText=""
                     display={$relayInsightsCardView === 'chart' ? 'donut' : 'text'}
                     donutPercent={usagePercentageVersion}
                     donutTitle={usagePercentageVersion == null || !readableSoftware || !version ? undefined : `${usagePercentageVersion}% of ${readableSoftware} relays use ${version}`}
-                    value={readable($relayInsightsCardView === 'count'? `${usageCountVersion}`: `${usagePercentageVersion}%`)} 
-                    bottomText={`${$relayInsightsCardView === 'count'? '': 'of '} <em>${readableSoftware}</em> relays use ${version}`} 
-                    index={1} 
+                    value={readable($relayInsightsCardView === 'count'? `${usageCountVersion}`: `${usagePercentageVersion}%`)}
+                    index={1}
                     innerClass="gradient-purple"
-                    />
+                    >
+                    <svelte:fragment slot="bottomText">
+                        {$relayInsightsCardView === 'count' ? '' : 'of '} <em>{readableSoftware}</em> relays use {version}
+                    </svelte:fragment>
+                </CountCard>
             {/if}
 
             {#if usagePercentageGeocode || usageCountGeocode}
-                <CountCard 
-                    topText="" 
+                <CountCard
+                    topText=""
                     display={$relayInsightsCardView === 'chart' ? 'donut' : 'text'}
                     donutPercent={usagePercentageGeocode}
                     donutTitle={usagePercentageGeocode == null || !geocode ? undefined : `${usagePercentageGeocode}% of relays are located in ${geocode}`}
-                    value={readable($relayInsightsCardView === 'count'? `${usageCountGeocode}`: `${usagePercentageGeocode}%`)} 
-                    bottomText={`of relays are located in ${geocode} ${countryCodeToFlagEmoji(geocode)}`} 
-                    index={2} 
+                    value={readable($relayInsightsCardView === 'count'? `${usageCountGeocode}`: `${usagePercentageGeocode}%`)}
+                    index={2}
                     innerClass="gradient-purple"
-                    />
+                    >
+                    <svelte:fragment slot="bottomText">
+                        of relays are located in {geocode} {countryCodeToFlagEmoji(geocode)}
+                    </svelte:fragment>
+                </CountCard>
             {/if}
 
             {#if isp}
-                <CountCard 
-                    topText="" 
+                <CountCard
+                    topText=""
                     display={$relayInsightsCardView === 'chart' ? 'donut' : 'text'}
                     donutPercent={usagePercentageIsp}
                     donutTitle={usagePercentageIsp == null || !isp ? undefined : `${usagePercentageIsp}% of relays use ${isp} as their ISP`}
-                    value={readable($relayInsightsCardView === 'count'? `${usageCountIsp}`: `${usagePercentageIsp}%`)} 
-                    bottomText={`of relays use ${isp} as their ISP`} 
-                    index={3} 
+                    value={readable($relayInsightsCardView === 'count'? `${usageCountIsp}`: `${usagePercentageIsp}%`)}
+                    index={3}
                     innerClass="gradient-purple"
-                    />
+                    >
+                    <svelte:fragment slot="bottomText">
+                        of relays use {isp} as their ISP
+                    </svelte:fragment>
+                </CountCard>
             {/if}
 
         </div>

--- a/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardOperator.svelte
+++ b/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardOperator.svelte
@@ -5,6 +5,7 @@
     import * as Card from '$lib/components/ui/card';
 	import ProfileCompact from '$lib/components/partials/ProfileCompact.svelte';
     import { darkMode } from '$lib/stores/app';
+    import { bannerStyleString } from '$utils/style-helpers';
     import { delay } from "@nostrwatch/utils";
 	
 	import { route66 } from '$lib/stores';
@@ -72,23 +73,13 @@
     </Card.Header>  
     <Card.Content class="flex flex-col xl:flex-row pt-10">
         <div class="flex-row xl:flex-none w-full xl:w-1/4">
-            <div 
+            <div
                 class="p-3 pr-10 -mr-5 rounded-md relative"
-                style="{
+                style={
                     $profile?.banner
-                        ? 
-                            $darkMode
-                                ? 
-                                    `background: linear-gradient(rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.8)),  url('${$profile.banner}'); 
-                                    background-repeat: no-repeat; 
-                                    background-size: cover;`
-                                :
-                                    `background: linear-gradient(rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.8)),  url('${$profile.banner}'); 
-                                    background-repeat: no-repeat; 
-                                    background-size: cover;`
-                            
+                        ? bannerStyleString($profile.banner, { darkMode: $darkMode, opacity: 0.8 })
                         : ''
-                }"
+                }
                 >
                 <div class="absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-black to-transparent pointer-events-none z-10"></div>
 

--- a/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/partials/RelayFeeItem.svelte
+++ b/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/partials/RelayFeeItem.svelte
@@ -7,10 +7,10 @@
         amount: number,
         unit: string,
         period?: number
-    } 
+    }
 
 
-    export let key: string; 
+    export let key: string;
     export let fee: Nip11Fee;
     const className = $$props.class
 
@@ -25,6 +25,12 @@
                 : fee?.period
                     ? formatSeconds(fee?.period)
                     : undefined
+    // CountCard's value-display gate requires a defined `$value`. We pass a
+    // sentinel readable (the coerced numeric amount as a string) so the gate
+    // resolves true; the actual rendered value comes from the default slot
+    // below, where Number(amount) does the CARD-03 coercion in template
+    // text-bind context.
+    $: valueSentinel = readable(String(Number(amount)));
 </script>
 
 <!-- {key}
@@ -33,7 +39,9 @@
 
 <CountCard
     class={className}
-    value={readable(`${amount}<span class="text-sm">sats</span>`)}
+    value={valueSentinel}
     label={key}
     {bottomText}
-    />
+    >
+    <span>{Number(amount)}<span class="text-sm">sats</span></span>
+</CountCard>


### PR DESCRIPTION
## Summary

Continues #899 / #900. v2.5 milestone closes every remaining XSS sink in `apps/gui` discovered during the audit on this branch.

**Phase breakdown:**
- **24** Sanitize Helper Surface — `safeHttpUrl` + `isUrlBreakout` factor + JSDoc dev note
- **25** CSS Banner Sinks — `bannerStyleString` helper covering 4 banner sinks (CSS-context single-quote breakout closed)
- **26** href Allowlist Sweep — NIP-11 `paymentsUrl` wrapped via `safeHttpUrl`; HREF-AUDIT enumerates every dynamic href
- **27** CountCard Structural Fix — slot-based API (text-bound by default); CardInsights / RelayFeeItem migrated; CardFees dead-import removed
- **28** notes.ts Hardening — sequential pipeline + always-on DOMPurify + `safeImageUrl`-validated parseImages/parseVideos + `escapeHtml`-wrapped kind:0 user.name (closes drive-by XSS via feed/wiki content)
- **29** Adversarial Regression Sweep — 3 cross-cutting test files + expanded sanitize.ts JSDoc + AUDIT-01 formatter migration formally deferred to v2.6+

**Stats:** 6 phases · 14 commits · 31 files · +2377/-330 LOC · 147/147 milestone tests green · 274/274 full GUI vitest green (modulo pre-existing playwright issues)

## Test plan
- [x] `cd apps/gui && pnpm vitest run` — confirm 274 unit tests green
- [x] Verify a relay returning `payments_url: "javascript:alert(1)"` produces no clickable JS link in CardFees
- [x] Verify malicious banner `x'); position:fixed; ...` does not break CSS context in DataTable / CardOperator / PageHeader
- [x] Verify a kind:1 with `<script>alert(1)</script>` renders as text in feed components
- [x] Verify `<img src=x onerror=alert(1)>` in note content has `onerror` stripped (DOMPurify keeps `<img src="x">`)
- [x] Verify a malicious kind:0 `name: "<img onerror=...>"` renders as text via `nostr:npub1...` references in note content
- [x] Spot-check legitimate content still renders (HTTPS image URLs, YouTube embeds, valid `nostr:nevent...` references)