### PR TITLE
Add RelayMon trusted relay assertion publishing

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -9,5 +9,7 @@
 ^/architecture
 ^/getting-started
 ^/packages
+# Local planning artifacts — intentionally absent from CI checkouts and package docs
+^file://.*/\.planning/
 # localhost dev server — not available in CI
 ^http://localhost

--- a/apps/docker-stacks/README.md
+++ b/apps/docker-stacks/README.md
@@ -13,9 +13,9 @@ A collection of Docker Compose configurations for deploying nostr-watch services
 
 ### How It Works
 
-nostr-watch monitors nostr relays and publishes the results as nostr events ([NIP-66](https://github.com/nostr-protocol/nips/blob/master/66.md)). There are two core services:
+nostr-watch monitors nostr relays and publishes the results as nostr events ([NIP-66](https://github.com/nostr-protocol/nips/blob/master/66.md)). RelayMon can also publish opt-in Trusted Relay Assertions (kind `30385`) using the draft TRA NIP shape from [`Letdown2491/trustedrelays`](https://github.com/Letdown2491/trustedrelays). There are two core services:
 
-- **RelayMon** — Continuously checks relays for connectivity (WebSocket open, read, NIP-11 info, DNS) and publishes the results. Supports clearnet, Tor, and I2P networks.
+- **RelayMon** — Continuously checks relays for connectivity (WebSocket open, read, NIP-11 info, DNS), publishes the results, and can optionally publish Trusted Relay Assertions. Supports clearnet, Tor, and I2P networks.
 - **Trawler** — Crawls nostr relay lists to discover new relays and writes them to a SQLite database. When paired with RelayMon, trawler feeds discovered relays into the monitor automatically.
 
 Each stack composes these services (and optional network proxies) into a ready-to-run deployment. You configure two things per service:
@@ -100,11 +100,12 @@ Controls application behavior — monitor identity, seed sources, check types, a
 Key sections:
 
 - **`monitor`** — Your monitor's identity: slug, name, owner pubkey, and announcement relays
-- **`publisher`** — Which relays receive check result events (Kind 1066, Kind 20166)
+- **`publisher`** — Which relays receive check result events (Kind 1066, Kind 20166) and default TRA events
 - **`relaymon.networks`** — Which networks to monitor (`clearnet`, `tor`, `i2pd`)
 - **`relaymon.seed`** — How the relay list is populated (`events`, `config`, `db`)
 - **`relaymon.checks`** — Which checks to run (`open`, `read`, `info`, `dns`) and their intervals/timeouts
 - **`relaymon.retry`** — Backoff strategy for failed relay connections
+- **`relaymon.trustedRelayAssertions`** — Optional kind `30385` Trusted Relay Assertion publishing controls
 
 ### Docker Compose Environment (set in `docker-compose.yaml`)
 

--- a/apps/docker-stacks/README.md
+++ b/apps/docker-stacks/README.md
@@ -40,6 +40,10 @@ Each stack composes these services (and optional network proxies) into a ready-t
 
 Each stack directory contains its own README with detailed setup instructions.
 
+## Installation
+
+Each stack is installed from its own directory by copying the example environment and configuration files, filling in local values, and starting Docker Compose. Use the Quick Start below for the clearnet RelayMon stack, or open the target stack README for stack-specific variables.
+
 ## Quick Start
 
 ```sh

--- a/apps/docker-stacks/relaymon-clearnet/README.md
+++ b/apps/docker-stacks/relaymon-clearnet/README.md
@@ -4,7 +4,7 @@ Runs RelayMon in clearnet mode — direct connections to relays with no proxy or
 
 ## How It Works
 
-RelayMon connects directly to nostr relays over the public internet, runs connectivity checks (WebSocket open, read, NIP-11 info, DNS), and publishes the results as nostr events. This is the simplest stack — a single container with no network routing.
+RelayMon connects directly to nostr relays over the public internet, runs connectivity checks (WebSocket open, read, NIP-11 info, DNS), and publishes the results as nostr events. It can also publish optional Trusted Relay Assertions (kind `30385`) when `relaymon.trustedRelayAssertions.enabled` is set. This is the simplest stack — a single container with no network routing.
 
 ## Setup
 
@@ -50,3 +50,4 @@ See `config.yaml.example` for a fully commented template. Key settings to custom
 - **`monitor.owner`** — Your nostr public key (hex format)
 - **`relaymon.seed`** — Where to get the list of relays to monitor
 - **`relaymon.checks`** — Which checks to run and how often
+- **`relaymon.trustedRelayAssertions`** — Optional kind `30385` assertion publishing controls

--- a/apps/docker-stacks/relaymon-clearnet/config.yaml.example
+++ b/apps/docker-stacks/relaymon-clearnet/config.yaml.example
@@ -91,10 +91,12 @@ relaymon:
   #   min_observations: 10
   #   material_change_threshold: 3
   #   refresh_interval: 1h
+  #   history_retention: 30d
+  #   max_observations_per_relay: 1000
   #   publish_unreachable: true
   #   publish_blocked: false
   #   algorithm:
-  #     version: relaymon-local-v1
+  #     version: relaymon-local-v2
   #     url: https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md
 
 # Optional: Health monitoring

--- a/apps/docker-stacks/relaymon-clearnet/config.yaml.example
+++ b/apps/docker-stacks/relaymon-clearnet/config.yaml.example
@@ -84,6 +84,19 @@ relaymon:
         read: 5000         # Read timeout (ms)
       max: 200             # Max concurrent checks
 
+  # Optional: publish Trusted Relay Assertions (Kind 30385)
+  # trustedRelayAssertions:
+  #   enabled: false
+  #   relays: []            # Defaults to publisher.relays when empty
+  #   min_observations: 10
+  #   material_change_threshold: 3
+  #   refresh_interval: 1h
+  #   publish_unreachable: true
+  #   publish_blocked: false
+  #   algorithm:
+  #     version: relaymon-local-v1
+  #     url: https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md
+
 # Optional: Health monitoring
 # health:
 #   enabled: true

--- a/apps/docker-stacks/relaymon-multinet/README.md
+++ b/apps/docker-stacks/relaymon-multinet/README.md
@@ -6,7 +6,7 @@ Runs RelayMon in multinet mode with Tor and I2P proxy support via [hedproxy](htt
 
 This stack runs three containers:
 
-- **relaymon** — The relay monitor, running in `multinet` mode. hedproxy runs inside this container and automatically routes connections based on the relay URL scheme:
+- **relaymon** — The relay monitor, running in `multinet` mode. It publishes NIP-66 results and can optionally publish Trusted Relay Assertions (kind `30385`). hedproxy runs inside this container and automatically routes connections based on the relay URL scheme:
   - `wss://` / `ws://` — direct clearnet connection
   - `.onion` URLs — routed through the Tor SOCKS5 proxy
   - `.i2p` URLs — routed through the I2P HTTP proxy
@@ -69,6 +69,8 @@ relaymon:
     - tor
     - i2pd
 ```
+
+Set `relaymon.trustedRelayAssertions.enabled` to `true` to publish optional kind `30385` trust assertions.
 
 ### Proxy Configuration (`config/`)
 

--- a/apps/docker-stacks/relaymon-multinet/config.yaml.example
+++ b/apps/docker-stacks/relaymon-multinet/config.yaml.example
@@ -82,8 +82,10 @@ relaymon:
   #   min_observations: 10
   #   material_change_threshold: 3
   #   refresh_interval: 1h
+  #   history_retention: 30d
+  #   max_observations_per_relay: 1000
   #   publish_unreachable: true
   #   publish_blocked: false
   #   algorithm:
-  #     version: relaymon-local-v1
+  #     version: relaymon-local-v2
   #     url: https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md

--- a/apps/docker-stacks/relaymon-multinet/config.yaml.example
+++ b/apps/docker-stacks/relaymon-multinet/config.yaml.example
@@ -74,3 +74,16 @@ relaymon:
         open: 30000
         read: 5000
       max: 200
+
+  # Optional: publish Trusted Relay Assertions (Kind 30385)
+  # trustedRelayAssertions:
+  #   enabled: false
+  #   relays: []
+  #   min_observations: 10
+  #   material_change_threshold: 3
+  #   refresh_interval: 1h
+  #   publish_unreachable: true
+  #   publish_blocked: false
+  #   algorithm:
+  #     version: relaymon-local-v1
+  #     url: https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md

--- a/apps/docker-stacks/relaymon-vpn/README.md
+++ b/apps/docker-stacks/relaymon-vpn/README.md
@@ -4,7 +4,7 @@ Runs RelayMon in clearnet mode, with all traffic routed through a VPN via [Gluet
 
 ## How It Works
 
-This stack adds a Gluetun VPN container in front of RelayMon. RelayMon uses Gluetun's network (`network_mode: container:gluetun`), so all outbound traffic — relay connections, DNS lookups, event publishing — goes through the VPN tunnel. The relay monitoring behavior is identical to the clearnet stack, just routed differently.
+This stack adds a Gluetun VPN container in front of RelayMon. RelayMon uses Gluetun's network (`network_mode: container:gluetun`), so all outbound traffic — relay connections, DNS lookups, NIP-66 publishing, and optional Trusted Relay Assertion publishing — goes through the VPN tunnel. The relay monitoring behavior is identical to the clearnet stack, just routed differently.
 
 ## Setup
 
@@ -56,4 +56,4 @@ To change the VPN provider, also update `VPN_SERVICE_PROVIDER` in `docker-compos
 
 ### `config.yaml`
 
-See `config.yaml.example` for a fully commented template. Configuration is the same as the clearnet stack.
+See `config.yaml.example` for a fully commented template. Configuration is the same as the clearnet stack. Set `relaymon.trustedRelayAssertions.enabled` to `true` to publish optional kind `30385` trust assertions.

--- a/apps/docker-stacks/relaymon-vpn/config.yaml.example
+++ b/apps/docker-stacks/relaymon-vpn/config.yaml.example
@@ -80,8 +80,10 @@ relaymon:
   #   min_observations: 10
   #   material_change_threshold: 3
   #   refresh_interval: 1h
+  #   history_retention: 30d
+  #   max_observations_per_relay: 1000
   #   publish_unreachable: true
   #   publish_blocked: false
   #   algorithm:
-  #     version: relaymon-local-v1
+  #     version: relaymon-local-v2
   #     url: https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md

--- a/apps/docker-stacks/relaymon-vpn/config.yaml.example
+++ b/apps/docker-stacks/relaymon-vpn/config.yaml.example
@@ -72,3 +72,16 @@ relaymon:
         open: 30000
         read: 5000
       max: 200
+
+  # Optional: publish Trusted Relay Assertions (Kind 30385)
+  # trustedRelayAssertions:
+  #   enabled: false
+  #   relays: []
+  #   min_observations: 10
+  #   material_change_threshold: 3
+  #   refresh_interval: 1h
+  #   publish_unreachable: true
+  #   publish_blocked: false
+  #   algorithm:
+  #     version: relaymon-local-v1
+  #     url: https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md

--- a/apps/docker-stacks/trawler-relaymon-clearnet/README.md
+++ b/apps/docker-stacks/trawler-relaymon-clearnet/README.md
@@ -7,7 +7,7 @@ Runs both Trawler and RelayMon in clearnet mode with separate databases.
 This stack combines two services:
 
 - **Trawler** — Crawls nostr relay lists (Kind 10002 events) to discover new relay URLs and writes them to its own SQLite database (`trawler.db`)
-- **RelayMon** — Maintains its own database (`relaymon.db`) for check state, and seeds its relay list by reading from trawler's database as a read-only source
+- **RelayMon** — Maintains its own database (`relaymon.db`) for check state, seeds its relay list by reading from trawler's database as a read-only source, and can optionally publish Trusted Relay Assertions (kind `30385`)
 
 Both services mount the same `./data` volume so RelayMon can read trawler's database, but each service writes to its own database file to avoid SQLite locking conflicts. Trawler continuously discovers new relays, and RelayMon picks them up on its next seed cycle via the `db` seed source.
 
@@ -62,6 +62,7 @@ See the `.example` files for fully commented templates. Key points:
 - Trawler writes to `/opt/data/trawler.db`
 - RelayMon writes to `/opt/data/relaymon.db`
 - RelayMon's `seed.options.db.path` points to `/opt/data/trawler.db` (read-only seed source)
+- Set `relaymon.trustedRelayAssertions.enabled` to `true` to publish optional kind `30385` trust assertions
 
 ### Database Architecture
 

--- a/apps/docker-stacks/trawler-relaymon-clearnet/relaymon-config.yaml.example
+++ b/apps/docker-stacks/trawler-relaymon-clearnet/relaymon-config.yaml.example
@@ -78,3 +78,16 @@ relaymon:
         open: 30000
         read: 5000
       max: 200
+
+  # Optional: publish Trusted Relay Assertions (Kind 30385)
+  # trustedRelayAssertions:
+  #   enabled: false
+  #   relays: []
+  #   min_observations: 10
+  #   material_change_threshold: 3
+  #   refresh_interval: 1h
+  #   publish_unreachable: true
+  #   publish_blocked: false
+  #   algorithm:
+  #     version: relaymon-local-v1
+  #     url: https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md

--- a/apps/docker-stacks/trawler-relaymon-clearnet/relaymon-config.yaml.example
+++ b/apps/docker-stacks/trawler-relaymon-clearnet/relaymon-config.yaml.example
@@ -86,8 +86,10 @@ relaymon:
   #   min_observations: 10
   #   material_change_threshold: 3
   #   refresh_interval: 1h
+  #   history_retention: 30d
+  #   max_observations_per_relay: 1000
   #   publish_unreachable: true
   #   publish_blocked: false
   #   algorithm:
-  #     version: relaymon-local-v1
+  #     version: relaymon-local-v2
   #     url: https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md

--- a/apps/docker-stacks/trawler-relaymon-multinet/README.md
+++ b/apps/docker-stacks/trawler-relaymon-multinet/README.md
@@ -7,7 +7,7 @@ Runs Trawler and RelayMon with Tor and I2P proxy support. RelayMon uses [hedprox
 This stack runs four containers on a shared Docker bridge network (`relaymon-net`):
 
 - **Trawler** — Crawls relay lists over clearnet to discover new relays, writes them to its own SQLite database (`trawler.db`)
-- **RelayMon** — Runs in `multinet` mode, maintaining its own database (`relaymon.db`) for check state. Seeds its relay list by reading from trawler's database as a read-only source. hedproxy routes connections based on URL scheme (`.onion` to Tor, `.i2p` to I2P, everything else direct)
+- **RelayMon** — Runs in `multinet` mode, maintaining its own database (`relaymon.db`) for check state. Seeds its relay list by reading from trawler's database as a read-only source and can optionally publish Trusted Relay Assertions (kind `30385`). hedproxy routes connections based on URL scheme (`.onion` to Tor, `.i2p` to I2P, everything else direct)
 - **tor-proxy** — Tor daemon exposing SOCKS5 on port 9050
 - **i2pd** — I2P daemon with SAM bridge
 
@@ -65,7 +65,7 @@ The default `docker-compose.yaml` does not mount a trawler `.env` file. If you n
 
 ### `relaymon-config.yaml` / `trawler-config.yaml`
 
-See the `.example` files for fully commented templates. The relaymon config enables all three networks (`clearnet`, `tor`, `i2pd`) and seeds from trawler's database.
+See the `.example` files for fully commented templates. The relaymon config enables all three networks (`clearnet`, `tor`, `i2pd`) and seeds from trawler's database. Set `relaymon.trustedRelayAssertions.enabled` to `true` to publish optional kind `30385` trust assertions.
 
 ### Database Architecture
 

--- a/apps/docker-stacks/trawler-relaymon-multinet/relaymon-config.yaml.example
+++ b/apps/docker-stacks/trawler-relaymon-multinet/relaymon-config.yaml.example
@@ -89,8 +89,10 @@ relaymon:
   #   min_observations: 10
   #   material_change_threshold: 3
   #   refresh_interval: 1h
+  #   history_retention: 30d
+  #   max_observations_per_relay: 1000
   #   publish_unreachable: true
   #   publish_blocked: false
   #   algorithm:
-  #     version: relaymon-local-v1
+  #     version: relaymon-local-v2
   #     url: https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md

--- a/apps/docker-stacks/trawler-relaymon-multinet/relaymon-config.yaml.example
+++ b/apps/docker-stacks/trawler-relaymon-multinet/relaymon-config.yaml.example
@@ -81,3 +81,16 @@ relaymon:
         open: 30000
         read: 5000
       max: 200
+
+  # Optional: publish Trusted Relay Assertions (Kind 30385)
+  # trustedRelayAssertions:
+  #   enabled: false
+  #   relays: []
+  #   min_observations: 10
+  #   material_change_threshold: 3
+  #   refresh_interval: 1h
+  #   publish_unreachable: true
+  #   publish_blocked: false
+  #   algorithm:
+  #     version: relaymon-local-v1
+  #     url: https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md

--- a/apps/relaymon/README.md
+++ b/apps/relaymon/README.md
@@ -9,7 +9,7 @@ Deno-based relay health monitor with NIP-66 event publishing.
 
 ## Overview
 
-`@nostrwatch/relaymon` monitors Nostr relay (WebSocket server) health through automated check cycles. It runs configurable check suites — DNS, connectivity, SSL, info document retrieval, and geo-location — against a seeded relay list, then publishes results as [NIP-66](https://github.com/nostr-protocol/nips/blob/master/66.md) relay status events to the Nostr network. It can also publish opt-in Trusted Relay Assertions (kind `30385`) using the draft TRA NIP shape from [`Letdown2491/trustedrelays`](https://github.com/Letdown2491/trustedrelays). Relays are discovered from multiple seed sources including static configuration, API endpoints, and existing NIP-66 events. Supports clearnet, Tor (`.onion`), and I2P (`.i2p`) relay monitoring via configurable network routing.
+`@nostrwatch/relaymon` monitors Nostr relay (WebSocket server) health through automated check cycles. It runs configurable check suites — DNS, connectivity, SSL, info document retrieval, and geo-location — against a seeded relay list, then publishes results as [NIP-66](https://github.com/nostr-protocol/nips/blob/master/66.md) relay status events to the Nostr network. It can also publish opt-in Trusted Relay Assertions (kind `30385`) using the draft TRA NIP shape from [`Letdown2491/trustedrelays`](https://github.com/Letdown2491/trustedrelays). RelayMon TRA events are monitor-local assertions derived only from that monitor's own observation history and are signed by the same monitor key used for NIP-66 publishing. RelayMon does not ingest report/appeal events or manage trusted-provider declarations for this feature. Relays are discovered from multiple seed sources including static configuration, API endpoints, and existing NIP-66 events. Supports clearnet, Tor (`.onion`), and I2P (`.i2p`) relay monitoring via configurable network routing.
 
 ## Prerequisites
 
@@ -151,10 +151,12 @@ relaymon:
     min_observations: 10
     material_change_threshold: 3
     refresh_interval: "1h"
+    history_retention: "30d"
+    max_observations_per_relay: 1000
     publish_unreachable: true
     publish_blocked: false
     algorithm:
-      version: relaymon-local-v1
+      version: relaymon-local-v2
       url: https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md
 
 queue:

--- a/apps/relaymon/README.md
+++ b/apps/relaymon/README.md
@@ -9,7 +9,7 @@ Deno-based relay health monitor with NIP-66 event publishing.
 
 ## Overview
 
-`@nostrwatch/relaymon` monitors Nostr relay (WebSocket server) health through automated check cycles. It runs configurable check suites — DNS, connectivity, SSL, info document retrieval, and geo-location — against a seeded relay list, then publishes results as [NIP-66](https://github.com/nostr-protocol/nips/blob/master/66.md) relay status events to the Nostr network. Relays are discovered from multiple seed sources including static configuration, API endpoints, and existing NIP-66 events. Supports clearnet, Tor (`.onion`), and I2P (`.i2p`) relay monitoring via configurable network routing.
+`@nostrwatch/relaymon` monitors Nostr relay (WebSocket server) health through automated check cycles. It runs configurable check suites — DNS, connectivity, SSL, info document retrieval, and geo-location — against a seeded relay list, then publishes results as [NIP-66](https://github.com/nostr-protocol/nips/blob/master/66.md) relay status events to the Nostr network. It can also publish opt-in Trusted Relay Assertions (kind `30385`) using the draft TRA NIP shape from [`Letdown2491/trustedrelays`](https://github.com/Letdown2491/trustedrelays). Relays are discovered from multiple seed sources including static configuration, API endpoints, and existing NIP-66 events. Supports clearnet, Tor (`.onion`), and I2P (`.i2p`) relay monitoring via configurable network routing.
 
 ## Prerequisites
 
@@ -145,6 +145,17 @@ relaymon:
         read: 5000
       max: "100"
       statusInterval: 20
+  trustedRelayAssertions:
+    enabled: false
+    relays: []
+    min_observations: 10
+    material_change_threshold: 3
+    refresh_interval: "1h"
+    publish_unreachable: true
+    publish_blocked: false
+    algorithm:
+      version: relaymon-local-v1
+      url: https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md
 
 queue:
   workerConcurrency: 10
@@ -160,6 +171,7 @@ queue:
 | `relaymon.retry.expiry` | Stepped retry backoff rules (max retries + delay per step) |
 | `relaymon.seed.sources` | Where to discover relays: `config`, `static`, `api`, `events`, `db` |
 | `relaymon.checks.enabled` | Which check types to run (e.g., `open`, `read`) |
+| `relaymon.trustedRelayAssertions` | Optional kind `30385` Trusted Relay Assertion publishing controls |
 | `queue.workerConcurrency` | Maximum parallel relay checks |
 
 ## Known Limitations
@@ -178,7 +190,7 @@ No agent skills defined yet for this package.
 - [`@nostrwatch/db`](../../libraries/db/README.md) — SQLite database abstraction layer
 - [`@nostrwatch/logger`](../../internal/logger/README.md) — structured logging
 - [`@nostrwatch/announce`](../../internal/announce/README.md) — monitor profile and relay list announcement
-- [`@nostrwatch/publisher`](../../internal/publisher/README.md) — NIP-66 event publishing
+- [`@nostrwatch/publisher`](../../internal/publisher/README.md) — NIP-66 and Trusted Relay Assertion event publishing
 - [`apps/docker-stacks`](../docker-stacks/README.md) — pre-configured Docker Compose stacks for relaymon
 
 ## License

--- a/apps/relaymon/config.sample.yaml
+++ b/apps/relaymon/config.sample.yaml
@@ -110,6 +110,20 @@ relaymon:
   #       - '7d'   # Weekly aggregates
   #       - '30d'  # Monthly aggregates (approximate)
 
+  # Trusted Relay Assertions (Kind 30385) - publish local trust scores derived
+  # from relaymon observations using the Trusted Relay Assertions NIP shape.
+  # trustedRelayAssertions:
+  #   enabled: false
+  #   relays: []  # Defaults to publisher.relays when empty
+  #   min_observations: 10
+  #   material_change_threshold: 3
+  #   refresh_interval: 1h
+  #   publish_unreachable: true
+  #   publish_blocked: false
+  #   algorithm:
+  #     version: relaymon-local-v1
+  #     url: https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md
+
 
 # RelayMon Health Monitoring Configuration Example
 #

--- a/apps/relaymon/config.sample.yaml
+++ b/apps/relaymon/config.sample.yaml
@@ -110,18 +110,22 @@ relaymon:
   #       - '7d'   # Weekly aggregates
   #       - '30d'  # Monthly aggregates (approximate)
 
-  # Trusted Relay Assertions (Kind 30385) - publish local trust scores derived
-  # from relaymon observations using the Trusted Relay Assertions NIP shape.
+  # Trusted Relay Assertions (Kind 30385) - publish monitor-local trust scores
+  # derived only from this RelayMon instance's observations. Events are signed
+  # by the same monitor key used for NIP-66; RelayMon does not manage separate
+  # trusted-provider keys or ingest report/appeal events for these assertions.
   # trustedRelayAssertions:
   #   enabled: false
   #   relays: []  # Defaults to publisher.relays when empty
   #   min_observations: 10
   #   material_change_threshold: 3
   #   refresh_interval: 1h
+  #   history_retention: 30d
+  #   max_observations_per_relay: 1000
   #   publish_unreachable: true
   #   publish_blocked: false
   #   algorithm:
-  #     version: relaymon-local-v1
+  #     version: relaymon-local-v2
   #     url: https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md
 
 

--- a/apps/relaymon/deno.json
+++ b/apps/relaymon/deno.json
@@ -1,124 +1,124 @@
 {
-    "compilerOptions": {
-      "lib": ["deno.ns", "deno.window", "esnext"],
-      "strict": true
-    },
-    "nodeModulesDir": "auto",
-    "tasks": {
-      "interactive": "deno run --allow-ffi --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run interactive.ts",
-      "compile": "mkdir -p dist && deno compile --no-check --allow-ffi --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run --output dist/relaymon index.ts",
-      "start": "deno run --env-file=.env --allow-all --unstable-sloppy-imports index.ts",
-      "test": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run",
+  "compilerOptions": {
+    "lib": ["deno.ns", "deno.window", "esnext"],
+    "strict": true
+  },
+  "nodeModulesDir": "auto",
+  "tasks": {
+    "interactive": "deno run --allow-ffi --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run interactive.ts",
+    "compile": "mkdir -p dist && deno compile --no-check --allow-ffi --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run --output dist/relaymon index.ts",
+    "start": "deno run --env-file=.env --allow-all --unstable-sloppy-imports index.ts",
+    "test": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run",
 
-      "test:basic": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/basic.test.ts",
-      "test:dbcheck": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/dbcheck.test.ts",
-      "test:docker-proxy-chain": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/docker-proxy-chain.test.ts",
-      "test:proxy-connectivity": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/proxy-connectivity.test.ts",
-      "test:publish-retry": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/publish-retry.test.ts",
-      "test:simple-retry": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/simple-retry.test.ts",
+    "test:basic": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/basic.test.ts",
+    "test:dbcheck": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/dbcheck.test.ts",
+    "test:docker-proxy-chain": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/docker-proxy-chain.test.ts",
+    "test:proxy-connectivity": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/proxy-connectivity.test.ts",
+    "test:publish-retry": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/publish-retry.test.ts",
+    "test:simple-retry": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/simple-retry.test.ts",
 
-      "test:config-types": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/config-types.test.ts",
-      "test:database": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/database.test.ts",
-      "test:deletion": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/deletion.test.ts",
-      "test:delta-detector": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/delta-detector.test.ts",
-      "test:error-types": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/error-types.test.ts",
-      "test:hostname-dedup": "deno test --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/hostname-dedup.test.ts",
-      "test:ignorelist-sync": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/ignorelist-sync.test.ts",
-      "test:kind1066": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/kind1066.test.ts",
-      "test:period-calculator": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/period-calculator.test.ts",
-      "test:relay-types": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/relay-types.test.ts",
-      "test:seeder": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/seeder.test.ts",
-      "test:worker-publishing": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/worker-publishing.test.ts",
-      "test:worker-retry": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/worker-retry.test.ts",
+    "test:config-types": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/config-types.test.ts",
+    "test:database": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/database.test.ts",
+    "test:deletion": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/deletion.test.ts",
+    "test:delta-detector": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/delta-detector.test.ts",
+    "test:error-types": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/error-types.test.ts",
+    "test:hostname-dedup": "deno test --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/hostname-dedup.test.ts",
+    "test:ignorelist-sync": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/ignorelist-sync.test.ts",
+    "test:kind1066": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/kind1066.test.ts",
+    "test:kind30385": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/kind30385.test.ts",
+    "test:period-calculator": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/period-calculator.test.ts",
+    "test:relay-types": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/relay-types.test.ts",
+    "test:seeder": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/seeder.test.ts",
+    "test:worker-publishing": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/worker-publishing.test.ts",
+    "test:worker-retry": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/worker-retry.test.ts",
 
-      "test:baseline": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/integration/baseline.test.ts",
-      "test:delta-integration": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/integration/delta-events.test.ts",
-      "test:worker-integration": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/integration/worker.test.ts",
+    "test:baseline": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/integration/baseline.test.ts",
+    "test:delta-integration": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/integration/delta-events.test.ts",
+    "test:worker-integration": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/integration/worker.test.ts",
 
-      "test:unit": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/",
-      "test:integration": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/integration/",
-      "test:delta": "deno task test:delta-detector && deno task test:kind1066 && deno task test:period-calculator && deno task test:delta-integration",
+    "test:unit": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/",
+    "test:integration": "deno test --no-lock --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/integration/",
+    "test:delta": "deno task test:delta-detector && deno task test:kind1066 && deno task test:period-calculator && deno task test:delta-integration",
 
-      "link:nocap": "bash -c 'if ! [ -L ./node_modules/@nostrwatch/nocap ]; then ln -sfn /Users/sandwich/Develop/nostr-watch/libraries/nocap ./node_modules/@nostrwatch/nocap; fi'",
-      "status": "deno run --allow-net --allow-env --allow-read --allow-write --allow-run src/core/status.ts",
-      "dbcheck": "deno run --unstable-sloppy-imports --allow-all src/db/dbcheck.ts",
-      "compile:dbcheck": "mkdir -p dist && deno compile --no-check --allow-net --allow-env --allow-read --allow-write --allow-run --output dist/relaymon-dbcheck src/db/dbcheck.ts",
-      "compile:macos-x64": "mkdir -p dist && deno compile --no-check --allow-ffi --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run --target x86_64-apple-darwin --output dist/relaymon-macos-x64 index.ts",
-      "compile:macos-arm64": "mkdir -p dist && deno compile --no-check --allow-ffi --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run --target aarch64-apple-darwin --output dist/relaymon-macos-arm64 index.ts",
-      "compile:linux-x64": "mkdir -p dist && deno compile --no-check --allow-ffi --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run --target x86_64-unknown-linux-gnu --output dist/relaymon-linux-x64 index.ts",
-      "compile:linux-arm64": "mkdir -p dist && deno compile --no-check --allow-ffi --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run --target aarch64-unknown-linux-gnu --output dist/relaymon-linux-arm64 index.ts",
-      "compile:windows-x64": "mkdir -p dist && deno compile --no-check --allow-ffi --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run --target x86_64-pc-windows-msvc --output dist/relaymon-windows-x64.exe index.ts",
-      "compile:all": "deno task compile:macos-x64 && deno task compile:macos-arm64 && deno task compile:linux-x64 && deno task compile:linux-arm64 && deno task compile:windows-x64 && deno task compile:windows-arm64"
-    },
-    "fmt": {
-      "files": {
-        "include": ["**/*.ts", "**/*.js", "**/*.json", "**/*.yaml", "**/*.yml"]
-      }
-    },
-    "lint": {
-      "files": {
-        "include": ["**/*.ts", "**/*.js"]
-      }
-    },
-    "version": "0.2.0",
-    "imports": {
-      "nostr-geotags": "https://esm.sh/nostr-geotags@latest",
-
-      "npm:nostr-fetch": "npm:nostr-fetch@0.17.0",
-      "npm:nostr-tools": "https://esm.sh/nostr-tools@2.23.3",
-      "nostr-tools": "https://esm.sh/nostr-tools@2.23.3",
-      "nostr-tools/pure": "https://esm.sh/nostr-tools@2.23.3/pure",
-      "nostr-tools/nip19": "https://esm.sh/nostr-tools@2.23.3/nip19",
-    
-      "npm:murmurhash": "npm:murmurhash@2.0.1",
-      "npm:p-queue": "https://esm.sh/p-queue@latest",
-      "npm:chalk": "https://esm.sh/chalk@latest",
-      "npm:cross-fetch": "https://esm.sh/cross-fetch@latest",
-      
-      "@noble/hashes/utils": "https://esm.sh/@noble/hashes@1.3.2/utils",
-      
-      "ws": "https://esm.sh/ws@latest",
-      "murmurhash": "npm:murmurhash@2.0.1",
-      "promise-deferred": "https://esm.sh/promise-deferred@latest",
-      "npm:promise-deferred": "https://esm.sh/promise-deferred@latest",
-
-      "cross-fetch": "https://esm.sh/cross-fetch@latest",
-      "buffer": "node:buffer",
-      "socks-proxy-agent": "https://esm.sh/socks-proxy-agent@latest",
-      
-      "sqlite": "https://esm.sh/sqlite@latest",
-      "npm:sqlite": "https://esm.sh/sqlite@latest",
-      "winston": "https://esm.sh/winston@latest",
-      "debug": "https://esm.sh/debug@latest",
-      "js-yaml": "https://esm.sh/js-yaml@latest",
-      "std/flags": "https://deno.land/std@0.218.2/flags/mod.ts",
-      "std/fs": "https://deno.land/std@0.218.2/fs/mod.ts",
-      "chalk": "https://esm.sh/chalk@latest",
-
-      "npm:@nostrwatch/utils": "../../internal/utils/src/index.ts",
-      "npm:@nostrwatch/nocap": "../../libraries/nocap/src/index.ts",
-      "npm:@nostrwatch/nocap-every-adapter-default": "../../libraries/nocap/adapters/default/ZEveryAdapterDefault/src/index.ts",
-      "npm:@nostrwatch/publisher": "../../internal/publisher/src/index.ts",
-      "npm:@nostrwatch/websocket": "../../libraries/websocket/src/index.ts",
-      "npm:@nostrwatch/logger": "../../internal/logger/src/index.ts",
-      "npm:@nostrwatch/publisher-nostrtools": "../../internal/publisher/adapters/NostrTools/src/index.ts",
-      "npm:@nostrwatch/db": "../../libraries/db/src/index.ts",
-      "npm:@nostrwatch/announce": "../../internal/announce/src/index.ts",
-
-      "@nostrwatch/nostrings": "../../libraries/nostrings/src/index.ts",
-      "@nostrwatch/websocket": "../../libraries/websocket/src/index.ts",
-      "@nostrwatch/utils": "../../internal/utils/src/index.ts",
-      "@nostrwatch/nocap": "../../libraries/nocap/src/index.ts",
-      "@nostrwatch/nocap-every-adapter-default": "../../libraries/nocap/adapters/default/ZEveryAdapterDefault/src/index.ts",
-      "@nostrwatch/publisher": "../../internal/publisher/src/index.ts",
-      "@nostrwatch/logger": "../../internal/logger/src/index.ts",
-      "@nostrwatch/nocap-info-adapter-default": "../../libraries/nocap/adapters/default/InfoAdapterDefault/src/index.ts",
-      "@nostrwatch/nocap-ssl-adapter-default": "../../libraries/nocap/adapters/default/SslAdapterDefault/src/index.ts",
-      "@nostrwatch/nocap-dns-adapter-default": "../../libraries/nocap/adapters/default/DnsAdapterDefault/src/index.ts",
-      "@nostrwatch/nocap-geo-adapter-default": "../../libraries/nocap/adapters/default/GeoAdapterDefault/src/index.ts",
-      "@nostrwatch/nocap-websocket-adapter-default": "../../libraries/nocap/adapters/default/WebsocketAdapterDefault/src/index.ts",
-      "@nostrwatch/publisher-nostrtools": "../../internal/publisher/adapters/NostrTools/src/index.ts",
-      "@nostrwatch/announce": "../../internal/announce/src/index.ts"
+    "link:nocap": "bash -c 'if ! [ -L ./node_modules/@nostrwatch/nocap ]; then ln -sfn /Users/sandwich/Develop/nostr-watch/libraries/nocap ./node_modules/@nostrwatch/nocap; fi'",
+    "status": "deno run --allow-net --allow-env --allow-read --allow-write --allow-run src/core/status.ts",
+    "dbcheck": "deno run --unstable-sloppy-imports --allow-all src/db/dbcheck.ts",
+    "compile:dbcheck": "mkdir -p dist && deno compile --no-check --allow-net --allow-env --allow-read --allow-write --allow-run --output dist/relaymon-dbcheck src/db/dbcheck.ts",
+    "compile:macos-x64": "mkdir -p dist && deno compile --no-check --allow-ffi --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run --target x86_64-apple-darwin --output dist/relaymon-macos-x64 index.ts",
+    "compile:macos-arm64": "mkdir -p dist && deno compile --no-check --allow-ffi --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run --target aarch64-apple-darwin --output dist/relaymon-macos-arm64 index.ts",
+    "compile:linux-x64": "mkdir -p dist && deno compile --no-check --allow-ffi --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run --target x86_64-unknown-linux-gnu --output dist/relaymon-linux-x64 index.ts",
+    "compile:linux-arm64": "mkdir -p dist && deno compile --no-check --allow-ffi --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run --target aarch64-unknown-linux-gnu --output dist/relaymon-linux-arm64 index.ts",
+    "compile:windows-x64": "mkdir -p dist && deno compile --no-check --allow-ffi --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run --target x86_64-pc-windows-msvc --output dist/relaymon-windows-x64.exe index.ts",
+    "compile:all": "deno task compile:macos-x64 && deno task compile:macos-arm64 && deno task compile:linux-x64 && deno task compile:linux-arm64 && deno task compile:windows-x64 && deno task compile:windows-arm64"
+  },
+  "fmt": {
+    "files": {
+      "include": ["**/*.ts", "**/*.js", "**/*.json", "**/*.yaml", "**/*.yml"]
     }
+  },
+  "lint": {
+    "files": {
+      "include": ["**/*.ts", "**/*.js"]
+    }
+  },
+  "version": "0.2.0",
+  "imports": {
+    "nostr-geotags": "https://esm.sh/nostr-geotags@latest",
+
+    "npm:nostr-fetch": "npm:nostr-fetch@0.17.0",
+    "npm:nostr-tools": "https://esm.sh/nostr-tools@2.23.3",
+    "nostr-tools": "https://esm.sh/nostr-tools@2.23.3",
+    "nostr-tools/pure": "https://esm.sh/nostr-tools@2.23.3/pure",
+    "nostr-tools/nip19": "https://esm.sh/nostr-tools@2.23.3/nip19",
+
+    "npm:murmurhash": "npm:murmurhash@2.0.1",
+    "npm:p-queue": "https://esm.sh/p-queue@latest",
+    "npm:chalk": "https://esm.sh/chalk@latest",
+    "npm:cross-fetch": "https://esm.sh/cross-fetch@latest",
+
+    "@noble/hashes/utils": "https://esm.sh/@noble/hashes@1.3.2/utils",
+
+    "ws": "https://esm.sh/ws@latest",
+    "murmurhash": "npm:murmurhash@2.0.1",
+    "promise-deferred": "https://esm.sh/promise-deferred@latest",
+    "npm:promise-deferred": "https://esm.sh/promise-deferred@latest",
+
+    "cross-fetch": "https://esm.sh/cross-fetch@latest",
+    "buffer": "node:buffer",
+    "socks-proxy-agent": "https://esm.sh/socks-proxy-agent@latest",
+
+    "sqlite": "https://esm.sh/sqlite@latest",
+    "npm:sqlite": "https://esm.sh/sqlite@latest",
+    "winston": "https://esm.sh/winston@latest",
+    "debug": "https://esm.sh/debug@latest",
+    "js-yaml": "https://esm.sh/js-yaml@latest",
+    "std/flags": "https://deno.land/std@0.218.2/flags/mod.ts",
+    "std/fs": "https://deno.land/std@0.218.2/fs/mod.ts",
+    "chalk": "https://esm.sh/chalk@latest",
+
+    "npm:@nostrwatch/utils": "../../internal/utils/src/index.ts",
+    "npm:@nostrwatch/nocap": "../../libraries/nocap/src/index.ts",
+    "npm:@nostrwatch/nocap-every-adapter-default": "../../libraries/nocap/adapters/default/ZEveryAdapterDefault/src/index.ts",
+    "npm:@nostrwatch/publisher": "../../internal/publisher/src/index.ts",
+    "npm:@nostrwatch/websocket": "../../libraries/websocket/src/index.ts",
+    "npm:@nostrwatch/logger": "../../internal/logger/src/index.ts",
+    "npm:@nostrwatch/publisher-nostrtools": "../../internal/publisher/adapters/NostrTools/src/index.ts",
+    "npm:@nostrwatch/db": "../../libraries/db/src/index.ts",
+    "npm:@nostrwatch/announce": "../../internal/announce/src/index.ts",
+
+    "@nostrwatch/nostrings": "../../libraries/nostrings/src/index.ts",
+    "@nostrwatch/websocket": "../../libraries/websocket/src/index.ts",
+    "@nostrwatch/utils": "../../internal/utils/src/index.ts",
+    "@nostrwatch/nocap": "../../libraries/nocap/src/index.ts",
+    "@nostrwatch/nocap-every-adapter-default": "../../libraries/nocap/adapters/default/ZEveryAdapterDefault/src/index.ts",
+    "@nostrwatch/publisher": "../../internal/publisher/src/index.ts",
+    "@nostrwatch/logger": "../../internal/logger/src/index.ts",
+    "@nostrwatch/nocap-info-adapter-default": "../../libraries/nocap/adapters/default/InfoAdapterDefault/src/index.ts",
+    "@nostrwatch/nocap-ssl-adapter-default": "../../libraries/nocap/adapters/default/SslAdapterDefault/src/index.ts",
+    "@nostrwatch/nocap-dns-adapter-default": "../../libraries/nocap/adapters/default/DnsAdapterDefault/src/index.ts",
+    "@nostrwatch/nocap-geo-adapter-default": "../../libraries/nocap/adapters/default/GeoAdapterDefault/src/index.ts",
+    "@nostrwatch/nocap-websocket-adapter-default": "../../libraries/nocap/adapters/default/WebsocketAdapterDefault/src/index.ts",
+    "@nostrwatch/publisher-nostrtools": "../../internal/publisher/adapters/NostrTools/src/index.ts",
+    "@nostrwatch/announce": "../../internal/announce/src/index.ts"
+  }
 }
-  

--- a/apps/relaymon/src/config/config.ts
+++ b/apps/relaymon/src/config/config.ts
@@ -10,11 +10,11 @@ const originalTimeValues = new Map<string, string>();
 
 export function timeString(input: number | string): number {
   if (typeof input === "number") return input;
-  
+
   // Store the original string for later reference
   const pathKey = String(Math.random()); // Simple way to get a unique key
   originalTimeValues.set(pathKey, input);
-  
+
   const trimmed = input.trim();
   const regex = /^(\d+(?:\.\d+)?)(ms|s|m|h|d)$/;
   const match = trimmed.match(regex);
@@ -60,7 +60,7 @@ function processConfigTimeValues(config: Config, parentPath = ""): void {
       originalTimeValues.set(path, originalValue);
     }
   }
-  
+
   if (config.relaymon?.checks?.options) {
     if (config.relaymon.checks.options.expires) {
       const path = `${parentPath}.relaymon.checks.options.expires`;
@@ -72,7 +72,7 @@ function processConfigTimeValues(config: Config, parentPath = ""): void {
         originalTimeValues.set(path, originalValue);
       }
     }
-    
+
     if (config.relaymon.checks.options.interval) {
       const path = `${parentPath}.relaymon.checks.options.interval`;
       const originalValue = config.relaymon.checks.options.interval;
@@ -84,7 +84,7 @@ function processConfigTimeValues(config: Config, parentPath = ""): void {
       }
     }
   }
-  
+
   if (Array.isArray(config.relaymon?.retry?.expiry)) {
     config.relaymon.retry.expiry = config.relaymon.retry.expiry.map(
       (entry: { delay: string | number; retries: number }, index: number) => {
@@ -93,10 +93,9 @@ function processConfigTimeValues(config: Config, parentPath = ""): void {
 
         const result = {
           ...entry,
-          delay:
-            typeof entry.delay === "string"
-              ? timeString(entry.delay)
-              : entry.delay,
+          delay: typeof entry.delay === "string"
+            ? timeString(entry.delay)
+            : entry.delay,
         };
 
         if (typeof originalDelay === "string") {
@@ -118,6 +117,19 @@ function processConfigTimeValues(config: Config, parentPath = ""): void {
     }
   }
 
+  if (config.relaymon?.trustedRelayAssertions?.refresh_interval) {
+    const path =
+      `${parentPath}.relaymon.trustedRelayAssertions.refresh_interval`;
+    const originalValue =
+      config.relaymon.trustedRelayAssertions.refresh_interval;
+    config.relaymon.trustedRelayAssertions.refresh_interval = timeString(
+      config.relaymon.trustedRelayAssertions.refresh_interval,
+    );
+    if (typeof originalValue === "string") {
+      originalTimeValues.set(path, originalValue);
+    }
+  }
+
   // Process health config time values
   if (config.health?.kuma?.intervalMs) {
     const path = `${parentPath}.health.kuma.intervalMs`;
@@ -131,7 +143,9 @@ function processConfigTimeValues(config: Config, parentPath = ""): void {
   if (config.health?.kuma?.startupGraceMs) {
     const path = `${parentPath}.health.kuma.startupGraceMs`;
     const originalValue = config.health.kuma.startupGraceMs;
-    config.health.kuma.startupGraceMs = timeString(config.health.kuma.startupGraceMs);
+    config.health.kuma.startupGraceMs = timeString(
+      config.health.kuma.startupGraceMs,
+    );
     if (typeof originalValue === "string") {
       originalTimeValues.set(path, originalValue);
     }
@@ -140,7 +154,9 @@ function processConfigTimeValues(config: Config, parentPath = ""): void {
   if (config.health?.thresholds?.checkIdleMs) {
     const path = `${parentPath}.health.thresholds.checkIdleMs`;
     const originalValue = config.health.thresholds.checkIdleMs;
-    config.health.thresholds.checkIdleMs = timeString(config.health.thresholds.checkIdleMs);
+    config.health.thresholds.checkIdleMs = timeString(
+      config.health.thresholds.checkIdleMs,
+    );
     if (typeof originalValue === "string") {
       originalTimeValues.set(path, originalValue);
     }
@@ -149,7 +165,9 @@ function processConfigTimeValues(config: Config, parentPath = ""): void {
   if (config.health?.thresholds?.startupGraceMs) {
     const path = `${parentPath}.health.thresholds.startupGraceMs`;
     const originalValue = config.health.thresholds.startupGraceMs;
-    config.health.thresholds.startupGraceMs = timeString(config.health.thresholds.startupGraceMs);
+    config.health.thresholds.startupGraceMs = timeString(
+      config.health.thresholds.startupGraceMs,
+    );
     if (typeof originalValue === "string") {
       originalTimeValues.set(path, originalValue);
     }
@@ -172,36 +190,36 @@ export function msToTimeString(ms: number): string {
   // First check if we have the original string value
   const original = getOriginalTimeString(ms);
   if (original) return original;
-  
+
   // Otherwise generate a new one
   if (ms < 1000) return `${ms}ms`;
   if (ms % 1000 === 0) {
     const seconds = ms / 1000;
-    
+
     if (seconds % 60 === 0) {
       const minutes = seconds / 60;
-      
+
       if (minutes % 60 === 0) {
         const hours = minutes / 60;
-        
+
         if (hours % 24 === 0) {
           const days = hours / 24;
           return `${days}d`;
         }
-        
+
         return `${hours}h`;
       }
-      
+
       return `${minutes}m`;
     }
-    
+
     return `${seconds}s`;
   }
-  
+
   // Fallback for irregular values
-  if (ms >= 86400000) return `${Math.floor(ms/86400000)}d`;
-  if (ms >= 3600000) return `${Math.floor(ms/3600000)}h`;
-  if (ms >= 60000) return `${Math.floor(ms/60000)}m`;
-  if (ms >= 1000) return `${Math.floor(ms/1000)}s`;
+  if (ms >= 86400000) return `${Math.floor(ms / 86400000)}d`;
+  if (ms >= 3600000) return `${Math.floor(ms / 3600000)}h`;
+  if (ms >= 60000) return `${Math.floor(ms / 60000)}m`;
+  if (ms >= 1000) return `${Math.floor(ms / 1000)}s`;
   return `${ms}ms`;
 }

--- a/apps/relaymon/src/config/config.ts
+++ b/apps/relaymon/src/config/config.ts
@@ -130,6 +130,19 @@ function processConfigTimeValues(config: Config, parentPath = ""): void {
     }
   }
 
+  if (config.relaymon?.trustedRelayAssertions?.history_retention) {
+    const path =
+      `${parentPath}.relaymon.trustedRelayAssertions.history_retention`;
+    const originalValue =
+      config.relaymon.trustedRelayAssertions.history_retention;
+    config.relaymon.trustedRelayAssertions.history_retention = timeString(
+      config.relaymon.trustedRelayAssertions.history_retention,
+    );
+    if (typeof originalValue === "string") {
+      originalTimeValues.set(path, originalValue);
+    }
+  }
+
   // Process health config time values
   if (config.health?.kuma?.intervalMs) {
     const path = `${parentPath}.health.kuma.intervalMs`;

--- a/apps/relaymon/src/core/worker.ts
+++ b/apps/relaymon/src/core/worker.ts
@@ -782,7 +782,11 @@ export class Worker {
 
     try {
       const canonicalUrl = normalizeRelayUrl(result.url);
-      const history = recordTrustedRelayObservation(canonicalUrl, result);
+      const history = recordTrustedRelayObservation(canonicalUrl, result, {
+        recordHistory: true,
+        historyRetentionMs: traConfig.history_retention,
+        maxObservationsPerRelay: traConfig.max_observations_per_relay,
+      });
       const assertion = buildTrustedRelayAssertion(result, history, traConfig);
 
       if (
@@ -818,6 +822,8 @@ export class Worker {
         backoffMs = this.publishInitialBackoffMs,
       ) => {
         try {
+          // Kind 30385 is a monitor-local assertion signed by the same
+          // RelayMon key used for this monitor's NIP-66 events.
           const event = new Kind30385(this.pubkey);
           const privkey = getPrivateKey();
           const signedEvent = await event.generateAndSignEvent(

--- a/apps/relaymon/src/core/worker.ts
+++ b/apps/relaymon/src/core/worker.ts
@@ -1,12 +1,34 @@
 import { Nocap } from "npm:@nostrwatch/nocap";
 import EveryAdapterDefault from "npm:@nostrwatch/nocap-every-adapter-default";
-import { Publisher, Kind30166 } from "npm:@nostrwatch/publisher";
+import { Kind30166, Publisher } from "npm:@nostrwatch/publisher";
 import { relayHostnameDedup, setConfig } from "../utils/hostnames.ts";
-import { persistResult, incrementRetryCount, getRetryCount, db, storeRelayInfo, isRelayIgnored, getLastDeltaState, storeDeltaState, getPeriodSnapshot, storePeriodSnapshot, markRelayIgnored, markRelayUnignored } from "../db/db.ts";
+import {
+  db,
+  getLastDeltaState,
+  getPeriodSnapshot,
+  getPublishedTrustedRelayAssertion,
+  getRetryCount,
+  incrementRetryCount,
+  isRelayIgnored,
+  markRelayIgnored,
+  markRelayUnignored,
+  persistResult,
+  recordTrustedRelayObservation,
+  storeDeltaState,
+  storePeriodSnapshot,
+  storePublishedTrustedRelayAssertion,
+  storeRelayInfo,
+} from "../db/db.ts";
 import { delay } from "npm:@nostrwatch/utils";
 import { getLogger, LogLevel } from "../utils/logger.ts";
 import { RetryManager } from "../utils/retryManager.ts";
-import { statuses, updateSessionStats, incrementChecksCounter, incrementRelaysRecovered, incrementNewRelaysFound } from "./status.ts";
+import {
+  incrementChecksCounter,
+  incrementNewRelaysFound,
+  incrementRelaysRecovered,
+  statuses,
+  updateSessionStats,
+} from "./status.ts";
 import chalk from "npm:chalk";
 import { QueueManager } from "../utils/queueManager.ts";
 import { getExpiredRelays } from "../db/db.ts";
@@ -24,6 +46,12 @@ import { Kind1066 } from "../delta/kind1066.ts";
 import { Kind20166 } from "../delta/kind20166.ts";
 import { getPeriodsToEmit, validatePeriods } from "../delta/periods.ts";
 import { getPrivateKey } from "./daemon.ts";
+import {
+  buildTrustedRelayAssertion,
+  hasTrustedRelayMaterialChange,
+  Kind30385,
+  normalizeRelayUrl,
+} from "../tra/kind30385.ts";
 
 chalk.level = 1;
 
@@ -32,11 +60,12 @@ export class Worker {
   private logger = getLogger("Worker");
   private config: Config;
   private publisher: Publisher;
+  private trustedRelayPublisher: Publisher | null = null;
   private retryManager: RetryManager;
   private statusIntval: ReturnType<typeof setInterval>;
   private knownRelayStatus: Map<string, boolean> = new Map();
   private publishMaxRetries: number = 5;
-  private publishInitialBackoffMs: number = 1000*60;
+  private publishInitialBackoffMs: number = 1000 * 60;
   private warmupMode: boolean = false;
   private ignoreListSync: IgnoreListSync | null = null;
 
@@ -44,15 +73,24 @@ export class Worker {
     private pubkey: string,
     private queueManager: QueueManager,
     config: Config,
-    ignoreListSync?: IgnoreListSync
+    ignoreListSync?: IgnoreListSync,
   ) {
     this.config = config;
     this.ignoreListSync = ignoreListSync || null;
     this.publisher = new Publisher(this.pubkey, config.publisher.relays);
+    if (config.relaymon.trustedRelayAssertions?.relays?.length) {
+      this.trustedRelayPublisher = new Publisher(
+        this.pubkey,
+        config.relaymon.trustedRelayAssertions.relays,
+      );
+    }
 
     this.retryManager = new RetryManager(config.relaymon.retry.expiry);
-    this.statusIntval = statuses(this.queueManager, config.relaymon.checks.options.statusInterval);
-    
+    this.statusIntval = statuses(
+      this.queueManager,
+      config.relaymon.checks.options.statusInterval,
+    );
+
     if (config.logLevel) {
       this.logger.setLevel(config.logLevel);
     }
@@ -76,9 +114,9 @@ export class Worker {
 
       if (warnings.length > 0) {
         this.logger.warn("Period configuration warnings:");
-        warnings.forEach(w => this.logger.warn(`  - ${w}`));
+        warnings.forEach((w) => this.logger.warn(`  - ${w}`));
       } else {
-        this.logger.info(`Period aggregates enabled: ${periods.join(', ')}`);
+        this.logger.info(`Period aggregates enabled: ${periods.join(", ")}`);
       }
     }
   }
@@ -87,25 +125,29 @@ export class Worker {
   // and first-checks bypass DB ignore gating to ensure all relays are checked at least once.
   public setWarmupMode(enabled: boolean): void {
     this.warmupMode = enabled;
-    this.logger.info(`Warmup mode ${enabled ? 'enabled' : 'disabled'}`);
+    this.logger.info(`Warmup mode ${enabled ? "enabled" : "disabled"}`);
   }
 
   private initializeRelayStatusFromDB(): void {
     try {
       const results = db.query(`SELECT url, online, retries FROM relay_status`);
-      
+
       for (const [url, online, retries] of results) {
         this.knownRelayStatus.set(url as string, (online as number) === 1);
-        
+
         if ((retries as number) > 0) {
           this.relayRetries.set(url as string, retries as number);
           this.logger.debug(`Loaded retry count for ${url}: ${retries}`);
         }
       }
-      
-      this.logger.info(`Initialized status for ${this.knownRelayStatus.size} relays from database`);
+
+      this.logger.info(
+        `Initialized status for ${this.knownRelayStatus.size} relays from database`,
+      );
     } catch (error) {
-      this.logger.error(`Failed to initialize relay status from database: ${error.message}`);
+      this.logger.error(
+        `Failed to initialize relay status from database: ${error.message}`,
+      );
     }
   }
 
@@ -117,41 +159,66 @@ export class Worker {
     let isFirstCheck = false;
 
     if (isHostnameBlocked(relayUrl)) {
-      this.logger.debug(`Skipping check for relay ${relayUrl} - hostname is in blocklist`);
-      await deleteRelayCheckEvent(relayUrl, "hostname is in blocklist", this.config, this.queueManager);
-      db.query("DELETE FROM relay_status WHERE url = ?", [relayUrl]); 
+      this.logger.debug(
+        `Skipping check for relay ${relayUrl} - hostname is in blocklist`,
+      );
+      await deleteRelayCheckEvent(
+        relayUrl,
+        "hostname is in blocklist",
+        this.config,
+        this.queueManager,
+      );
+      db.query("DELETE FROM relay_status WHERE url = ?", [relayUrl]);
       return;
     }
 
     // Determine if this is the first-ever check for this relay
     try {
-      const checkedAt = db.query("SELECT checked_at FROM relay_status WHERE url = ?", [relayUrl]);
+      const checkedAt = db.query(
+        "SELECT checked_at FROM relay_status WHERE url = ?",
+        [relayUrl],
+      );
       if (checkedAt.length > 0 && (checkedAt[0][0] === -1)) {
         isFirstCheck = true;
         this.logger.debug(`This is the first check for relay: ${relayUrl}`);
       }
     } catch (error) {
-      this.logger.error(`Error checking if first check for ${relayUrl}: ${error}`);
+      this.logger.error(
+        `Error checking if first check for ${relayUrl}: ${error}`,
+      );
     }
 
     if (isRelayIgnored(relayUrl)) {
-      this.logger.debug(`Skipping check for relay ${relayUrl} - already marked as ignored in database`);
+      this.logger.debug(
+        `Skipping check for relay ${relayUrl} - already marked as ignored in database`,
+      );
       // During warmup, if this is the first check, bypass the ignore and continue
       if (this.warmupMode && isFirstCheck) {
-        this.logger.debug(`Warmup: bypassing DB ignore for first check of ${relayUrl}`);
+        this.logger.debug(
+          `Warmup: bypassing DB ignore for first check of ${relayUrl}`,
+        );
       } else {
         try {
-          await deleteRelayCheckEvent(relayUrl, "Relay was previously marked as ignored", this.config, this.queueManager);
-          this.logger.debug(`Published deletion event for previously ignored relay ${relayUrl}`);
+          await deleteRelayCheckEvent(
+            relayUrl,
+            "Relay was previously marked as ignored",
+            this.config,
+            this.queueManager,
+          );
+          this.logger.debug(
+            `Published deletion event for previously ignored relay ${relayUrl}`,
+          );
         } catch (error) {
-          this.logger.error(`Error publishing deletion event for ${relayUrl}: ${error}`);
+          this.logger.error(
+            `Error publishing deletion event for ${relayUrl}: ${error}`,
+          );
         }
         return;
       }
     }
 
     this.logger.debug(`Starting check for relay: ${relayUrl}`);
-    
+
     try {
       const nocap = new Nocap(relayUrl, {
         timeouts: this.config.relaymon.checks.options.timeout,
@@ -159,7 +226,7 @@ export class Worker {
       });
       await nocap.useAdapters(Object.values(EveryAdapterDefault));
       const result = await nocap.check(
-        this.config.relaymon.checks.enabled || ["open", "read"]
+        this.config.relaymon.checks.enabled || ["open", "read"],
       );
 
       if (result.info?.data && Object.keys(result.info.data).length > 0) {
@@ -167,28 +234,36 @@ export class Worker {
           const infoHash = createInfoHash(result.info.data);
           if (infoHash) {
             storeRelayInfo(relayUrl, result.info.data, infoHash);
-            this.logger.debug(`Stored NIP-11 info for ${relayUrl} with hash ${infoHash}`);
+            this.logger.debug(
+              `Stored NIP-11 info for ${relayUrl} with hash ${infoHash}`,
+            );
           }
         } catch (infoError) {
-          this.logger.error(`Error storing NIP-11 info for ${relayUrl}: ${infoError}`);
+          this.logger.error(
+            `Error storing NIP-11 info for ${relayUrl}: ${infoError}`,
+          );
         }
       }
 
       const dedupedResult = await relayHostnameDedup(result);
-      
+
       wasOnline = result.open?.data === true;
 
       // Fake relay detection: connects but doesn't speak nostr protocol
-      const checksEnabled = this.config.relaymon.checks.enabled || ["open", "read"];
+      const checksEnabled = this.config.relaymon.checks.enabled ||
+        ["open", "read"];
       const readCheckEnabled = checksEnabled.includes("read");
-      const readFailedProtocol = result.read?.data !== true
-        && typeof result.read?.message === 'string'
-        && result.read.message.includes('NIP-01 compatible');
+      const readFailedProtocol = result.read?.data !== true &&
+        typeof result.read?.message === "string" &&
+        result.read.message.includes("NIP-01 compatible");
       const isFakeRelay = wasOnline && readCheckEnabled && readFailedProtocol;
 
       if (isFakeRelay) {
-        const fakeRelayReason = "Not a relay: WebSocket connects but does not speak nostr protocol";
-        this.logger.warn(`Fake relay detected: ${relayUrl} (open=true, read=false)`);
+        const fakeRelayReason =
+          "Not a relay: WebSocket connects but does not speak nostr protocol";
+        this.logger.warn(
+          `Fake relay detected: ${relayUrl} (open=true, read=false)`,
+        );
         wasOnline = false;
         dedupedResult.ignore = true;
         dedupedResult.ignore_reason = fakeRelayReason;
@@ -204,29 +279,35 @@ export class Worker {
           relayUrl,
           "Fake relay: WebSocket connects but does not speak nostr protocol",
           this.config,
-          this.queueManager
+          this.queueManager,
         );
       }
 
       if (isFirstCheck && wasOnline) {
         incrementNewRelaysFound(1, true);
-        this.logger.debug(`New relay ${relayUrl} is online - incrementing new relays found counter`);
+        this.logger.debug(
+          `New relay ${relayUrl} is online - incrementing new relays found counter`,
+        );
       }
-      
+
       const previouslyOnline = this.knownRelayStatus.get(relayUrl);
       if (previouslyOnline === true && !wasOnline) {
         wentOffline = true;
-        this.logger.debug(`Relay ${relayUrl} went offline (was previously online)`);
+        this.logger.debug(
+          `Relay ${relayUrl} went offline (was previously online)`,
+        );
       }
-      
+
       const previousStatus = this.knownRelayStatus.get(relayUrl);
       const previouslyOffline = previousStatus === false;
       if (previouslyOffline && wasOnline) {
         recovered = true;
-        this.logger.debug(`Relay ${relayUrl} recovered (was previously offline)`);
+        this.logger.debug(
+          `Relay ${relayUrl} recovered (was previously offline)`,
+        );
         incrementRelaysRecovered();
       }
-      
+
       const isRetry = previouslyOffline && !wasOnline;
 
       // Determine operational status transition for delta events
@@ -247,40 +328,58 @@ export class Worker {
       }
 
       // Publish delta event (Kind 1066) if enabled
-      this.publishDeltaEvent(relayUrl, dedupedResult, operationalStatus, wasOnline);
+      this.publishDeltaEvent(
+        relayUrl,
+        dedupedResult,
+        operationalStatus,
+        wasOnline,
+      );
 
-      this.logger.debug(`Persisting result for relay: ${relayUrl}, online: ${wasOnline}`);
+      this.logger.debug(
+        `Persisting result for relay: ${relayUrl}, online: ${wasOnline}`,
+      );
       persistResult(dedupedResult);
-      
+
+      this.publishTrustedRelayAssertion(dedupedResult);
+
       if (wentOffline || isRetry) {
-        this.logger.debug(`Incrementing retry count for ${relayUrl} as it ${wentOffline ? 'went offline' : 'is still offline'}`);
+        this.logger.debug(
+          `Incrementing retry count for ${relayUrl} as it ${
+            wentOffline ? "went offline" : "is still offline"
+          }`,
+        );
         this.handleRetryForRelay(relayUrl);
       }
-      
+
       try {
         this.progressMessage(relayUrl, result, recovered, false);
       } catch (displayError) {
         console.error("Error displaying progress:", displayError);
       }
-      
+
       if (wasOnline) {
         this.relayRetries.set(relayUrl, 0);
       }
       this.logger.debug(`Successfully completed check for relay: ${relayUrl}`);
-
     } catch (error: unknown) {
       wasSuccessful = false;
-      this.logger.error(`Error processing relay ${relayUrl}: ${getErrorMessage(error)}`);
-      
+      this.logger.error(
+        `Error processing relay ${relayUrl}: ${getErrorMessage(error)}`,
+      );
+
       const currentRetryCount = this.relayRetries.get(relayUrl) || 0;
       if (currentRetryCount > 0) {
-        this.logger.debug(`Incrementing retry count for ${relayUrl} after repeated error (current: ${currentRetryCount})`);
+        this.logger.debug(
+          `Incrementing retry count for ${relayUrl} after repeated error (current: ${currentRetryCount})`,
+        );
         this.handleRetryForRelay(relayUrl);
       } else {
-        this.logger.debug(`First error for ${relayUrl}, not incrementing retry count yet`);
+        this.logger.debug(
+          `First error for ${relayUrl}, not incrementing retry count yet`,
+        );
         this.relayRetries.set(relayUrl, 0);
       }
-      
+
       try {
         this.progressMessage(relayUrl, {}, false, true);
       } catch (displayError) {
@@ -319,17 +418,21 @@ export class Worker {
       }
 
       // Check if the read failure is still a protocol incompatibility
-      const readFailedProtocol = result.read?.data !== true
-        && typeof result.read?.message === 'string'
-        && result.read.message.includes('NIP-01 compatible');
+      const readFailedProtocol = result.read?.data !== true &&
+        typeof result.read?.message === "string" &&
+        result.read.message.includes("NIP-01 compatible");
 
       if (readFailedProtocol) {
-        this.logger.debug(`Re-check: ${relayUrl} still fails protocol check, keeping ignored`);
+        this.logger.debug(
+          `Re-check: ${relayUrl} still fails protocol check, keeping ignored`,
+        );
         return false;
       }
 
       // Relay is online and either read passed or failed for non-protocol reasons → unignore
-      this.logger.info(`Re-check: ${relayUrl} is no longer a fake relay, unignoring`);
+      this.logger.info(
+        `Re-check: ${relayUrl} is no longer a fake relay, unignoring`,
+      );
 
       markRelayUnignored(relayUrl);
 
@@ -344,7 +447,11 @@ export class Worker {
 
       return true;
     } catch (error: unknown) {
-      this.logger.error(`Error re-checking ignored relay ${relayUrl}: ${getErrorMessage(error)}`);
+      this.logger.error(
+        `Error re-checking ignored relay ${relayUrl}: ${
+          getErrorMessage(error)
+        }`,
+      );
       return false;
     }
   }
@@ -352,35 +459,51 @@ export class Worker {
   async publishResult(result: RelayCheckResult): Promise<void> {
     try {
       if (this.warmupMode) {
-        this.logger.debug(`Warmup mode active; suppressing check event publish for ${result.url}`);
+        this.logger.debug(
+          `Warmup mode active; suppressing check event publish for ${result.url}`,
+        );
         return;
       }
-      const publishJob = async (retryCount = 0, maxRetries = this.publishMaxRetries, backoffMs = this.publishInitialBackoffMs) => {
+      const publishJob = async (
+        retryCount = 0,
+        maxRetries = this.publishMaxRetries,
+        backoffMs = this.publishInitialBackoffMs,
+      ) => {
         try {
           const event = new Kind30166(this.pubkey);
           const privkey = getPrivateKey();
           const generated = event.generateEvent(result);
-          generated.tags.push(['client', '@nostrwatch/relaymon']);
+          generated.tags.push(["client", "@nostrwatch/relaymon"]);
           const signedEvent = await event.signEvent(privkey);
           await this.publisher.publishEvent(signedEvent);
           this.logger.debug(`Published event for relay ${result.url}`);
         } catch (error: unknown) {
           const errorMsg = getErrorMessage(error);
-          this.logger.error(`Publish failed for ${result.url} (attempt ${retryCount + 1}/${maxRetries + 1}): ${errorMsg}`);
+          this.logger.error(
+            `Publish failed for ${result.url} (attempt ${retryCount + 1}/${
+              maxRetries + 1
+            }): ${errorMsg}`,
+          );
 
           if (retryCount < maxRetries) {
             const nextRetryCount = retryCount + 1;
             const nextBackoffMs = backoffMs * 2;
-            this.logger.info(`Scheduling retry ${nextRetryCount}/${maxRetries} for ${result.url} in ${(nextBackoffMs / 1000).toFixed(1)}s`);
+            this.logger.info(
+              `Scheduling retry ${nextRetryCount}/${maxRetries} for ${result.url} in ${
+                (nextBackoffMs / 1000).toFixed(1)
+              }s`,
+            );
 
             setTimeout(() => {
               this.queueManager.addPublishJob(
                 () => publishJob(nextRetryCount, maxRetries, nextBackoffMs),
-                { isRetry: true, category: 'delta' }
+                { isRetry: true, category: "delta" },
               );
             }, nextBackoffMs);
           } else {
-            this.logger.error(`Exceeded maximum retries (${maxRetries}) for publishing ${result.url}`);
+            this.logger.error(
+              `Exceeded maximum retries (${maxRetries}) for publishing ${result.url}`,
+            );
           }
 
           // Always throw to properly count failures in queue metrics
@@ -388,9 +511,16 @@ export class Worker {
         }
       };
 
-      this.queueManager.addPublishJob(() => publishJob(), { isRetry: false, category: 'check' });
+      this.queueManager.addPublishJob(() => publishJob(), {
+        isRetry: false,
+        category: "check",
+      });
     } catch (error: unknown) {
-      this.logger.error(`Failed to add publish job for ${result.url}: ${getErrorMessage(error)}`);
+      this.logger.error(
+        `Failed to add publish job for ${result.url}: ${
+          getErrorMessage(error)
+        }`,
+      );
     }
   }
 
@@ -398,7 +528,7 @@ export class Worker {
     relayUrl: string,
     result: RelayCheckResult,
     operationalStatus?: "init" | "down" | "up",
-    isOnline?: boolean
+    isOnline?: boolean,
   ): Promise<void> {
     // Check if delta events are enabled
     if (!this.config.relaymon.delta?.enabled) {
@@ -417,7 +547,9 @@ export class Worker {
       // Check if we should stop publishing delta events (exceeded max retries for offline relay)
       const maxRetries = this.config.relaymon.delta.max_retries ?? 10;
       if (!wasOnline && retryCount > maxRetries) {
-        this.logger.debug(`Skipping delta event for ${relayUrl} - exceeded max_retries (${maxRetries})`);
+        this.logger.debug(
+          `Skipping delta event for ${relayUrl} - exceeded max_retries (${maxRetries})`,
+        );
         return;
       }
 
@@ -432,24 +564,34 @@ export class Worker {
       const currentGeo = result.geo?.data;
 
       // Create composite state objects for delta detection
-      const lastCompositeState = lastState ? {
-        ...lastState.state,
-        ...(lastState.dns ? Object.fromEntries(
-          Object.entries(lastState.dns).map(([k, v]) => [`dns.${k}`, v])
-        ) : {}),
-        ...(lastState.geo ? Object.fromEntries(
-          Object.entries(lastState.geo).map(([k, v]) => [`geo.${k}`, v])
-        ) : {}),
-      } : null;
+      const lastCompositeState = lastState
+        ? {
+          ...lastState.state,
+          ...(lastState.dns
+            ? Object.fromEntries(
+              Object.entries(lastState.dns).map(([k, v]) => [`dns.${k}`, v]),
+            )
+            : {}),
+          ...(lastState.geo
+            ? Object.fromEntries(
+              Object.entries(lastState.geo).map(([k, v]) => [`geo.${k}`, v]),
+            )
+            : {}),
+        }
+        : null;
 
       const currentCompositeState = {
         ...currentInfo,
-        ...(currentDns ? Object.fromEntries(
-          Object.entries(currentDns).map(([k, v]) => [`dns.${k}`, v])
-        ) : {}),
-        ...(currentGeo ? Object.fromEntries(
-          Object.entries(currentGeo).map(([k, v]) => [`geo.${k}`, v])
-        ) : {}),
+        ...(currentDns
+          ? Object.fromEntries(
+            Object.entries(currentDns).map(([k, v]) => [`dns.${k}`, v]),
+          )
+          : {}),
+        ...(currentGeo
+          ? Object.fromEntries(
+            Object.entries(currentGeo).map(([k, v]) => [`geo.${k}`, v]),
+          )
+          : {}),
       };
 
       // Detect deltas from last check
@@ -473,7 +615,8 @@ export class Worker {
 
       if (periodsEnabled && this.config.relaymon.delta.periods) {
         const checkIntervalMs = this.config.relaymon.checks.options.interval;
-        const configuredPeriods = this.config.relaymon.delta.periods.definitions;
+        const configuredPeriods =
+          this.config.relaymon.delta.periods.definitions;
         const nowTs = Math.floor(Date.now() / 1000);
 
         // Get period snapshots for this relay
@@ -492,12 +635,16 @@ export class Worker {
           configuredPeriods,
           checkIntervalMs,
           periodSnapshotTimes,
-          nowTs
+          nowTs,
         );
 
         // Store snapshots for all periods that are being emitted
         if (periodsToEmit.length > 0) {
-          this.logger.debug(`Emitting period aggregates for ${relayUrl}: ${periodsToEmit.join(', ')}`);
+          this.logger.debug(
+            `Emitting period aggregates for ${relayUrl}: ${
+              periodsToEmit.join(", ")
+            }`,
+          );
           for (const period of periodsToEmit) {
             storePeriodSnapshot(relayUrl, period, currentInfo);
           }
@@ -505,7 +652,11 @@ export class Worker {
       }
 
       // Generate and publish delta event
-      const publishJob = async (retryCount = 0, maxRetries = this.publishMaxRetries, backoffMs = this.publishInitialBackoffMs) => {
+      const publishJob = async (
+        retryCount = 0,
+        maxRetries = this.publishMaxRetries,
+        backoffMs = this.publishInitialBackoffMs,
+      ) => {
         try {
           const event = new Kind1066(this.pubkey);
           const privkey = getPrivateKey();
@@ -521,45 +672,68 @@ export class Worker {
           }, privkey);
 
           await this.publisher.publishEvent(signedEvent);
-          this.logger.debug(`Published delta event (Kind 1066) for relay ${relayUrl}` +
-            (periodsToEmit.length > 0 ? ` with periods: ${periodsToEmit.join(', ')}` : ''));
+          this.logger.debug(
+            `Published delta event (Kind 1066) for relay ${relayUrl}` +
+              (periodsToEmit.length > 0
+                ? ` with periods: ${periodsToEmit.join(", ")}`
+                : ""),
+          );
 
           // Publish ephemeral state change event (Kind 20166) if status changed
           if (operationalStatus) {
             try {
               const ephemeralEvent = new Kind20166(this.pubkey);
-              const ephemeralSigned = await ephemeralEvent.generateAndSignEvent({
-                url: relayUrl,
-                operationalStatus,
-                online: wasOnline,
-                rttOpen: result.open?.duration,
-                retryCount: wasOnline ? undefined : retryCount,
-              }, privkey);
+              const ephemeralSigned = await ephemeralEvent.generateAndSignEvent(
+                {
+                  url: relayUrl,
+                  operationalStatus,
+                  online: wasOnline,
+                  rttOpen: result.open?.duration,
+                  retryCount: wasOnline ? undefined : retryCount,
+                },
+                privkey,
+              );
 
               await this.publisher.publishEvent(ephemeralSigned);
-              this.logger.debug(`Published ephemeral state change event (Kind 20166) for relay ${relayUrl}: ${operationalStatus}`);
+              this.logger.debug(
+                `Published ephemeral state change event (Kind 20166) for relay ${relayUrl}: ${operationalStatus}`,
+              );
             } catch (ephemeralError: unknown) {
               // Don't fail the whole job if ephemeral publish fails
-              this.logger.warn(`Failed to publish ephemeral event for ${relayUrl}: ${getErrorMessage(ephemeralError)}`);
+              this.logger.warn(
+                `Failed to publish ephemeral event for ${relayUrl}: ${
+                  getErrorMessage(ephemeralError)
+                }`,
+              );
             }
           }
         } catch (error: unknown) {
           const errorMsg = getErrorMessage(error);
-          this.logger.error(`Delta event publish failed for ${relayUrl} (attempt ${retryCount + 1}/${maxRetries + 1}): ${errorMsg}`);
+          this.logger.error(
+            `Delta event publish failed for ${relayUrl} (attempt ${
+              retryCount + 1
+            }/${maxRetries + 1}): ${errorMsg}`,
+          );
 
           if (retryCount < maxRetries) {
             const nextRetryCount = retryCount + 1;
             const nextBackoffMs = backoffMs * 2;
-            this.logger.info(`Scheduling delta event retry ${nextRetryCount}/${maxRetries} for ${relayUrl} in ${(nextBackoffMs / 1000).toFixed(1)}s`);
+            this.logger.info(
+              `Scheduling delta event retry ${nextRetryCount}/${maxRetries} for ${relayUrl} in ${
+                (nextBackoffMs / 1000).toFixed(1)
+              }s`,
+            );
 
             setTimeout(() => {
               this.queueManager.addPublishJob(
                 () => publishJob(nextRetryCount, maxRetries, nextBackoffMs),
-                { isRetry: true, category: 'check' }
+                { isRetry: true, category: "check" },
               );
             }, nextBackoffMs);
           } else {
-            this.logger.error(`Exceeded maximum retries (${maxRetries}) for publishing delta event for ${relayUrl}`);
+            this.logger.error(
+              `Exceeded maximum retries (${maxRetries}) for publishing delta event for ${relayUrl}`,
+            );
           }
 
           // Always throw to properly count failures in queue metrics
@@ -568,12 +742,143 @@ export class Worker {
       };
 
       if (this.warmupMode) {
-        this.logger.debug(`Warmup mode active; suppressing delta event publish for ${relayUrl}`);
+        this.logger.debug(
+          `Warmup mode active; suppressing delta event publish for ${relayUrl}`,
+        );
         return;
       }
-      this.queueManager.addPublishJob(() => publishJob(), { isRetry: false, category: 'delta' });
+      this.queueManager.addPublishJob(() => publishJob(), {
+        isRetry: false,
+        category: "delta",
+      });
     } catch (error: unknown) {
-      this.logger.error(`Failed to publish delta event for ${relayUrl}: ${getErrorMessage(error)}`);
+      this.logger.error(
+        `Failed to publish delta event for ${relayUrl}: ${
+          getErrorMessage(error)
+        }`,
+      );
+    }
+  }
+
+  async publishTrustedRelayAssertion(result: RelayCheckResult): Promise<void> {
+    const traConfig = this.config.relaymon.trustedRelayAssertions;
+    if (!traConfig?.enabled) {
+      return;
+    }
+
+    if (this.warmupMode) {
+      this.logger.debug(
+        `Warmup mode active; suppressing trusted relay assertion for ${result.url}`,
+      );
+      return;
+    }
+
+    if (result.ignore && !traConfig.publish_blocked) {
+      this.logger.debug(
+        `Skipping trusted relay assertion for ignored relay ${result.url}`,
+      );
+      return;
+    }
+
+    try {
+      const canonicalUrl = normalizeRelayUrl(result.url);
+      const history = recordTrustedRelayObservation(canonicalUrl, result);
+      const assertion = buildTrustedRelayAssertion(result, history, traConfig);
+
+      if (
+        assertion.status === "unreachable" &&
+        traConfig.publish_unreachable === false
+      ) {
+        this.logger.debug(
+          `Skipping trusted relay assertion for unreachable relay ${assertion.relayUrl}`,
+        );
+        return;
+      }
+
+      const previous = getPublishedTrustedRelayAssertion(assertion.relayUrl);
+      const change = hasTrustedRelayMaterialChange(
+        assertion,
+        previous,
+        traConfig.material_change_threshold ?? 3,
+        typeof traConfig.refresh_interval === "number"
+          ? traConfig.refresh_interval
+          : 60 * 60 * 1000,
+      );
+
+      if (!change.changed) {
+        this.logger.debug(
+          `Skipping trusted relay assertion for ${assertion.relayUrl} - no material change`,
+        );
+        return;
+      }
+
+      const publishJob = async (
+        retryCount = 0,
+        maxRetries = this.publishMaxRetries,
+        backoffMs = this.publishInitialBackoffMs,
+      ) => {
+        try {
+          const event = new Kind30385(this.pubkey);
+          const privkey = getPrivateKey();
+          const signedEvent = await event.generateAndSignEvent(
+            assertion,
+            privkey,
+          );
+          const publisher = this.trustedRelayPublisher ?? this.publisher;
+
+          await publisher.publishEvent(signedEvent);
+          storePublishedTrustedRelayAssertion(
+            assertion.relayUrl,
+            assertion,
+            signedEvent.id,
+          );
+          this.logger.debug(
+            `Published trusted relay assertion (Kind 30385) for ${assertion.relayUrl}` +
+              (change.reason ? ` (${change.reason})` : ""),
+          );
+        } catch (error: unknown) {
+          const errorMsg = getErrorMessage(error);
+          this.logger.error(
+            `Trusted relay assertion publish failed for ${result.url} (attempt ${
+              retryCount + 1
+            }/${maxRetries + 1}): ${errorMsg}`,
+          );
+
+          if (retryCount < maxRetries) {
+            const nextRetryCount = retryCount + 1;
+            const nextBackoffMs = backoffMs * 2;
+            this.logger.info(
+              `Scheduling trusted relay assertion retry ${nextRetryCount}/${maxRetries} for ${result.url} in ${
+                (nextBackoffMs / 1000).toFixed(1)
+              }s`,
+            );
+
+            setTimeout(() => {
+              this.queueManager.addPublishJob(
+                () => publishJob(nextRetryCount, maxRetries, nextBackoffMs),
+                { isRetry: true, category: "other" },
+              );
+            }, nextBackoffMs);
+          } else {
+            this.logger.error(
+              `Exceeded maximum retries (${maxRetries}) for trusted relay assertion ${result.url}`,
+            );
+          }
+
+          throw error;
+        }
+      };
+
+      this.queueManager.addPublishJob(() => publishJob(), {
+        isRetry: false,
+        category: "other",
+      });
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to publish trusted relay assertion for ${result.url}: ${
+          getErrorMessage(error)
+        }`,
+      );
     }
   }
 
@@ -581,12 +886,14 @@ export class Worker {
     let currentRetries = this.relayRetries.get(relayUrl) || 0;
     currentRetries++;
     this.relayRetries.set(relayUrl, currentRetries);
-    
+
     incrementRetryCount(relayUrl);
-    
+
     const delayMs = this.retryManager.getDelay(currentRetries);
     this.logger.debug(
-      `Relay ${relayUrl} failed check, incremented retry count to ${currentRetries} (next check after ~${delayMs/1000}s based on backoff)`
+      `Relay ${relayUrl} failed check, incremented retry count to ${currentRetries} (next check after ~${
+        delayMs / 1000
+      }s based on backoff)`,
     );
   }
 
@@ -595,7 +902,7 @@ export class Worker {
    */
   formatDuration(ms: number): string {
     const seconds = Math.floor(ms / 1000);
-    
+
     if (seconds < 60) {
       return `${seconds}s`;
     } else if (seconds < 3600) {
@@ -611,7 +918,7 @@ export class Worker {
     url: string,
     result: NocapCheckResult | Record<string, never> = {},
     recovered: boolean = false,
-    error: boolean = false
+    error: boolean = false,
   ): void {
     const maxRelayWidth = 50;
     const failure = chalk.red;
@@ -626,30 +933,36 @@ export class Worker {
 
     let formattedUrl = url;
     if (url.length > maxRelayWidth) {
-      formattedUrl = url.substring(0, maxRelayWidth - 3) + '...';
+      formattedUrl = url.substring(0, maxRelayWidth - 3) + "...";
     } else {
-      formattedUrl = url.padEnd(maxRelayWidth, ' ');
+      formattedUrl = url.padEnd(maxRelayWidth, " ");
     }
 
     let progress = "";
-    progress += chalk.hex('#9F2B68').bold(`${formattedUrl}: `);
+    progress += chalk.hex("#9F2B68").bold(`${formattedUrl}: `);
 
     const checks: string[] = this.config.relaymon.checks.enabled || [];
     if (checks.includes("open")) {
       progress += `${
-        result?.open?.data === true ? success("online   ") : failure("offline  ")
+        result?.open?.data === true
+          ? success("online   ")
+          : failure("offline  ")
       } `;
       incD(result?.open?.duration || 0);
     }
     if (checks.includes("read")) {
       progress += `${
-        result?.read?.data === true ? success("readable   ") : failure("unreadable ")
+        result?.read?.data === true
+          ? success("readable   ")
+          : failure("unreadable ")
       } `;
       incD(result?.read?.duration || 0);
     }
     if (checks.includes("write")) {
       progress += `${
-        result?.write?.data === true ? success("writable   ") : failure("unwritable ")
+        result?.write?.data === true
+          ? success("writable   ")
+          : failure("unwritable ")
       } `;
       incD(result?.write?.duration || 0);
     }
@@ -691,26 +1004,30 @@ export class Worker {
 
     if (error) {
       progress += `${chalk.gray.italic("error")} `;
-      
+
       if (retries > 0) {
         const nextRetryDelay = this.retryManager.getDelay(retries);
         const formattedDelay = this.formatDuration(nextRetryDelay);
-        progress += chalk.yellow(`[retries: ${retries}, next: ${formattedDelay}]`);
+        progress += chalk.yellow(
+          `[retries: ${retries}, next: ${formattedDelay}]`,
+        );
       }
     } else if (!isOnline) {
       if (retries > 0) {
         const nextRetryDelay = this.retryManager.getDelay(retries);
         const formattedDelay = this.formatDuration(nextRetryDelay);
-        progress += chalk.yellow(`[retries: ${retries}, next: ${formattedDelay}]`);
+        progress += chalk.yellow(
+          `[retries: ${retries}, next: ${formattedDelay}]`,
+        );
       }
     } else {
       progress += chalk.gray.italic(`${(duration / 1000).toFixed(2)} seconds `);
-      
+
       if (recovered) {
         progress += recoverHighlight(`[RECOVERED]`);
       }
     }
-    
+
     console.log(progress);
   }
 }

--- a/apps/relaymon/src/db/db.ts
+++ b/apps/relaymon/src/db/db.ts
@@ -3,28 +3,62 @@ import { getLogger } from "../utils/logger.ts";
 import type { RelayInfo } from "../types/relay.ts";
 import { createInfoHash } from "../utils/hostnames.ts";
 import {
+  enqueueRemediationDeletion,
   rerunDedupForAllRowsMigration,
   rerunNostringsSweepMigration,
-  enqueueRemediationDeletion,
 } from "../utils/remediation.ts";
 import { purgeNatoPhoneticSpam } from "../../../../libraries/db/src/nato-purge.ts";
 
 const logger = getLogger("DB");
 let isInitialized = false;
 
+function ensureTrustedRelayAssertionTable(): void {
+  db.query(`
+    CREATE TABLE IF NOT EXISTS relay_trust_assertion_state (
+      url TEXT PRIMARY KEY,
+      first_seen INTEGER NOT NULL,
+      last_observed INTEGER NOT NULL,
+      observations INTEGER NOT NULL DEFAULT 0,
+      reachable_observations INTEGER NOT NULL DEFAULT 0,
+      total_rtt_open INTEGER NOT NULL DEFAULT 0,
+      rtt_open_samples INTEGER NOT NULL DEFAULT 0,
+      total_rtt_read INTEGER NOT NULL DEFAULT 0,
+      rtt_read_samples INTEGER NOT NULL DEFAULT 0,
+      last_online_at INTEGER,
+      last_status TEXT,
+      last_score INTEGER,
+      last_reliability INTEGER,
+      last_quality INTEGER,
+      last_accessibility INTEGER,
+      last_confidence TEXT,
+      last_event_id TEXT,
+      last_published_at INTEGER
+    )
+  `);
+}
+
 /**
  * Initialize the database with a specific path
  * @param dbPath Optional path to the SQLite database file
  * @param enableWAL Optional boolean to enable WAL mode (default: true)
  */
-export async function initializeDB(dbPath?: string, enableWAL: boolean = true): Promise<void> {
+export async function initializeDB(
+  dbPath?: string,
+  enableWAL: boolean = true,
+): Promise<void> {
   if (isInitialized) {
-    logger.warn("Database already initialized, ignoring repeated initialization");
+    logger.warn(
+      "Database already initialized, ignoring repeated initialization",
+    );
     return;
   }
 
   const path = dbPath || "relaymon.db";
-  logger.info(`Initializing database with path: ${path}, WAL mode: ${enableWAL ? "enabled" : "disabled"}`);
+  logger.info(
+    `Initializing database with path: ${path}, WAL mode: ${
+      enableWAL ? "enabled" : "disabled"
+    }`,
+  );
   initDB(path, enableWAL);
 
   // Create the relay_info table if it doesn't exist
@@ -122,6 +156,15 @@ export async function initializeDB(dbPath?: string, enableWAL: boolean = true): 
     logger.error(`Failed to create relay_period_snapshots table: ${e}`);
   }
 
+  // Trusted Relay Assertions (kind 30385) need lightweight local history so
+  // RelayMon can publish material changes instead of re-announcing every check.
+  try {
+    ensureTrustedRelayAssertionTable();
+    logger.info("Created relay_trust_assertion_state table if it didn't exist");
+  } catch (e) {
+    logger.error(`Failed to create relay_trust_assertion_state table: ${e}`);
+  }
+
   // Phase 18 Fix 2: re-hash existing relay_info rows using the new
   // normalizeNip11-aware createInfoHash. Idempotent via relaymon_migrations
   // sentinel.
@@ -199,18 +242,24 @@ export async function initializeDB(dbPath?: string, enableWAL: boolean = true): 
  *
  * @param purgedUrlsPath Path to the file containing purged URLs (one per line)
  */
-export async function enqueueNatoPurgedUrls(purgedUrlsPath: string): Promise<void> {
+export async function enqueueNatoPurgedUrls(
+  purgedUrlsPath: string,
+): Promise<void> {
   try {
     let fileContent: string;
     try {
       fileContent = await Deno.readTextFile(purgedUrlsPath);
     } catch (e) {
       // File does not exist — no URLs were purged (or purge hasn't run yet)
-      logger.debug(`NATO purged URLs file not found at ${purgedUrlsPath}, nothing to enqueue: ${e}`);
+      logger.debug(
+        `NATO purged URLs file not found at ${purgedUrlsPath}, nothing to enqueue: ${e}`,
+      );
       return;
     }
 
-    const urls = fileContent.split("\n").filter((line: string) => line.trim().length > 0);
+    const urls = fileContent.split("\n").filter((line: string) =>
+      line.trim().length > 0
+    );
 
     if (urls.length === 0) {
       logger.debug("NATO purged URLs file is empty, nothing to enqueue");
@@ -233,17 +282,24 @@ export async function enqueueNatoPurgedUrls(purgedUrlsPath: string): Promise<voi
  * @param info The NIP-11 info object
  * @param infoHash Hash of the NIP-11 info for comparison
  */
-export function storeRelayInfo(url: string, info: RelayInfo, infoHash: string): void {
+export function storeRelayInfo(
+  url: string,
+  info: RelayInfo,
+  infoHash: string,
+): void {
   try {
     const infoJson = JSON.stringify(info);
     const timestamp = Math.floor(Date.now() / 1000);
-    
+
     // Use REPLACE to update or insert
-    db.query(`
+    db.query(
+      `
       REPLACE INTO relay_info (url, info_json, info_hash, last_updated)
       VALUES (?, ?, ?, ?)
-    `, [url, infoJson, infoHash, timestamp]);
-    
+    `,
+      [url, infoJson, infoHash, timestamp],
+    );
+
     logger.debug(`Stored NIP-11 info for ${url} with hash ${infoHash}`);
   } catch (e) {
     logger.error(`Failed to store relay info for ${url}: ${e}`);
@@ -316,32 +372,37 @@ export function rehashRelayInfoMigration(): void {
  * @param url The relay URL
  * @returns Object with info and infoHash, or null if not found
  */
-export function getRelayInfo(url: string): { info: RelayInfo; infoHash: string } | null {
+export function getRelayInfo(
+  url: string,
+): { info: RelayInfo; infoHash: string } | null {
   try {
-    const result = db.query(`
+    const result = db.query(
+      `
       SELECT info_json, info_hash FROM relay_info
       WHERE url = ?
-    `, [url]);
-    
+    `,
+      [url],
+    );
+
     if (!result || result.length === 0) {
       return null;
     }
-    
+
     const [infoJson, infoHash] = result[0];
-    
+
     let info = null;
     try {
-      if (infoJson && typeof infoJson === 'string') {
+      if (infoJson && typeof infoJson === "string") {
         info = JSON.parse(infoJson);
       }
     } catch (e) {
       logger.warn(`Failed to parse info JSON for relay ${url}: ${e}`);
       return null;
     }
-    
+
     return {
       info,
-      infoHash: infoHash as string
+      infoHash: infoHash as string,
     };
   } catch (e) {
     logger.error(`Error getting relay info from DB for ${url}: ${e}`);
@@ -356,16 +417,19 @@ export function getRelayInfo(url: string): { info: RelayInfo; infoHash: string }
  */
 export function getRelaysWithSameInfo(infoHash: string): string[] {
   try {
-    const results = db.query(`
+    const results = db.query(
+      `
       SELECT url FROM relay_info
       WHERE info_hash = ?
-    `, [infoHash]);
-    
+    `,
+      [infoHash],
+    );
+
     if (!results || results.length === 0) {
       return [];
     }
-    
-    return results.map(row => row[0] as string);
+
+    return results.map((row) => row[0] as string);
   } catch (e) {
     logger.error(`Error getting relays with info hash ${infoHash}: ${e}`);
     return [];
@@ -379,7 +443,9 @@ export function getRelaysWithSameInfo(infoHash: string): string[] {
  */
 export function isRelayIgnored(url: string): boolean {
   try {
-    const result = db.query(`SELECT ignore FROM relay_status WHERE url = ?`, [url]);
+    const result = db.query(`SELECT ignore FROM relay_status WHERE url = ?`, [
+      url,
+    ]);
     if (!result || result.length === 0) {
       return false; // Relay not found in database
     }
@@ -410,11 +476,14 @@ export interface DeltaState {
  */
 export function getLastDeltaState(url: string): DeltaState | null {
   try {
-    const result = db.query(`
+    const result = db.query(
+      `
       SELECT state_json, rtt_open, rtt_read, rtt_write, dns_json, geo_json
       FROM relay_delta_state
       WHERE url = ?
-    `, [url]);
+    `,
+      [url],
+    );
 
     if (!result || result.length === 0) {
       return null;
@@ -424,7 +493,7 @@ export function getLastDeltaState(url: string): DeltaState | null {
 
     let state = null;
     try {
-      if (stateJson && typeof stateJson === 'string') {
+      if (stateJson && typeof stateJson === "string") {
         state = JSON.parse(stateJson);
       }
     } catch (e) {
@@ -434,7 +503,7 @@ export function getLastDeltaState(url: string): DeltaState | null {
 
     let dns = undefined;
     try {
-      if (dnsJson && typeof dnsJson === 'string') {
+      if (dnsJson && typeof dnsJson === "string") {
         dns = JSON.parse(dnsJson);
       }
     } catch (e) {
@@ -443,7 +512,7 @@ export function getLastDeltaState(url: string): DeltaState | null {
 
     let geo = undefined;
     try {
-      if (geoJson && typeof geoJson === 'string') {
+      if (geoJson && typeof geoJson === "string") {
         geo = JSON.parse(geoJson);
       }
     } catch (e) {
@@ -452,9 +521,15 @@ export function getLastDeltaState(url: string): DeltaState | null {
 
     return {
       state,
-      rttOpen: rttOpen !== null && rttOpen !== -1 ? rttOpen as number : undefined,
-      rttRead: rttRead !== null && rttRead !== -1 ? rttRead as number : undefined,
-      rttWrite: rttWrite !== null && rttWrite !== -1 ? rttWrite as number : undefined,
+      rttOpen: rttOpen !== null && rttOpen !== -1
+        ? rttOpen as number
+        : undefined,
+      rttRead: rttRead !== null && rttRead !== -1
+        ? rttRead as number
+        : undefined,
+      rttWrite: rttWrite !== null && rttWrite !== -1
+        ? rttWrite as number
+        : undefined,
       dns,
       geo,
     };
@@ -479,10 +554,13 @@ export function storeDeltaState(url: string, deltaState: DeltaState): void {
     const dnsJson = deltaState.dns ? JSON.stringify(deltaState.dns) : null;
     const geoJson = deltaState.geo ? JSON.stringify(deltaState.geo) : null;
 
-    db.query(`
+    db.query(
+      `
       REPLACE INTO relay_delta_state (url, state_json, rtt_open, rtt_read, rtt_write, dns_json, geo_json, last_updated)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `, [url, stateJson, rttOpen, rttRead, rttWrite, dnsJson, geoJson, timestamp]);
+    `,
+      [url, stateJson, rttOpen, rttRead, rttWrite, dnsJson, geoJson, timestamp],
+    );
 
     logger.debug(`Stored delta state for ${url}`);
   } catch (e) {
@@ -518,13 +596,19 @@ export interface PeriodSnapshot {
  * @param period The period (e.g., "6h", "1d", "7d")
  * @returns The period snapshot or null if not found
  */
-export function getPeriodSnapshot(url: string, period: string): PeriodSnapshot | null {
+export function getPeriodSnapshot(
+  url: string,
+  period: string,
+): PeriodSnapshot | null {
   try {
-    const result = db.query(`
+    const result = db.query(
+      `
       SELECT state_json, snapshot_at
       FROM relay_period_snapshots
       WHERE url = ? AND period = ?
-    `, [url, period]);
+    `,
+      [url, period],
+    );
 
     if (!result || result.length === 0) {
       return null;
@@ -534,20 +618,24 @@ export function getPeriodSnapshot(url: string, period: string): PeriodSnapshot |
 
     let state = null;
     try {
-      if (stateJson && typeof stateJson === 'string') {
+      if (stateJson && typeof stateJson === "string") {
         state = JSON.parse(stateJson);
       }
     } catch (e) {
-      logger.warn(`Failed to parse period snapshot JSON for relay ${url}, period ${period}: ${e}`);
+      logger.warn(
+        `Failed to parse period snapshot JSON for relay ${url}, period ${period}: ${e}`,
+      );
       return null;
     }
 
     return {
       state,
-      snapshotAt: snapshotAt as number
+      snapshotAt: snapshotAt as number,
     };
   } catch (e) {
-    logger.error(`Error getting period snapshot for ${url}, period ${period}: ${e}`);
+    logger.error(
+      `Error getting period snapshot for ${url}, period ${period}: ${e}`,
+    );
     return null;
   }
 }
@@ -558,19 +646,28 @@ export function getPeriodSnapshot(url: string, period: string): PeriodSnapshot |
  * @param period The period (e.g., "6h", "1d", "7d")
  * @param state The relay state to snapshot
  */
-export function storePeriodSnapshot(url: string, period: string, state: RelayInfo): void {
+export function storePeriodSnapshot(
+  url: string,
+  period: string,
+  state: RelayInfo,
+): void {
   try {
     const stateJson = JSON.stringify(state);
     const timestamp = Math.floor(Date.now() / 1000);
 
-    db.query(`
+    db.query(
+      `
       REPLACE INTO relay_period_snapshots (url, period, state_json, snapshot_at)
       VALUES (?, ?, ?, ?)
-    `, [url, period, stateJson, timestamp]);
+    `,
+      [url, period, stateJson, timestamp],
+    );
 
     logger.debug(`Stored period snapshot for ${url}, period ${period}`);
   } catch (e) {
-    logger.error(`Failed to store period snapshot for ${url}, period ${period}: ${e}`);
+    logger.error(
+      `Failed to store period snapshot for ${url}, period ${period}: ${e}`,
+    );
   }
 }
 
@@ -592,25 +689,32 @@ export function clearPeriodSnapshots(url: string): void {
  * @param url The relay URL
  * @returns Map of period to snapshot
  */
-export function getAllPeriodSnapshots(url: string): Map<string, PeriodSnapshot> {
+export function getAllPeriodSnapshots(
+  url: string,
+): Map<string, PeriodSnapshot> {
   const snapshots = new Map<string, PeriodSnapshot>();
 
   try {
-    const results = db.query(`
+    const results = db.query(
+      `
       SELECT period, state_json, snapshot_at
       FROM relay_period_snapshots
       WHERE url = ?
-    `, [url]);
+    `,
+      [url],
+    );
 
     for (const [period, stateJson, snapshotAt] of results) {
       try {
         const state = JSON.parse(stateJson as string);
         snapshots.set(period as string, {
           state,
-          snapshotAt: snapshotAt as number
+          snapshotAt: snapshotAt as number,
         });
       } catch (e) {
-        logger.warn(`Failed to parse snapshot for ${url}, period ${period}: ${e}`);
+        logger.warn(
+          `Failed to parse snapshot for ${url}, period ${period}: ${e}`,
+        );
       }
     }
   } catch (e) {
@@ -620,6 +724,239 @@ export function getAllPeriodSnapshots(url: string): Map<string, PeriodSnapshot> 
   return snapshots;
 }
 
+export interface TrustedRelayObservationState {
+  url: string;
+  firstSeen: number;
+  lastObserved: number;
+  observations: number;
+  reachableObservations: number;
+  totalRttOpen: number;
+  rttOpenSamples: number;
+  totalRttRead: number;
+  rttReadSamples: number;
+  lastOnlineAt?: number;
+}
+
+export interface PublishedTrustedRelayAssertionState {
+  status?: string;
+  score?: number;
+  reliability?: number;
+  quality?: number;
+  accessibility?: number;
+  confidence?: string;
+  eventId?: string;
+  publishedAt?: number;
+}
+
+function observationRowToState(
+  row: unknown[],
+  url: string,
+): TrustedRelayObservationState {
+  const [
+    firstSeen,
+    lastObserved,
+    observations,
+    reachableObservations,
+    totalRttOpen,
+    rttOpenSamples,
+    totalRttRead,
+    rttReadSamples,
+    lastOnlineAt,
+  ] = row;
+
+  return {
+    url,
+    firstSeen: firstSeen as number,
+    lastObserved: lastObserved as number,
+    observations: observations as number,
+    reachableObservations: reachableObservations as number,
+    totalRttOpen: totalRttOpen as number,
+    rttOpenSamples: rttOpenSamples as number,
+    totalRttRead: totalRttRead as number,
+    rttReadSamples: rttReadSamples as number,
+    lastOnlineAt: lastOnlineAt === null ? undefined : lastOnlineAt as number,
+  };
+}
+
+export function recordTrustedRelayObservation(url: string, result: {
+  online?: boolean;
+  open?: { duration?: number };
+  read?: { duration?: number };
+}): TrustedRelayObservationState {
+  ensureTrustedRelayAssertionTable();
+
+  const now = Math.floor(Date.now() / 1000);
+  const online = result.online === true;
+  const rttOpen =
+    typeof result.open?.duration === "number" && result.open.duration > 0
+      ? Math.round(result.open.duration)
+      : 0;
+  const rttRead =
+    typeof result.read?.duration === "number" && result.read.duration > 0
+      ? Math.round(result.read.duration)
+      : 0;
+
+  db.query(
+    `
+    INSERT INTO relay_trust_assertion_state (
+      url,
+      first_seen,
+      last_observed,
+      observations,
+      reachable_observations,
+      total_rtt_open,
+      rtt_open_samples,
+      total_rtt_read,
+      rtt_read_samples,
+      last_online_at
+    )
+    VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(url) DO UPDATE SET
+      last_observed = excluded.last_observed,
+      observations = relay_trust_assertion_state.observations + 1,
+      reachable_observations = relay_trust_assertion_state.reachable_observations + excluded.reachable_observations,
+      total_rtt_open = relay_trust_assertion_state.total_rtt_open + excluded.total_rtt_open,
+      rtt_open_samples = relay_trust_assertion_state.rtt_open_samples + excluded.rtt_open_samples,
+      total_rtt_read = relay_trust_assertion_state.total_rtt_read + excluded.total_rtt_read,
+      rtt_read_samples = relay_trust_assertion_state.rtt_read_samples + excluded.rtt_read_samples,
+      last_online_at = CASE
+        WHEN excluded.last_online_at IS NOT NULL THEN excluded.last_online_at
+        ELSE relay_trust_assertion_state.last_online_at
+      END
+  `,
+    [
+      url,
+      now,
+      now,
+      online ? 1 : 0,
+      rttOpen,
+      rttOpen > 0 ? 1 : 0,
+      rttRead,
+      rttRead > 0 ? 1 : 0,
+      online ? now : null,
+    ],
+  );
+
+  const rows = db.query(
+    `
+    SELECT
+      first_seen,
+      last_observed,
+      observations,
+      reachable_observations,
+      total_rtt_open,
+      rtt_open_samples,
+      total_rtt_read,
+      rtt_read_samples,
+      last_online_at
+    FROM relay_trust_assertion_state
+    WHERE url = ?
+  `,
+    [url],
+  );
+
+  if (!rows.length) {
+    throw new Error(
+      `Failed to read trusted relay observation state for ${url}`,
+    );
+  }
+
+  return observationRowToState(rows[0], url);
+}
+
+export function getPublishedTrustedRelayAssertion(
+  url: string,
+): PublishedTrustedRelayAssertionState | null {
+  ensureTrustedRelayAssertionTable();
+
+  const rows = db.query(
+    `
+    SELECT
+      last_status,
+      last_score,
+      last_reliability,
+      last_quality,
+      last_accessibility,
+      last_confidence,
+      last_event_id,
+      last_published_at
+    FROM relay_trust_assertion_state
+    WHERE url = ?
+  `,
+    [url],
+  );
+
+  if (!rows.length) {
+    return null;
+  }
+
+  const [
+    status,
+    score,
+    reliability,
+    quality,
+    accessibility,
+    confidence,
+    eventId,
+    publishedAt,
+  ] = rows[0];
+
+  if (publishedAt === null || publishedAt === undefined) {
+    return null;
+  }
+
+  return {
+    status: status as string | undefined,
+    score: score === null ? undefined : score as number,
+    reliability: reliability === null ? undefined : reliability as number,
+    quality: quality === null ? undefined : quality as number,
+    accessibility: accessibility === null ? undefined : accessibility as number,
+    confidence: confidence as string | undefined,
+    eventId: eventId as string | undefined,
+    publishedAt: publishedAt as number,
+  };
+}
+
+export function storePublishedTrustedRelayAssertion(url: string, assertion: {
+  status: string;
+  score?: number;
+  reliability?: number;
+  quality?: number;
+  accessibility?: number;
+  confidence: string;
+}, eventId: string): void {
+  ensureTrustedRelayAssertionTable();
+
+  const now = Math.floor(Date.now() / 1000);
+
+  db.query(
+    `
+    UPDATE relay_trust_assertion_state
+    SET
+      last_status = ?,
+      last_score = ?,
+      last_reliability = ?,
+      last_quality = ?,
+      last_accessibility = ?,
+      last_confidence = ?,
+      last_event_id = ?,
+      last_published_at = ?
+    WHERE url = ?
+  `,
+    [
+      assertion.status,
+      assertion.score ?? null,
+      assertion.reliability ?? null,
+      assertion.quality ?? null,
+      assertion.accessibility ?? null,
+      assertion.confidence,
+      eventId,
+      now,
+      url,
+    ],
+  );
+}
+
 /**
  * Mark a relay as ignored in the database
  * @param url The relay URL to mark as ignored
@@ -627,7 +964,10 @@ export function getAllPeriodSnapshots(url: string): Map<string, PeriodSnapshot> 
  */
 export function markRelayIgnored(url: string, reason?: string): void {
   try {
-    db.query(`UPDATE relay_status SET ignore = 1, ignore_reason = ? WHERE url = ?`, [reason || "", url]);
+    db.query(
+      `UPDATE relay_status SET ignore = 1, ignore_reason = ? WHERE url = ?`,
+      [reason || "", url],
+    );
     if (reason) {
       logger.info(`Marked relay ${url} as ignored: ${reason}`);
     } else {
@@ -644,7 +984,10 @@ export function markRelayIgnored(url: string, reason?: string): void {
  */
 export function markRelayUnignored(url: string): void {
   try {
-    db.query(`UPDATE relay_status SET ignore = 0, ignore_reason = '' WHERE url = ?`, [url]);
+    db.query(
+      `UPDATE relay_status SET ignore = 0, ignore_reason = '' WHERE url = ?`,
+      [url],
+    );
     logger.info(`Unmarked relay ${url} as ignored`);
   } catch (e) {
     logger.error(`Failed to unignore relay ${url}: ${e}`);
@@ -656,15 +999,22 @@ export function markRelayUnignored(url: string): void {
  * @param reasonPattern Substring to match against ignore_reason
  * @returns Array of {url, reason} objects
  */
-export function getIgnoredRelaysByReason(reasonPattern: string): Array<{url: string, reason: string}> {
+export function getIgnoredRelaysByReason(
+  reasonPattern: string,
+): Array<{ url: string; reason: string }> {
   try {
     const results = db.query(
       `SELECT url, ignore_reason FROM relay_status WHERE ignore = 1 AND ignore_reason LIKE ?`,
-      [`%${reasonPattern}%`]
+      [`%${reasonPattern}%`],
     );
-    return results.map(([url, reason]) => ({ url: url as string, reason: reason as string }));
+    return results.map(([url, reason]) => ({
+      url: url as string,
+      reason: reason as string,
+    }));
   } catch (e) {
-    logger.error(`Error getting ignored relays by reason pattern "${reasonPattern}": ${e}`);
+    logger.error(
+      `Error getting ignored relays by reason pattern "${reasonPattern}": ${e}`,
+    );
     return [];
   }
 }
@@ -676,7 +1026,10 @@ export function getIgnoredRelaysByReason(reasonPattern: string): Array<{url: str
  */
 export function getIgnoreReason(url: string): string {
   try {
-    const result = db.query(`SELECT ignore_reason FROM relay_status WHERE url = ?`, [url]);
+    const result = db.query(
+      `SELECT ignore_reason FROM relay_status WHERE url = ?`,
+      [url],
+    );
     if (!result || result.length === 0) {
       return "";
     }

--- a/apps/relaymon/src/db/db.ts
+++ b/apps/relaymon/src/db/db.ts
@@ -37,6 +37,38 @@ function ensureTrustedRelayAssertionTable(): void {
   `);
 }
 
+function ensureTrustedRelayObservationHistoryTable(): void {
+  db.query(`
+    CREATE TABLE IF NOT EXISTS relay_trust_observations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      url TEXT NOT NULL,
+      observed_at INTEGER NOT NULL,
+      online INTEGER NOT NULL,
+      rtt_open INTEGER,
+      rtt_read INTEGER,
+      rtt_write INTEGER,
+      network TEXT,
+      nip11_present INTEGER NOT NULL DEFAULT 0,
+      operator_pubkey TEXT,
+      ssl_valid INTEGER,
+      dns_address TEXT,
+      dns_as TEXT,
+      dns_asn TEXT,
+      country_code TEXT,
+      region TEXT,
+      is_hosting INTEGER
+    )
+  `);
+  db.query(`
+    CREATE INDEX IF NOT EXISTS relay_trust_observations_url_observed_idx
+    ON relay_trust_observations (url, observed_at)
+  `);
+  db.query(`
+    CREATE INDEX IF NOT EXISTS relay_trust_observations_observed_idx
+    ON relay_trust_observations (observed_at)
+  `);
+}
+
 /**
  * Initialize the database with a specific path
  * @param dbPath Optional path to the SQLite database file
@@ -156,8 +188,9 @@ export async function initializeDB(
     logger.error(`Failed to create relay_period_snapshots table: ${e}`);
   }
 
-  // Trusted Relay Assertions (kind 30385) need lightweight local history so
+  // Trusted Relay Assertions (kind 30385) need local publication state so
   // RelayMon can publish material changes instead of re-announcing every check.
+  // Detailed per-check TRA history is created only by opt-in TRA publishing.
   try {
     ensureTrustedRelayAssertionTable();
     logger.info("Created relay_trust_assertion_state table if it didn't exist");
@@ -735,6 +768,33 @@ export interface TrustedRelayObservationState {
   totalRttRead: number;
   rttReadSamples: number;
   lastOnlineAt?: number;
+  history?: TrustedRelayObservationSample[];
+}
+
+export interface TrustedRelayObservationSample {
+  url: string;
+  observedAt: number;
+  online: boolean;
+  rttOpen?: number;
+  rttRead?: number;
+  rttWrite?: number;
+  network?: string;
+  nip11Present: boolean;
+  operatorPubkey?: string;
+  sslValid?: boolean;
+  dnsAddress?: string;
+  dnsAs?: string;
+  dnsAsn?: string;
+  countryCode?: string;
+  region?: string;
+  isHosting?: boolean;
+}
+
+export interface TrustedRelayObservationOptions {
+  recordHistory?: boolean;
+  historyRetentionMs?: number | string;
+  maxObservationsPerRelay?: number;
+  observedAt?: number;
 }
 
 export interface PublishedTrustedRelayAssertionState {
@@ -778,23 +838,224 @@ function observationRowToState(
   };
 }
 
+function firstGeoData(result: {
+  geo?: { data?: unknown };
+}): Record<string, unknown> | undefined {
+  const geo = result.geo?.data;
+  if (Array.isArray(geo)) {
+    return geo[0] && typeof geo[0] === "object"
+      ? geo[0] as Record<string, unknown>
+      : undefined;
+  }
+  return geo && typeof geo === "object"
+    ? geo as Record<string, unknown>
+    : undefined;
+}
+
+function inferRelayHosting(result: {
+  geo?: { data?: unknown };
+}): boolean | undefined {
+  const geo = firstGeoData(result);
+  const haystack = `${geo?.isp ?? ""} ${geo?.as ?? ""}`.toLowerCase();
+  if (!haystack.trim()) return undefined;
+
+  return [
+    "hosting",
+    "cloud",
+    "datacenter",
+    "data center",
+    "hetzner",
+    "ovh",
+    "digitalocean",
+    "amazon",
+    "google",
+    "microsoft",
+    "linode",
+    "vultr",
+  ].some((needle) => haystack.includes(needle));
+}
+
+function normalizePositiveDuration(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.round(value)
+    : null;
+}
+
+function normalizeRetentionSeconds(
+  retentionMs: number | string | undefined,
+): number | undefined {
+  if (retentionMs === undefined) return undefined;
+  let ms: number | undefined;
+  if (typeof retentionMs === "number") {
+    ms = retentionMs;
+  } else {
+    const match = retentionMs.trim().match(/^(\d+(?:\.\d+)?)(ms|s|m|h|d)$/);
+    if (match) {
+      const value = parseFloat(match[1]);
+      const unit = match[2];
+      const multipliers: Record<string, number> = {
+        ms: 1,
+        s: 1000,
+        m: 60 * 1000,
+        h: 60 * 60 * 1000,
+        d: 24 * 60 * 60 * 1000,
+      };
+      ms = value * multipliers[unit];
+    }
+  }
+  if (ms === undefined || !Number.isFinite(ms) || ms <= 0) return undefined;
+  return Math.floor(ms / 1000);
+}
+
+function observationSampleFromRow(
+  row: unknown[],
+): TrustedRelayObservationSample {
+  const [
+    url,
+    observedAt,
+    online,
+    rttOpen,
+    rttRead,
+    rttWrite,
+    network,
+    nip11Present,
+    operatorPubkey,
+    sslValid,
+    dnsAddress,
+    dnsAs,
+    dnsAsn,
+    countryCode,
+    region,
+    isHosting,
+  ] = row;
+
+  return {
+    url: url as string,
+    observedAt: observedAt as number,
+    online: (online as number) === 1,
+    rttOpen: rttOpen === null ? undefined : rttOpen as number,
+    rttRead: rttRead === null ? undefined : rttRead as number,
+    rttWrite: rttWrite === null ? undefined : rttWrite as number,
+    network: network === null ? undefined : network as string,
+    nip11Present: (nip11Present as number) === 1,
+    operatorPubkey: operatorPubkey === null
+      ? undefined
+      : operatorPubkey as string,
+    sslValid: sslValid === null ? undefined : (sslValid as number) === 1,
+    dnsAddress: dnsAddress === null ? undefined : dnsAddress as string,
+    dnsAs: dnsAs === null ? undefined : dnsAs as string,
+    dnsAsn: dnsAsn === null ? undefined : dnsAsn as string,
+    countryCode: countryCode === null ? undefined : countryCode as string,
+    region: region === null ? undefined : region as string,
+    isHosting: isHosting === null ? undefined : (isHosting as number) === 1,
+  };
+}
+
+export function getTrustedRelayObservationHistory(
+  url: string,
+): TrustedRelayObservationSample[] {
+  const table = db.query(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name='relay_trust_observations'",
+  );
+  if (!table.length) {
+    return [];
+  }
+
+  const rows = db.query(
+    `
+    SELECT
+      url,
+      observed_at,
+      online,
+      rtt_open,
+      rtt_read,
+      rtt_write,
+      network,
+      nip11_present,
+      operator_pubkey,
+      ssl_valid,
+      dns_address,
+      dns_as,
+      dns_asn,
+      country_code,
+      region,
+      is_hosting
+    FROM relay_trust_observations
+    WHERE url = ?
+    ORDER BY observed_at ASC, id ASC
+  `,
+    [url],
+  );
+
+  return rows.map(observationSampleFromRow);
+}
+
+function pruneTrustedRelayObservationHistory(
+  url: string,
+  observedAt: number,
+  options: TrustedRelayObservationOptions,
+): void {
+  const retentionSeconds = normalizeRetentionSeconds(
+    options.historyRetentionMs,
+  );
+  if (retentionSeconds !== undefined) {
+    db.query(
+      `
+      DELETE FROM relay_trust_observations
+      WHERE url = ? AND observed_at < ?
+    `,
+      [url, observedAt - retentionSeconds],
+    );
+  }
+
+  const maxRows = options.maxObservationsPerRelay;
+  if (typeof maxRows === "number" && Number.isFinite(maxRows) && maxRows > 0) {
+    db.query(
+      `
+      DELETE FROM relay_trust_observations
+      WHERE url = ?
+        AND id NOT IN (
+          SELECT id FROM relay_trust_observations
+          WHERE url = ?
+          ORDER BY observed_at DESC, id DESC
+          LIMIT ?
+        )
+    `,
+      [url, url, Math.floor(maxRows)],
+    );
+  }
+}
+
 export function recordTrustedRelayObservation(url: string, result: {
   online?: boolean;
   open?: { duration?: number };
   read?: { duration?: number };
-}): TrustedRelayObservationState {
+  write?: { duration?: number };
+  checked_at?: number;
+  network?: string;
+  info?: { data?: { pubkey?: string; name?: string; software?: string } };
+  ssl?: { data?: { valid?: boolean } };
+  dns?: {
+    data?: {
+      address?: string;
+      addresses?: string[];
+      as?: string;
+      asn?: string | number;
+    };
+  };
+  geo?: { data?: unknown };
+}, options: TrustedRelayObservationOptions = {}): TrustedRelayObservationState {
   ensureTrustedRelayAssertionTable();
 
-  const now = Math.floor(Date.now() / 1000);
+  const now = typeof options.observedAt === "number"
+    ? Math.floor(options.observedAt)
+    : typeof result.checked_at === "number" && result.checked_at > 0
+    ? Math.floor(result.checked_at)
+    : Math.floor(Date.now() / 1000);
   const online = result.online === true;
-  const rttOpen =
-    typeof result.open?.duration === "number" && result.open.duration > 0
-      ? Math.round(result.open.duration)
-      : 0;
-  const rttRead =
-    typeof result.read?.duration === "number" && result.read.duration > 0
-      ? Math.round(result.read.duration)
-      : 0;
+  const rttOpen = normalizePositiveDuration(result.open?.duration);
+  const rttRead = normalizePositiveDuration(result.read?.duration);
+  const rttWrite = normalizePositiveDuration(result.write?.duration);
 
   db.query(
     `
@@ -829,13 +1090,74 @@ export function recordTrustedRelayObservation(url: string, result: {
       now,
       now,
       online ? 1 : 0,
-      rttOpen,
-      rttOpen > 0 ? 1 : 0,
-      rttRead,
-      rttRead > 0 ? 1 : 0,
+      rttOpen ?? 0,
+      rttOpen !== null ? 1 : 0,
+      rttRead ?? 0,
+      rttRead !== null ? 1 : 0,
       online ? now : null,
     ],
   );
+
+  if (options.recordHistory === true) {
+    ensureTrustedRelayObservationHistoryTable();
+    const geo = firstGeoData(result);
+    const countryCode = typeof geo?.countryCode === "string"
+      ? geo.countryCode.toUpperCase()
+      : undefined;
+    const region = typeof geo?.region === "string" ? geo.region : undefined;
+    const dnsData = result.dns?.data;
+    const dnsAddress = Array.isArray(dnsData?.addresses)
+      ? dnsData?.addresses[0]
+      : dnsData?.address;
+    const dnsAsn = dnsData?.asn === undefined ? undefined : String(dnsData.asn);
+    const isHosting = inferRelayHosting(result);
+
+    db.query(
+      `
+      INSERT INTO relay_trust_observations (
+        url,
+        observed_at,
+        online,
+        rtt_open,
+        rtt_read,
+        rtt_write,
+        network,
+        nip11_present,
+        operator_pubkey,
+        ssl_valid,
+        dns_address,
+        dns_as,
+        dns_asn,
+        country_code,
+        region,
+        is_hosting
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+      [
+        url,
+        now,
+        online ? 1 : 0,
+        rttOpen,
+        rttRead,
+        rttWrite,
+        result.network ?? null,
+        result.info?.data ? 1 : 0,
+        result.info?.data?.pubkey ?? null,
+        typeof result.ssl?.data?.valid === "boolean"
+          ? result.ssl.data.valid ? 1 : 0
+          : null,
+        dnsAddress ?? null,
+        dnsData?.as ?? null,
+        dnsAsn ?? null,
+        countryCode ?? null,
+        region ?? null,
+        isHosting === undefined ? null : isHosting ? 1 : 0,
+      ],
+    );
+
+    pruneTrustedRelayObservationHistory(url, now, options);
+  }
 
   const rows = db.query(
     `
@@ -861,7 +1183,11 @@ export function recordTrustedRelayObservation(url: string, result: {
     );
   }
 
-  return observationRowToState(rows[0], url);
+  const state = observationRowToState(rows[0], url);
+  if (options.recordHistory === true) {
+    state.history = getTrustedRelayObservationHistory(url);
+  }
+  return state;
 }
 
 export function getPublishedTrustedRelayAssertion(

--- a/apps/relaymon/src/delta/kind1066.ts
+++ b/apps/relaymon/src/delta/kind1066.ts
@@ -2,7 +2,7 @@ import { Event, type NostrEvent } from "npm:@nostrwatch/publisher";
 import { finalizeEvent } from "nostr-tools/pure";
 import { hexToBytes } from "@noble/hashes/utils";
 import { getLogger } from "../utils/logger.ts";
-import { deltasToTags, type Delta } from "./detector.ts";
+import { type Delta, deltasToTags } from "./detector.ts";
 
 const logger = getLogger("Kind1066");
 
@@ -12,8 +12,8 @@ export interface Kind1066EventData {
   retryCount?: number;
   rttOpen?: number;
   deltas: Delta[];
-  periods?: string[];  // Period tags (e.g., ["6h", "1d", "7d"])
-  operationalStatus?: "init" | "down" | "up";  // Liveness state transition
+  periods?: string[]; // Period tags (e.g., ["6h", "1d", "7d"])
+  operationalStatus?: "init" | "down" | "up"; // Liveness state transition
 }
 
 /**
@@ -35,42 +35,48 @@ export class Kind1066 extends Event {
     const tags: string[][] = [];
 
     // Always include the relay URL as 'r' tag (reference)
-    tags.push(['r', data.url]);
+    tags.push(["r", data.url]);
 
     // Add operational status tag if this is a state transition
     if (data.operationalStatus) {
-      tags.push(['status', data.operationalStatus]);
-      logger.debug(`Added operational status tag: status:${data.operationalStatus}`);
+      tags.push(["O", data.operationalStatus]);
+      logger.debug(`Added operational status tag: O:${data.operationalStatus}`);
     }
 
     // Add period tags (T tags) if provided - cascading from shortest to longest
     if (data.periods && data.periods.length > 0) {
       for (const period of data.periods) {
-        tags.push(['T', period]);
+        tags.push(["T", period]);
       }
-      logger.debug(`Added ${data.periods.length} period tags: ${data.periods.join(', ')}`);
+      logger.debug(
+        `Added ${data.periods.length} period tags: ${data.periods.join(", ")}`,
+      );
     }
 
     if (data.online) {
       // Online event: include rtt-open and deltas
       if (data.rttOpen !== undefined && data.rttOpen > 0) {
-        tags.push(['rtt-open', String(Math.round(data.rttOpen))]);
+        tags.push(["rtt-open", String(Math.round(data.rttOpen))]);
       }
 
       // Add delta tags (changes, additions, removals)
       const deltaTags = deltasToTags(data.deltas);
       tags.push(...deltaTags);
 
-      logger.debug(`Generated online delta event for ${data.url} with ${data.deltas.length} deltas`);
+      logger.debug(
+        `Generated online delta event for ${data.url} with ${data.deltas.length} deltas`,
+      );
     } else {
       // Offline event: only include retry count
       const retryCount = data.retryCount ?? 0;
-      tags.push(['retry', String(retryCount)]);
+      tags.push(["retry", String(retryCount)]);
 
-      logger.debug(`Generated offline delta event for ${data.url} with retry count ${retryCount}`);
+      logger.debug(
+        `Generated offline delta event for ${data.url} with retry count ${retryCount}`,
+      );
     }
 
-    tags.push(['client', '@nostrwatch/relaymon']);
+    tags.push(["client", "@nostrwatch/relaymon"]);
 
     return tags;
   }
@@ -94,7 +100,10 @@ export class Kind1066 extends Event {
   /**
    * Generate and sign a Kind 1066 event in one call
    */
-  async generateAndSignEvent(data: Kind1066EventData, privkey: string): Promise<any> {
+  async generateAndSignEvent(
+    data: Kind1066EventData,
+    privkey: string,
+  ): Promise<any> {
     const unsignedEvent = this.generateEvent(data);
     const signedEvent = finalizeEvent(unsignedEvent, hexToBytes(privkey));
     return signedEvent;
@@ -107,7 +116,7 @@ export class Kind1066 extends Event {
 export async function createKind1066Event(
   pubkey: string,
   data: Kind1066EventData,
-  privkey: string
+  privkey: string,
 ): Promise<any> {
   const builder = new Kind1066(pubkey);
   return builder.generateAndSignEvent(data, privkey);

--- a/apps/relaymon/src/tra/kind30385.ts
+++ b/apps/relaymon/src/tra/kind30385.ts
@@ -1,0 +1,538 @@
+import { Event } from "npm:@nostrwatch/publisher";
+import { finalizeEvent } from "nostr-tools/pure";
+import { hexToBytes } from "@noble/hashes/utils";
+import type { TrustedRelayAssertionsConfig } from "../types/config.ts";
+import type { GeoResult, RelayCheckResult, RelayInfo } from "../types/relay.ts";
+import type {
+  PublishedTrustedRelayAssertionState,
+  TrustedRelayObservationState,
+} from "../db/db.ts";
+
+export type TrustedRelayAssertionStatus =
+  | "evaluated"
+  | "insufficient_data"
+  | "unreachable"
+  | "blocked";
+
+export interface TrustedRelayAssertion {
+  relayUrl: string;
+  status: TrustedRelayAssertionStatus;
+  score?: number;
+  reliability?: number;
+  quality?: number;
+  accessibility?: number;
+  confidence: "low" | "medium" | "high";
+  observations: number;
+  observationPeriod: string;
+  firstSeen: number;
+  algorithm: string;
+  algorithmUrl?: string;
+  operator?: string;
+  operatorVerified?: "nip11";
+  operatorConfidence?: number;
+  policy?: "open" | "moderated" | "curated" | "specialized";
+  policyConfidence?: number;
+  countryCode?: string;
+  region?: string;
+  isHosting?: boolean;
+  network?: "clearnet" | "tor" | "i2p";
+}
+
+export interface TrustedRelayMaterialChange {
+  changed: boolean;
+  reason?: string;
+}
+
+interface Kind30385Event {
+  kind: 30385;
+  pubkey: string;
+  created_at: number;
+  tags: string[][];
+  content: string;
+}
+
+const DEFAULT_ALGORITHM_VERSION = "relaymon-local-v1";
+const DEFAULT_ALGORITHM_URL =
+  "https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md";
+
+export function normalizeRelayUrl(url: string): string {
+  const parsed = new URL(url);
+  parsed.protocol = parsed.protocol === "wss:" ? "wss:" : "ws:";
+  parsed.hash = "";
+  const normalized = parsed.toString().toLowerCase();
+  return normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
+}
+
+function clampScore(score: number): number {
+  return Math.min(100, Math.max(0, Math.round(score)));
+}
+
+function scoreLatency(ms: number | undefined): number {
+  if (ms === undefined || !Number.isFinite(ms) || ms <= 0) return 50;
+  if (ms <= 50) return 100;
+  if (ms <= 100) return 95;
+  if (ms <= 150) return 90;
+  if (ms <= 200) return 85;
+  if (ms <= 300) return 75;
+  if (ms <= 500) return 60;
+  if (ms <= 750) return 40;
+  if (ms <= 1000) return 20;
+  return 0;
+}
+
+function average(total: number, samples: number): number | undefined {
+  if (samples <= 0) return undefined;
+  return total / samples;
+}
+
+function computeReliability(
+  result: RelayCheckResult,
+  history: TrustedRelayObservationState,
+): number {
+  const uptime = history.observations > 0
+    ? (history.reachableObservations / history.observations) * 100
+    : result.online
+    ? 100
+    : 0;
+  const averageOpen = average(history.totalRttOpen, history.rttOpenSamples) ??
+    result.open?.duration;
+  const latencyScore = scoreLatency(averageOpen);
+  const offlinePenalty = result.online ? 0 : 25;
+
+  return clampScore((uptime * 0.7) + (latencyScore * 0.3) - offlinePenalty);
+}
+
+function scorePolicyClarity(nip11?: RelayInfo): number {
+  if (!nip11) return 50;
+
+  let score = 50;
+  if (nip11.name && nip11.description) score += 15;
+  else if (nip11.name || nip11.description) score += 8;
+
+  if (nip11.contact) score += 15;
+  if (nip11.software || nip11.version) score += 5;
+  if (nip11.limitation) {
+    score += 10;
+    if (nip11.limitation.max_message_length !== undefined) score += 1;
+    if (nip11.limitation.max_subscriptions !== undefined) score += 1;
+    if (nip11.limitation.max_event_tags !== undefined) score += 1;
+    if (nip11.limitation.max_content_length !== undefined) score += 1;
+  }
+  if (nip11.limitation?.payment_required && !nip11.fees) score -= 10;
+
+  let cap = 100;
+  if (!(nip11.name || nip11.description)) cap = Math.min(cap, 50);
+  if (!nip11.contact) cap = Math.min(cap, 70);
+  if (!nip11.limitation) cap = Math.min(cap, 85);
+
+  return clampScore(Math.min(score, cap));
+}
+
+function scoreConnectionSecurity(result: RelayCheckResult): number {
+  if (result.protocol === "wss:") {
+    if (result.ssl?.data?.valid === false) return 75;
+    return 100;
+  }
+  if (result.protocol === "ws:") return 0;
+  return 50;
+}
+
+function scoreOperatorAccountability(nip11?: RelayInfo): number {
+  return isHexPubkey(nip11?.pubkey) ? 70 : 50;
+}
+
+function computeQuality(result: RelayCheckResult): number {
+  const nip11 = result.info?.data;
+  const policy = scorePolicyClarity(nip11);
+  const security = scoreConnectionSecurity(result);
+  const operator = scoreOperatorAccountability(nip11);
+  return clampScore((policy * 0.60) + (security * 0.25) + (operator * 0.15));
+}
+
+function scoreAccessBarriers(nip11?: RelayInfo): number {
+  if (!nip11) return 70;
+  const penalties: number[] = [];
+  const limitation = nip11.limitation;
+  if (limitation?.payment_required) penalties.push(40);
+  if (limitation?.auth_required) penalties.push(30);
+  if (
+    typeof limitation?.min_pow_difficulty === "number" &&
+    limitation.min_pow_difficulty > 0
+  ) {
+    penalties.push(Math.min(15, limitation.min_pow_difficulty));
+  }
+
+  penalties.sort((a, b) => b - a);
+  const multipliers = [1, 0.5, 0.3, 0.2];
+  const totalPenalty = penalties.reduce((total, penalty, index) => {
+    return total +
+      (penalty * multipliers[Math.min(index, multipliers.length - 1)]);
+  }, 0);
+
+  return clampScore(100 - totalPenalty);
+}
+
+function scoreLimitRestrictiveness(nip11?: RelayInfo): number {
+  if (!nip11?.limitation) return nip11 ? 100 : 80;
+  const limitation = nip11.limitation;
+  let score = 100;
+
+  if (
+    limitation.max_subscriptions !== undefined &&
+    limitation.max_subscriptions < 5
+  ) score -= 15;
+  else if (
+    limitation.max_subscriptions !== undefined &&
+    limitation.max_subscriptions < 10
+  ) score -= 5;
+
+  if (
+    limitation.max_content_length !== undefined &&
+    limitation.max_content_length < 1000
+  ) score -= 15;
+  else if (
+    limitation.max_content_length !== undefined &&
+    limitation.max_content_length < 5000
+  ) score -= 5;
+
+  if (
+    limitation.max_message_length !== undefined &&
+    limitation.max_message_length < 10000
+  ) score -= 10;
+  else if (
+    limitation.max_message_length !== undefined &&
+    limitation.max_message_length < 32000
+  ) score -= 3;
+
+  if (limitation.max_filters !== undefined && limitation.max_filters < 5) {
+    score -= 10;
+  } else if (
+    limitation.max_filters !== undefined && limitation.max_filters < 10
+  ) score -= 3;
+
+  if (
+    limitation.max_event_tags !== undefined && limitation.max_event_tags < 50
+  ) score -= 5;
+
+  return clampScore(score);
+}
+
+function computeAccessibility(result: RelayCheckResult): number {
+  const nip11 = result.info?.data;
+  const geo = firstGeo(result.geo?.data);
+  const countryScore = geo?.countryCode ? 75 : 75;
+  const surveillanceScore = geo?.countryCode ? 85 : 85;
+
+  return clampScore(
+    (scoreAccessBarriers(nip11) * 0.40) +
+      (scoreLimitRestrictiveness(nip11) * 0.20) +
+      (countryScore * 0.20) +
+      (surveillanceScore * 0.20),
+  );
+}
+
+function getConfidence(observations: number): "low" | "medium" | "high" {
+  if (observations >= 500) return "high";
+  if (observations >= 100) return "medium";
+  return "low";
+}
+
+function observationPeriod(firstSeen: number, lastObserved: number): string {
+  const days = Math.floor(Math.max(0, lastObserved - firstSeen) / 86400);
+  return days > 0 ? `${days}d` : "<1d";
+}
+
+function isHexPubkey(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{64}$/i.test(value);
+}
+
+function firstGeo(
+  geo: GeoResult | GeoResult[] | undefined,
+): GeoResult | undefined {
+  if (Array.isArray(geo)) return geo[0];
+  return geo;
+}
+
+function inferPolicy(
+  result: RelayCheckResult,
+): TrustedRelayAssertion["policy"] {
+  const info = result.info?.data;
+  if (!info) return undefined;
+
+  const supportedNips = Array.isArray(info.supported_nips)
+    ? info.supported_nips.map(Number)
+    : [];
+  if (
+    supportedNips.includes(46) &&
+    supportedNips.every((nip) => [1, 9, 46].includes(nip))
+  ) {
+    return "specialized";
+  }
+
+  if (
+    info.limitation?.restricted_writes ||
+    Array.isArray(info.kinds) && info.kinds.length > 0
+  ) {
+    return "specialized";
+  }
+
+  if (info.limitation?.auth_required || info.limitation?.payment_required) {
+    return "curated";
+  }
+
+  if (
+    typeof info.posting_policy === "string" ||
+    Array.isArray(info.tags) && info.tags.length > 0
+  ) {
+    return "moderated";
+  }
+
+  return "open";
+}
+
+function inferPolicyConfidence(result: RelayCheckResult): number | undefined {
+  if (!result.info?.data) return undefined;
+  if (
+    result.info.data.limitation || result.info.data.posting_policy ||
+    result.info.data.tags
+  ) return 85;
+  return 60;
+}
+
+function inferNetwork(
+  result: RelayCheckResult,
+  relayUrl: string,
+): TrustedRelayAssertion["network"] {
+  const host = new URL(relayUrl).hostname;
+  if (result.network === "tor" || host.endsWith(".onion")) return "tor";
+  if (result.network === "i2p" || host.endsWith(".i2p")) return "i2p";
+  if (result.network === "clearnet") return "clearnet";
+  return undefined;
+}
+
+function inferIsHosting(result: RelayCheckResult): boolean | undefined {
+  const geo = firstGeo(result.geo?.data);
+  const haystack = `${geo?.isp ?? ""} ${geo?.as ?? ""}`.toLowerCase();
+  if (!haystack.trim()) return undefined;
+
+  return [
+    "hosting",
+    "cloud",
+    "datacenter",
+    "data center",
+    "hetzner",
+    "ovh",
+    "digitalocean",
+    "amazon",
+    "google",
+    "microsoft",
+    "linode",
+    "vultr",
+  ].some((needle) => haystack.includes(needle));
+}
+
+export function buildTrustedRelayAssertion(
+  result: RelayCheckResult,
+  history: TrustedRelayObservationState,
+  config: TrustedRelayAssertionsConfig,
+): TrustedRelayAssertion {
+  const relayUrl = normalizeRelayUrl(result.url);
+  const reliability = computeReliability(result, history);
+  const quality = computeQuality(result);
+  const accessibility = computeAccessibility(result);
+  const score = clampScore(
+    (reliability * 0.40) + (quality * 0.35) + (accessibility * 0.25),
+  );
+  const minObservations = config.min_observations ?? 10;
+
+  let status: TrustedRelayAssertionStatus;
+  if (result.ignore) {
+    status = "blocked";
+  } else if (!result.online) {
+    status = "unreachable";
+  } else if (history.observations < minObservations) {
+    status = "insufficient_data";
+  } else {
+    status = "evaluated";
+  }
+
+  const assertion: TrustedRelayAssertion = {
+    relayUrl,
+    status,
+    score,
+    reliability,
+    quality,
+    accessibility,
+    confidence: getConfidence(history.observations),
+    observations: history.observations,
+    observationPeriod: observationPeriod(
+      history.firstSeen,
+      history.lastObserved,
+    ),
+    firstSeen: history.firstSeen,
+    algorithm: config.algorithm?.version ?? DEFAULT_ALGORITHM_VERSION,
+    algorithmUrl: config.algorithm?.url ?? DEFAULT_ALGORITHM_URL,
+    policy: inferPolicy(result),
+    policyConfidence: inferPolicyConfidence(result),
+    isHosting: inferIsHosting(result),
+    network: inferNetwork(result, relayUrl),
+  };
+
+  const info = result.info?.data;
+  if (isHexPubkey(info?.pubkey)) {
+    assertion.operator = info.pubkey.toLowerCase();
+    assertion.operatorVerified = "nip11";
+    assertion.operatorConfidence = 70;
+  }
+
+  const geo = firstGeo(result.geo?.data);
+  if (typeof geo?.countryCode === "string" && geo.countryCode.length > 0) {
+    assertion.countryCode = geo.countryCode.toUpperCase();
+  }
+  if (typeof geo?.region === "string" && geo.region.length > 0) {
+    assertion.region = geo.region;
+  }
+
+  return assertion;
+}
+
+export function hasTrustedRelayMaterialChange(
+  current: TrustedRelayAssertion,
+  previous: PublishedTrustedRelayAssertionState | null,
+  threshold = 3,
+  refreshIntervalMs = 60 * 60 * 1000,
+  now = Math.floor(Date.now() / 1000),
+): TrustedRelayMaterialChange {
+  if (!previous?.publishedAt) {
+    return { changed: true, reason: "first_publish" };
+  }
+
+  if (current.status !== previous.status) {
+    return {
+      changed: true,
+      reason: `status_changed:${previous.status}->${current.status}`,
+    };
+  }
+
+  if (current.confidence !== previous.confidence) {
+    return {
+      changed: true,
+      reason:
+        `confidence_changed:${previous.confidence}->${current.confidence}`,
+    };
+  }
+
+  const scoreFields: Array<
+    keyof Pick<
+      TrustedRelayAssertion,
+      "score" | "reliability" | "quality" | "accessibility"
+    >
+  > = [
+    "score",
+    "reliability",
+    "quality",
+    "accessibility",
+  ];
+  for (const field of scoreFields) {
+    const currentValue = current[field];
+    const previousValue = previous[field];
+    if (
+      currentValue !== undefined && previousValue !== undefined &&
+      Math.abs(currentValue - previousValue) >= threshold
+    ) {
+      return {
+        changed: true,
+        reason: `${field}_changed:${previousValue}->${currentValue}`,
+      };
+    }
+    if (currentValue !== undefined && previousValue === undefined) {
+      return { changed: true, reason: `${field}_appeared` };
+    }
+  }
+
+  const refreshSeconds = Math.floor(refreshIntervalMs / 1000);
+  if (refreshSeconds > 0 && now - previous.publishedAt >= refreshSeconds) {
+    return { changed: true, reason: "refresh_interval" };
+  }
+
+  return { changed: false };
+}
+
+export class Kind30385 extends Event {
+  constructor(pubkey: string) {
+    super(30385, pubkey);
+  }
+
+  private generateTags(assertion: TrustedRelayAssertion): string[][] {
+    const tags: string[][] = [
+      ["d", assertion.relayUrl],
+      ["status", assertion.status],
+      ["algorithm", assertion.algorithm],
+    ];
+
+    if (assertion.algorithmUrl) {
+      tags.push(["algorithm_url", assertion.algorithmUrl]);
+    }
+    if (assertion.score !== undefined) {
+      tags.push(["score", String(assertion.score)]);
+    }
+    if (assertion.reliability !== undefined) {
+      tags.push(["reliability", String(assertion.reliability)]);
+    }
+    if (assertion.quality !== undefined) {
+      tags.push(["quality", String(assertion.quality)]);
+    }
+    if (assertion.accessibility !== undefined) {
+      tags.push(["accessibility", String(assertion.accessibility)]);
+    }
+
+    tags.push(["confidence", assertion.confidence]);
+    tags.push(["observations", String(assertion.observations)]);
+    tags.push(["observation_period", assertion.observationPeriod]);
+    tags.push(["first_seen", String(assertion.firstSeen)]);
+
+    if (assertion.operator) tags.push(["operator", assertion.operator]);
+    if (assertion.operatorVerified) {
+      tags.push(["operator_verified", assertion.operatorVerified]);
+    }
+    if (assertion.operatorConfidence !== undefined) {
+      tags.push(["operator_confidence", String(assertion.operatorConfidence)]);
+    }
+    if (assertion.policy) tags.push(["policy", assertion.policy]);
+    if (assertion.policyConfidence !== undefined) {
+      tags.push(["policy_confidence", String(assertion.policyConfidence)]);
+    }
+    if (assertion.countryCode) {
+      tags.push(["country_code", assertion.countryCode]);
+    }
+    if (assertion.region) tags.push(["region", assertion.region]);
+    if (assertion.isHosting !== undefined) {
+      tags.push(["is_hosting", String(assertion.isHosting)]);
+    }
+    if (assertion.network) tags.push(["network", assertion.network]);
+
+    tags.push(["client", "@nostrwatch/relaymon"]);
+
+    return tags;
+  }
+
+  protected override _generateEvent(
+    assertion: TrustedRelayAssertion,
+  ): Kind30385Event {
+    return {
+      kind: 30385,
+      pubkey: this.pubkey,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: this.generateTags(assertion),
+      content: "",
+    };
+  }
+
+  async generateAndSignEvent(
+    assertion: TrustedRelayAssertion,
+    privkey: string,
+  ): Promise<any> {
+    const unsignedEvent = this.generateEvent(assertion);
+    return finalizeEvent(unsignedEvent, hexToBytes(privkey));
+  }
+}

--- a/apps/relaymon/src/tra/kind30385.ts
+++ b/apps/relaymon/src/tra/kind30385.ts
@@ -5,6 +5,7 @@ import type { TrustedRelayAssertionsConfig } from "../types/config.ts";
 import type { GeoResult, RelayCheckResult, RelayInfo } from "../types/relay.ts";
 import type {
   PublishedTrustedRelayAssertionState,
+  TrustedRelayObservationSample,
   TrustedRelayObservationState,
 } from "../db/db.ts";
 
@@ -51,9 +52,45 @@ interface Kind30385Event {
   content: string;
 }
 
-const DEFAULT_ALGORITHM_VERSION = "relaymon-local-v1";
+const DEFAULT_ALGORITHM_VERSION = "relaymon-local-v2";
 const DEFAULT_ALGORITHM_URL =
   "https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md";
+const ANONYMOUS_NETWORK_COUNTRY_CODE = "XX";
+const LOW_SURVEILLANCE_COUNTRIES = new Set([
+  "CH",
+  "DE",
+  "FI",
+  "IS",
+  "NL",
+  "NO",
+  "SE",
+]);
+const MODERATE_SURVEILLANCE_COUNTRIES = new Set([
+  "AU",
+  "CA",
+  "FR",
+  "GB",
+  "NZ",
+  "US",
+]);
+const HIGH_SURVEILLANCE_COUNTRIES = new Set([
+  "CN",
+  "IR",
+  "KP",
+  "RU",
+  "SA",
+  "TR",
+]);
+const HIGH_CENSORSHIP_COUNTRIES = new Set([
+  "CN",
+  "CU",
+  "IR",
+  "KP",
+  "RU",
+  "SA",
+  "SY",
+  "TM",
+]);
 
 export function normalizeRelayUrl(url: string): string {
   const parsed = new URL(url);
@@ -85,6 +122,160 @@ function average(total: number, samples: number): number | undefined {
   return total / samples;
 }
 
+function percentile(values: number[], percentileValue: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = (sorted.length - 1) * percentileValue;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return sorted[lower];
+  const weight = index - lower;
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight;
+}
+
+function sampleLatency(
+  sample: TrustedRelayObservationSample,
+): number | undefined {
+  const durations = [
+    sample.rttOpen,
+    sample.rttRead,
+    sample.rttWrite,
+  ].filter((value): value is number => {
+    return typeof value === "number" && Number.isFinite(value) && value > 0;
+  });
+  if (!durations.length) return undefined;
+  return durations.reduce((total, duration) => total + duration, 0) /
+    durations.length;
+}
+
+function resultLatency(result: RelayCheckResult): number | undefined {
+  const durations = [
+    result.open?.duration,
+    result.read?.duration,
+    result.write?.duration,
+  ].filter((value): value is number => {
+    return typeof value === "number" && Number.isFinite(value) && value > 0;
+  });
+  if (!durations.length) return undefined;
+  return durations.reduce((total, duration) => total + duration, 0) /
+    durations.length;
+}
+
+function historySamples(
+  history: TrustedRelayObservationState,
+): TrustedRelayObservationSample[] {
+  return [...(history.history ?? [])].sort((a, b) => {
+    if (a.observedAt !== b.observedAt) return a.observedAt - b.observedAt;
+    return a.url.localeCompare(b.url);
+  });
+}
+
+function computeLatencyScore(
+  result: RelayCheckResult,
+  history: TrustedRelayObservationState,
+): number {
+  const sampleLatencies = historySamples(history)
+    .map(sampleLatency)
+    .filter((value): value is number => value !== undefined);
+
+  if (sampleLatencies.length > 0) {
+    const mean = sampleLatencies.reduce((total, value) => total + value, 0) /
+      sampleLatencies.length;
+    return scoreLatency(mean);
+  }
+
+  const aggregateLatency = average(
+    history.totalRttOpen + history.totalRttRead,
+    history.rttOpenSamples + history.rttReadSamples,
+  );
+  return scoreLatency(aggregateLatency ?? resultLatency(result));
+}
+
+function computeConsistencyScore(
+  result: RelayCheckResult,
+  history: TrustedRelayObservationState,
+): number {
+  const sampleLatencies = historySamples(history)
+    .map(sampleLatency)
+    .filter((value): value is number => value !== undefined);
+  if (sampleLatencies.length < 3) {
+    return scoreLatency(resultLatency(result)) * 0.5 + 50;
+  }
+
+  const median = percentile(sampleLatencies, 0.5);
+  if (median <= 0) return 75;
+
+  const iqr = percentile(sampleLatencies, 0.75) -
+    percentile(sampleLatencies, 0.25);
+  const jitterRatio = iqr / median;
+  return clampScore(100 - (jitterRatio * 80));
+}
+
+function outageSeverityPenalty(length: number): number {
+  if (length <= 0) return 0;
+  if (length === 1) return 3;
+  if (length <= 3) return 8;
+  if (length <= 6) return 16;
+  if (length <= 12) return 28;
+  if (length <= 24) return 45;
+  return 65;
+}
+
+function computeOutageResilience(
+  result: RelayCheckResult,
+  history: TrustedRelayObservationState,
+): number {
+  const samples = historySamples(history);
+  if (samples.length === 0) {
+    const uptime = history.observations > 0
+      ? (history.reachableObservations / history.observations) * 100
+      : result.online
+      ? 100
+      : 0;
+    return clampScore(uptime - (result.online ? 0 : 20));
+  }
+
+  let outageCount = 0;
+  let currentOutageLength = 0;
+  let outageSeverity = 0;
+  let transitions = 0;
+  let previousOnline = samples[0]?.online;
+
+  for (const sample of samples) {
+    if (previousOnline !== undefined && sample.online !== previousOnline) {
+      transitions += 1;
+    }
+    previousOnline = sample.online;
+
+    if (!sample.online) {
+      currentOutageLength += 1;
+      continue;
+    }
+
+    if (currentOutageLength > 0) {
+      outageCount += 1;
+      outageSeverity += outageSeverityPenalty(currentOutageLength);
+      currentOutageLength = 0;
+    }
+  }
+
+  if (currentOutageLength > 0) {
+    outageCount += 1;
+    outageSeverity += outageSeverityPenalty(currentOutageLength);
+  }
+
+  const frequencyPenalty = Math.min(25, outageCount * 3);
+  const flappingPenalty = Math.min(20, transitions * 4);
+  const currentPenalty = result.online ? 0 : 10;
+  return clampScore(
+    100 -
+      Math.min(65, outageSeverity) -
+      frequencyPenalty -
+      flappingPenalty -
+      currentPenalty,
+  );
+}
+
 function computeReliability(
   result: RelayCheckResult,
   history: TrustedRelayObservationState,
@@ -94,12 +285,18 @@ function computeReliability(
     : result.online
     ? 100
     : 0;
-  const averageOpen = average(history.totalRttOpen, history.rttOpenSamples) ??
-    result.open?.duration;
-  const latencyScore = scoreLatency(averageOpen);
-  const offlinePenalty = result.online ? 0 : 25;
+  const latencyScore = computeLatencyScore(result, history);
+  const consistencyScore = computeConsistencyScore(result, history);
+  const outageResilience = computeOutageResilience(result, history);
+  const offlinePenalty = result.online ? 0 : 15;
 
-  return clampScore((uptime * 0.7) + (latencyScore * 0.3) - offlinePenalty);
+  return clampScore(
+    (uptime * 0.35) +
+      (outageResilience * 0.25) +
+      (consistencyScore * 0.20) +
+      (latencyScore * 0.20) -
+      offlinePenalty,
+  );
 }
 
 function scorePolicyClarity(nip11?: RelayInfo): number {
@@ -137,6 +334,22 @@ function scoreConnectionSecurity(result: RelayCheckResult): number {
   return 50;
 }
 
+function scoreDnsEvidence(result: RelayCheckResult): number {
+  if (!result.dns) return 50;
+  if (result.dns.error) return 25;
+
+  const data = result.dns.data;
+  let score = 60;
+  if (
+    typeof data.address === "string" ||
+    Array.isArray(data.addresses) && data.addresses.length > 0
+  ) {
+    score += 25;
+  }
+  if (data.as || data.asn) score += 10;
+  return clampScore(score);
+}
+
 function scoreOperatorAccountability(nip11?: RelayInfo): number {
   return isHexPubkey(nip11?.pubkey) ? 70 : 50;
 }
@@ -145,8 +358,12 @@ function computeQuality(result: RelayCheckResult): number {
   const nip11 = result.info?.data;
   const policy = scorePolicyClarity(nip11);
   const security = scoreConnectionSecurity(result);
+  const dns = scoreDnsEvidence(result);
   const operator = scoreOperatorAccountability(nip11);
-  return clampScore((policy * 0.60) + (security * 0.25) + (operator * 0.15));
+  return clampScore(
+    (policy * 0.45) + (security * 0.20) + (dns * 0.20) +
+      (operator * 0.15),
+  );
 }
 
 function scoreAccessBarriers(nip11?: RelayInfo): number {
@@ -217,11 +434,58 @@ function scoreLimitRestrictiveness(nip11?: RelayInfo): number {
   return clampScore(score);
 }
 
+function scoreJurisdiction(
+  countryCode: string | undefined,
+  network: TrustedRelayAssertion["network"],
+): number {
+  if (network === "tor" || network === "i2p") return 90;
+  if (!countryCode) return 70;
+  if (HIGH_CENSORSHIP_COUNTRIES.has(countryCode)) return 25;
+  if (LOW_SURVEILLANCE_COUNTRIES.has(countryCode)) return 90;
+  if (MODERATE_SURVEILLANCE_COUNTRIES.has(countryCode)) return 70;
+  return 75;
+}
+
+function scoreSurveillanceRisk(
+  countryCode: string | undefined,
+  network: TrustedRelayAssertion["network"],
+): number {
+  if (network === "tor" || network === "i2p") return 90;
+  if (!countryCode) return 70;
+  if (HIGH_SURVEILLANCE_COUNTRIES.has(countryCode)) return 25;
+  if (MODERATE_SURVEILLANCE_COUNTRIES.has(countryCode)) return 60;
+  if (LOW_SURVEILLANCE_COUNTRIES.has(countryCode)) return 90;
+  return 75;
+}
+
+function inferCountryCode(
+  result: RelayCheckResult,
+  network: TrustedRelayAssertion["network"],
+): string | undefined {
+  if (network === "tor" || network === "i2p") {
+    return ANONYMOUS_NETWORK_COUNTRY_CODE;
+  }
+
+  const geo = firstGeo(result.geo?.data);
+  if (typeof geo?.countryCode === "string" && geo.countryCode.length > 0) {
+    return geo.countryCode.toUpperCase();
+  }
+
+  const relayCountries = result.info?.data?.relay_countries;
+  const relayCountry = Array.isArray(relayCountries) ? relayCountries[0] : "";
+  if (typeof relayCountry === "string" && relayCountry.length > 0) {
+    return relayCountry.toUpperCase();
+  }
+
+  return undefined;
+}
+
 function computeAccessibility(result: RelayCheckResult): number {
   const nip11 = result.info?.data;
-  const geo = firstGeo(result.geo?.data);
-  const countryScore = geo?.countryCode ? 75 : 75;
-  const surveillanceScore = geo?.countryCode ? 85 : 85;
+  const network = inferNetwork(result, normalizeRelayUrl(result.url));
+  const countryCode = inferCountryCode(result, network);
+  const countryScore = scoreJurisdiction(countryCode, network);
+  const surveillanceScore = scoreSurveillanceRisk(countryCode, network);
 
   return clampScore(
     (scoreAccessBarriers(nip11) * 0.40) +
@@ -337,6 +601,7 @@ export function buildTrustedRelayAssertion(
   config: TrustedRelayAssertionsConfig,
 ): TrustedRelayAssertion {
   const relayUrl = normalizeRelayUrl(result.url);
+  const network = inferNetwork(result, relayUrl);
   const reliability = computeReliability(result, history);
   const quality = computeQuality(result);
   const accessibility = computeAccessibility(result);
@@ -375,7 +640,7 @@ export function buildTrustedRelayAssertion(
     policy: inferPolicy(result),
     policyConfidence: inferPolicyConfidence(result),
     isHosting: inferIsHosting(result),
-    network: inferNetwork(result, relayUrl),
+    network,
   };
 
   const info = result.info?.data;
@@ -385,11 +650,15 @@ export function buildTrustedRelayAssertion(
     assertion.operatorConfidence = 70;
   }
 
-  const geo = firstGeo(result.geo?.data);
-  if (typeof geo?.countryCode === "string" && geo.countryCode.length > 0) {
-    assertion.countryCode = geo.countryCode.toUpperCase();
+  const countryCode = inferCountryCode(result, network);
+  if (countryCode) {
+    assertion.countryCode = countryCode;
   }
-  if (typeof geo?.region === "string" && geo.region.length > 0) {
+  const geo = firstGeo(result.geo?.data);
+  if (
+    countryCode !== ANONYMOUS_NETWORK_COUNTRY_CODE &&
+    typeof geo?.region === "string" && geo.region.length > 0
+  ) {
     assertion.region = geo.region;
   }
 

--- a/apps/relaymon/src/types/config.ts
+++ b/apps/relaymon/src/types/config.ts
@@ -34,8 +34,8 @@ export interface MonitorInfoConfig {
   name?: string;
   about?: string;
   nip05?: string;
-  lud16?: string; 
-  picture?: string; 
+  lud16?: string;
+  picture?: string;
   banner?: string;
 }
 
@@ -92,7 +92,7 @@ export interface SeedOptions {
     path?: string;
   };
   config?: string[];
-  [key: string]: any;  // Allow other seed-specific options
+  [key: string]: any; // Allow other seed-specific options
 }
 
 /**
@@ -175,7 +175,7 @@ export interface DeduplicationConfig {
  */
 export interface PeriodConfig {
   enabled: boolean;
-  definitions: string[];  // e.g., ["6h", "1d", "7d", "30d"]
+  definitions: string[]; // e.g., ["6h", "1d", "7d", "30d"]
 }
 
 /**
@@ -183,8 +183,25 @@ export interface PeriodConfig {
  */
 export interface DeltaConfig {
   enabled: boolean;
-  max_retries?: number;  // Stop publishing delta events after N offline retries
-  periods?: PeriodConfig;  // Period aggregate configuration
+  max_retries?: number; // Stop publishing delta events after N offline retries
+  periods?: PeriodConfig; // Period aggregate configuration
+}
+
+/**
+ * Trusted Relay Assertion publishing configuration (Kind 30385)
+ */
+export interface TrustedRelayAssertionsConfig {
+  enabled: boolean;
+  relays?: string[];
+  min_observations?: number;
+  material_change_threshold?: number;
+  refresh_interval?: number | string;
+  publish_unreachable?: boolean;
+  publish_blocked?: boolean;
+  algorithm?: {
+    version?: string;
+    url?: string;
+  };
 }
 
 /**
@@ -198,6 +215,7 @@ export interface RelaymonConfig {
   ignorelist?: IgnoreListConfig;
   deduplication?: DeduplicationConfig;
   delta?: DeltaConfig;
+  trustedRelayAssertions?: TrustedRelayAssertionsConfig;
 }
 
 /**
@@ -346,7 +364,9 @@ export function validateConfig(config: unknown): Config {
   }
 
   if (!Array.isArray(c.relaymon.networks)) {
-    throw new Error("Missing required field: relaymon.networks (must be array)");
+    throw new Error(
+      "Missing required field: relaymon.networks (must be array)",
+    );
   }
 
   if (c.relaymon.networks.length === 0) {
@@ -357,7 +377,9 @@ export function validateConfig(config: unknown): Config {
   for (const network of c.relaymon.networks) {
     if (!isValidNetwork(network)) {
       throw new Error(
-        `Invalid network type: "${network}". Must be one of: ${VALID_NETWORKS.join(", ")}`
+        `Invalid network type: "${network}". Must be one of: ${
+          VALID_NETWORKS.join(", ")
+        }`,
       );
     }
   }
@@ -368,7 +390,9 @@ export function validateConfig(config: unknown): Config {
   }
 
   if (!Array.isArray(c.relaymon.retry.expiry)) {
-    throw new Error("Missing required field: relaymon.retry.expiry (must be array)");
+    throw new Error(
+      "Missing required field: relaymon.retry.expiry (must be array)",
+    );
   }
 
   // Validate seed configuration exists
@@ -377,11 +401,15 @@ export function validateConfig(config: unknown): Config {
   }
 
   if (typeof c.relaymon.seed.interval !== "number") {
-    throw new Error("Missing required field: relaymon.seed.interval (must be number)");
+    throw new Error(
+      "Missing required field: relaymon.seed.interval (must be number)",
+    );
   }
 
   if (!Array.isArray(c.relaymon.seed.sources)) {
-    throw new Error("Missing required field: relaymon.seed.sources (must be array)");
+    throw new Error(
+      "Missing required field: relaymon.seed.sources (must be array)",
+    );
   }
 
   if (!c.relaymon.seed.options || typeof c.relaymon.seed.options !== "object") {
@@ -394,11 +422,125 @@ export function validateConfig(config: unknown): Config {
   }
 
   if (!Array.isArray(c.relaymon.checks.enabled)) {
-    throw new Error("Missing required field: relaymon.checks.enabled (must be array)");
+    throw new Error(
+      "Missing required field: relaymon.checks.enabled (must be array)",
+    );
   }
 
-  if (!c.relaymon.checks.options || typeof c.relaymon.checks.options !== "object") {
+  if (
+    !c.relaymon.checks.options || typeof c.relaymon.checks.options !== "object"
+  ) {
     throw new Error("Missing required field: relaymon.checks.options");
+  }
+
+  // Validate Trusted Relay Assertions (Kind 30385) configuration if present.
+  // Defaults mirror the reference implementation's material-change behavior
+  // while keeping the feature opt-in for existing RelayMon deployments.
+  if (c.relaymon.trustedRelayAssertions !== undefined) {
+    const tra = c.relaymon.trustedRelayAssertions;
+    if (typeof tra !== "object" || tra === null || Array.isArray(tra)) {
+      throw new Error(
+        "relaymon.trustedRelayAssertions must be an object when present",
+      );
+    }
+
+    if (typeof tra.enabled !== "boolean") {
+      throw new Error(
+        "relaymon.trustedRelayAssertions.enabled must be boolean",
+      );
+    }
+
+    if (tra.relays === undefined) {
+      tra.relays = [];
+    } else if (
+      !Array.isArray(tra.relays) ||
+      !tra.relays.every((relay: unknown) => typeof relay === "string")
+    ) {
+      throw new Error(
+        "relaymon.trustedRelayAssertions.relays must be an array of strings",
+      );
+    }
+
+    if (tra.min_observations === undefined) {
+      tra.min_observations = 10;
+    } else if (
+      typeof tra.min_observations !== "number" || tra.min_observations < 1
+    ) {
+      throw new Error(
+        "relaymon.trustedRelayAssertions.min_observations must be a positive number",
+      );
+    }
+
+    if (tra.material_change_threshold === undefined) {
+      tra.material_change_threshold = 3;
+    } else if (
+      typeof tra.material_change_threshold !== "number" ||
+      tra.material_change_threshold < 0
+    ) {
+      throw new Error(
+        "relaymon.trustedRelayAssertions.material_change_threshold must be a non-negative number",
+      );
+    }
+
+    if (tra.refresh_interval === undefined) {
+      tra.refresh_interval = "1h";
+    } else if (
+      typeof tra.refresh_interval !== "number" &&
+      typeof tra.refresh_interval !== "string"
+    ) {
+      throw new Error(
+        "relaymon.trustedRelayAssertions.refresh_interval must be a number or timestring",
+      );
+    }
+
+    if (tra.publish_unreachable === undefined) {
+      tra.publish_unreachable = true;
+    } else if (typeof tra.publish_unreachable !== "boolean") {
+      throw new Error(
+        "relaymon.trustedRelayAssertions.publish_unreachable must be boolean",
+      );
+    }
+
+    if (tra.publish_blocked === undefined) {
+      tra.publish_blocked = false;
+    } else if (typeof tra.publish_blocked !== "boolean") {
+      throw new Error(
+        "relaymon.trustedRelayAssertions.publish_blocked must be boolean",
+      );
+    }
+
+    if (tra.algorithm === undefined) {
+      tra.algorithm = {};
+    } else if (
+      typeof tra.algorithm !== "object" || tra.algorithm === null ||
+      Array.isArray(tra.algorithm)
+    ) {
+      throw new Error(
+        "relaymon.trustedRelayAssertions.algorithm must be an object",
+      );
+    }
+
+    if (tra.algorithm.version === undefined) {
+      tra.algorithm.version = "relaymon-local-v1";
+    } else if (
+      typeof tra.algorithm.version !== "string" ||
+      tra.algorithm.version.length === 0
+    ) {
+      throw new Error(
+        "relaymon.trustedRelayAssertions.algorithm.version must be a non-empty string",
+      );
+    }
+
+    if (tra.algorithm.url === undefined) {
+      tra.algorithm.url =
+        "https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md";
+    } else if (
+      typeof tra.algorithm.url !== "string" || tra.algorithm.url.length === 0
+    ) {
+      throw new Error(
+        "relaymon.trustedRelayAssertions.algorithm.url must be a non-empty string",
+      );
+    }
   }
 
   // Phase 20: validate optional deduplication.nip11_stale_skip and apply
@@ -408,12 +550,17 @@ export function validateConfig(config: unknown): Config {
   // acceptable so this validator survives a future move of the conversion
   // step into processConfigTimeValues without further edits.
   if (c.relaymon.deduplication !== undefined) {
-    if (typeof c.relaymon.deduplication !== "object" || c.relaymon.deduplication === null) {
+    if (
+      typeof c.relaymon.deduplication !== "object" ||
+      c.relaymon.deduplication === null
+    ) {
       throw new Error("relaymon.deduplication must be an object when present");
     }
 
     const dedup = c.relaymon.deduplication;
-    if (dedup.nip11_stale_skip === undefined || dedup.nip11_stale_skip === null) {
+    if (
+      dedup.nip11_stale_skip === undefined || dedup.nip11_stale_skip === null
+    ) {
       // Default applied when missing — Plan 20-03 reads this via
       // appConfig?.relaymon?.deduplication?.nip11_stale_skip
       dedup.nip11_stale_skip = "7d";
@@ -434,7 +581,9 @@ export function validateConfig(config: unknown): Config {
     }
 
     if (typeof c.health.enabled !== "boolean") {
-      throw new Error("Missing required field: health.enabled (must be boolean)");
+      throw new Error(
+        "Missing required field: health.enabled (must be boolean)",
+      );
     }
 
     if (c.health.enabled) {
@@ -444,19 +593,27 @@ export function validateConfig(config: unknown): Config {
       }
 
       if (typeof c.health.server.enabled !== "boolean") {
-        throw new Error("Missing required field: health.server.enabled (must be boolean)");
+        throw new Error(
+          "Missing required field: health.server.enabled (must be boolean)",
+        );
       }
 
       if (typeof c.health.server.host !== "string") {
-        throw new Error("Missing required field: health.server.host (must be string)");
+        throw new Error(
+          "Missing required field: health.server.host (must be string)",
+        );
       }
 
       if (typeof c.health.server.port !== "number") {
-        throw new Error("Missing required field: health.server.port (must be number)");
+        throw new Error(
+          "Missing required field: health.server.port (must be number)",
+        );
       }
 
       if (typeof c.health.server.authEnabled !== "boolean") {
-        throw new Error("Missing required field: health.server.authEnabled (must be boolean)");
+        throw new Error(
+          "Missing required field: health.server.authEnabled (must be boolean)",
+        );
       }
 
       // Validate kuma config
@@ -465,23 +622,39 @@ export function validateConfig(config: unknown): Config {
       }
 
       if (typeof c.health.kuma.enabled !== "boolean") {
-        throw new Error("Missing required field: health.kuma.enabled (must be boolean)");
+        throw new Error(
+          "Missing required field: health.kuma.enabled (must be boolean)",
+        );
       }
 
-      if (typeof c.health.kuma.intervalMs !== "number" && typeof c.health.kuma.intervalMs !== "string") {
-        throw new Error("Missing required field: health.kuma.intervalMs (must be number or timestring)");
+      if (
+        typeof c.health.kuma.intervalMs !== "number" &&
+        typeof c.health.kuma.intervalMs !== "string"
+      ) {
+        throw new Error(
+          "Missing required field: health.kuma.intervalMs (must be number or timestring)",
+        );
       }
 
       if (typeof c.health.kuma.degradedAsUp !== "boolean") {
-        throw new Error("Missing required field: health.kuma.degradedAsUp (must be boolean)");
+        throw new Error(
+          "Missing required field: health.kuma.degradedAsUp (must be boolean)",
+        );
       }
 
-      if (typeof c.health.kuma.startupGraceMs !== "number" && typeof c.health.kuma.startupGraceMs !== "string") {
-        throw new Error("Missing required field: health.kuma.startupGraceMs (must be number or timestring)");
+      if (
+        typeof c.health.kuma.startupGraceMs !== "number" &&
+        typeof c.health.kuma.startupGraceMs !== "string"
+      ) {
+        throw new Error(
+          "Missing required field: health.kuma.startupGraceMs (must be number or timestring)",
+        );
       }
 
       if (!["summary", "detailed"].includes(c.health.kuma.msgVerbosity)) {
-        throw new Error("health.kuma.msgVerbosity must be 'summary' or 'detailed'");
+        throw new Error(
+          "health.kuma.msgVerbosity must be 'summary' or 'detailed'",
+        );
       }
 
       // Validate thresholds config
@@ -489,20 +662,34 @@ export function validateConfig(config: unknown): Config {
         throw new Error("Missing required field: health.thresholds");
       }
 
-      if (typeof c.health.thresholds.checkIdleMs !== "number" && typeof c.health.thresholds.checkIdleMs !== "string") {
-        throw new Error("Missing required field: health.thresholds.checkIdleMs (must be number or timestring)");
+      if (
+        typeof c.health.thresholds.checkIdleMs !== "number" &&
+        typeof c.health.thresholds.checkIdleMs !== "string"
+      ) {
+        throw new Error(
+          "Missing required field: health.thresholds.checkIdleMs (must be number or timestring)",
+        );
       }
 
       if (typeof c.health.thresholds.publishBacklogMax !== "number") {
-        throw new Error("Missing required field: health.thresholds.publishBacklogMax (must be number)");
+        throw new Error(
+          "Missing required field: health.thresholds.publishBacklogMax (must be number)",
+        );
       }
 
       if (typeof c.health.thresholds.errorRatePerMin !== "number") {
-        throw new Error("Missing required field: health.thresholds.errorRatePerMin (must be number)");
+        throw new Error(
+          "Missing required field: health.thresholds.errorRatePerMin (must be number)",
+        );
       }
 
-      if (typeof c.health.thresholds.startupGraceMs !== "number" && typeof c.health.thresholds.startupGraceMs !== "string") {
-        throw new Error("Missing required field: health.thresholds.startupGraceMs (must be number or timestring)");
+      if (
+        typeof c.health.thresholds.startupGraceMs !== "number" &&
+        typeof c.health.thresholds.startupGraceMs !== "string"
+      ) {
+        throw new Error(
+          "Missing required field: health.thresholds.startupGraceMs (must be number or timestring)",
+        );
       }
     }
   }

--- a/apps/relaymon/src/types/config.ts
+++ b/apps/relaymon/src/types/config.ts
@@ -196,6 +196,8 @@ export interface TrustedRelayAssertionsConfig {
   min_observations?: number;
   material_change_threshold?: number;
   refresh_interval?: number | string;
+  history_retention?: number | string;
+  max_observations_per_relay?: number;
   publish_unreachable?: boolean;
   publish_blocked?: boolean;
   algorithm?: {
@@ -493,6 +495,28 @@ export function validateConfig(config: unknown): Config {
       );
     }
 
+    if (tra.history_retention === undefined) {
+      tra.history_retention = "30d";
+    } else if (
+      typeof tra.history_retention !== "number" &&
+      typeof tra.history_retention !== "string"
+    ) {
+      throw new Error(
+        "relaymon.trustedRelayAssertions.history_retention must be a number or timestring",
+      );
+    }
+
+    if (tra.max_observations_per_relay === undefined) {
+      tra.max_observations_per_relay = 1000;
+    } else if (
+      typeof tra.max_observations_per_relay !== "number" ||
+      tra.max_observations_per_relay < 1
+    ) {
+      throw new Error(
+        "relaymon.trustedRelayAssertions.max_observations_per_relay must be a positive number",
+      );
+    }
+
     if (tra.publish_unreachable === undefined) {
       tra.publish_unreachable = true;
     } else if (typeof tra.publish_unreachable !== "boolean") {
@@ -521,7 +545,7 @@ export function validateConfig(config: unknown): Config {
     }
 
     if (tra.algorithm.version === undefined) {
-      tra.algorithm.version = "relaymon-local-v1";
+      tra.algorithm.version = "relaymon-local-v2";
     } else if (
       typeof tra.algorithm.version !== "string" ||
       tra.algorithm.version.length === 0

--- a/apps/relaymon/tests/integration/worker.test.ts
+++ b/apps/relaymon/tests/integration/worker.test.ts
@@ -10,14 +10,18 @@
  * - Status tracking
  */
 
-import { assertEquals, assert, assertExists } from "https://deno.land/std@0.218.2/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.218.2/assert/mod.ts";
 import { Worker } from "../../src/core/worker.ts";
 import { QueueManager } from "../../src/utils/queueManager.ts";
-import { initializeDB, db } from "../../src/db/db.ts";
+import { db, initializeDB } from "../../src/db/db.ts";
 import { mockConfig } from "../helpers/fixtures.ts";
 import type { Config } from "../../src/types/config.ts";
 import { getPublicKey, nip19 } from "npm:nostr-tools";
-import { hexToBytes } from "npm:@noble/hashes/utils";
+import { hexToBytes } from "@noble/hashes/utils";
 
 // Initialize test database
 const testDbPath = ":memory:";
@@ -25,7 +29,7 @@ initializeDB(testDbPath, false);
 
 // Test private key for signing
 const testPrivkey = "a".repeat(64);
-const testPubkey = getPublicKey(testPrivkey);
+const testPubkey = getPublicKey(hexToBytes(testPrivkey));
 
 // Set env var for tests (convert to nsec format)
 const testNsec = nip19.nsecEncode(hexToBytes(testPrivkey));
@@ -49,7 +53,7 @@ function workerTest(name: string, fn: () => void | Promise<void>) {
     name,
     sanitizeResources: false,
     sanitizeOps: false,
-    fn
+    fn,
   });
 }
 
@@ -78,15 +82,18 @@ workerTest("Worker - can be instantiated with valid config", () => {
 /**
  * Test: Worker initializes relay status from database
  */
-workerTest("Worker - initializes relay status from database on construction", () => {
-  clearDatabase();
-  db.query(
-    "INSERT INTO relay_status (url, online, retries, checked_at, network) VALUES (?, ?, ?, ?, ?)",
-    ["wss://test.relay.com", 1, 3, Date.now(), "clearnet"]
-  );
-  const { worker } = createTestWorker();
-  assertExists(worker);
-});
+workerTest(
+  "Worker - initializes relay status from database on construction",
+  () => {
+    clearDatabase();
+    db.query(
+      "INSERT INTO relay_status (url, online, retries, checked_at, network) VALUES (?, ?, ?, ?, ?)",
+      ["wss://test.relay.com", 1, 3, Date.now(), "clearnet"],
+    );
+    const { worker } = createTestWorker();
+    assertExists(worker);
+  },
+);
 
 /**
  * Test: processRelay skips blocked hostnames
@@ -113,7 +120,7 @@ workerTest("Worker - processRelay skips already ignored relays", async () => {
   // Pre-populate database with an ignored relay
   db.query(
     "INSERT INTO relay_status (url, online, ignore, checked_at, network) VALUES (?, ?, ?, ?, ?)",
-    ["wss://ignored.relay.com", 0, 1, Date.now(), "clearnet"]
+    ["wss://ignored.relay.com", 0, 1, Date.now(), "clearnet"],
   );
 
   const { worker } = createTestWorker();
@@ -122,7 +129,9 @@ workerTest("Worker - processRelay skips already ignored relays", async () => {
   await worker.processRelay("wss://ignored.relay.com");
 
   // Verify it's still marked as ignored
-  const result = db.query("SELECT ignore FROM relay_status WHERE url = ?", ["wss://ignored.relay.com"]);
+  const result = db.query("SELECT ignore FROM relay_status WHERE url = ?", [
+    "wss://ignored.relay.com",
+  ]);
   assertEquals(result.length, 1);
   assertEquals(result[0][0], 1); // Still ignored
 });
@@ -136,7 +145,7 @@ workerTest("Worker - processRelay handles first-time relay check", async () => {
   // Insert a relay with checked_at = -1 (first check marker)
   db.query(
     "INSERT INTO relay_status (url, online, checked_at, network) VALUES (?, ?, ?, ?)",
-    ["wss://new.relay.com", 0, -1, "clearnet"]
+    ["wss://new.relay.com", 0, -1, "clearnet"],
   );
 
   const { worker } = createTestWorker();
@@ -146,7 +155,9 @@ workerTest("Worker - processRelay handles first-time relay check", async () => {
   await worker.processRelay("wss://new.relay.com");
 
   // Verify it completed without error (checked_at may or may not be updated depending on error handling)
-  const result = db.query("SELECT checked_at FROM relay_status WHERE url = ?", ["wss://new.relay.com"]);
+  const result = db.query("SELECT checked_at FROM relay_status WHERE url = ?", [
+    "wss://new.relay.com",
+  ]);
   // Test passes if the relay still exists in the database
   assert(result.length > 0);
 });
@@ -154,63 +165,77 @@ workerTest("Worker - processRelay handles first-time relay check", async () => {
 /**
  * Test: processRelay persists check results to database
  */
-workerTest("Worker - processRelay persists check results to database", async () => {
-  clearDatabase();
+workerTest(
+  "Worker - processRelay persists check results to database",
+  async () => {
+    clearDatabase();
 
-  const { worker } = createTestWorker();
-  const testUrl = "wss://test-persistence.relay.com";
+    const { worker } = createTestWorker();
+    const testUrl = "wss://test-persistence.relay.com";
 
-  // Process a relay (will fail to connect, but should persist the attempt)
-  await worker.processRelay(testUrl);
+    // Process a relay (will fail to connect, but should persist the attempt)
+    await worker.processRelay(testUrl);
 
-  // Check that a database entry was created or updated
-  const result = db.query("SELECT url, checked_at FROM relay_status WHERE url = ?", [testUrl]);
+    // Check that a database entry was created or updated
+    const result = db.query(
+      "SELECT url, checked_at FROM relay_status WHERE url = ?",
+      [testUrl],
+    );
 
-  // Should have persisted something about this relay
-  assertExists(result);
-});
+    // Should have persisted something about this relay
+    assertExists(result);
+  },
+);
 
 /**
  * Test: processRelay handles relay check errors gracefully
  */
-workerTest("Worker - processRelay handles relay check errors gracefully", async () => {
-  clearDatabase();
+workerTest(
+  "Worker - processRelay handles relay check errors gracefully",
+  async () => {
+    clearDatabase();
 
-  const { worker } = createTestWorker();
+    const { worker } = createTestWorker();
 
-  // Process an invalid relay URL - should handle error gracefully
-  await worker.processRelay("wss://nonexistent-test-relay-12345.invalid");
+    // Process an invalid relay URL - should handle error gracefully
+    await worker.processRelay("wss://nonexistent-test-relay-12345.invalid");
 
-  // Should complete without throwing
-  assert(true);
-});
+    // Should complete without throwing
+    assert(true);
+  },
+);
 
 /**
  * Test: processRelay tracks retry counts for offline relays
  */
-workerTest("Worker - processRelay tracks retry counts for offline relays", async () => {
-  clearDatabase();
+workerTest(
+  "Worker - processRelay tracks retry counts for offline relays",
+  async () => {
+    clearDatabase();
 
-  const testUrl = "wss://offline-retry.relay.com";
+    const testUrl = "wss://offline-retry.relay.com";
 
-  // Pre-populate with an offline relay
-  db.query(
-    "INSERT INTO relay_status (url, online, retries, checked_at, network) VALUES (?, ?, ?, ?, ?)",
-    [testUrl, 0, 0, Date.now() - 1000000, "clearnet"]
-  );
+    // Pre-populate with an offline relay
+    db.query(
+      "INSERT INTO relay_status (url, online, retries, checked_at, network) VALUES (?, ?, ?, ?, ?)",
+      [testUrl, 0, 0, Date.now() - 1000000, "clearnet"],
+    );
 
-  const { worker } = createTestWorker();
+    const { worker } = createTestWorker();
 
-  // Process the relay - it will fail again, incrementing retry count
-  await worker.processRelay(testUrl);
+    // Process the relay - it will fail again, incrementing retry count
+    await worker.processRelay(testUrl);
 
-  // Check if retries were incremented
-  const result = db.query("SELECT retries FROM relay_status WHERE url = ?", [testUrl]);
-  if (result.length > 0) {
-    // Retries should have been incremented (could be 0 or 1 depending on logic)
-    assert((result[0][0] as number) >= 0);
-  }
-});
+    // Check if retries were incremented
+    const result = db.query("SELECT retries FROM relay_status WHERE url = ?", [
+      testUrl,
+    ]);
+    if (result.length > 0) {
+      // Retries should have been incremented (could be 0 or 1 depending on logic)
+      assert((result[0][0] as number) >= 0);
+    }
+  },
+);
 
 /**
  * Test: Worker respects publish retry configuration
@@ -223,9 +248,9 @@ workerTest("Worker - respects publish retry configuration from config", () => {
     publisher: {
       retry: {
         maxRetries: 10,
-        initialBackoffMs: 5000
-      }
-    }
+        initialBackoffMs: 5000,
+      },
+    },
   };
 
   const queueManager = new QueueManager(5, 2, customConfig as Config);
@@ -246,7 +271,7 @@ workerTest("Worker - can process multiple relays sequentially", async () => {
   const relays = [
     "wss://test1.relay.com",
     "wss://test2.relay.com",
-    "wss://test3.relay.com"
+    "wss://test3.relay.com",
   ];
 
   // Process all relays
@@ -262,40 +287,46 @@ workerTest("Worker - can process multiple relays sequentially", async () => {
 /**
  * Test: Worker handles relay recovery (offline -> online)
  */
-workerTest("Worker - tracks relay recovery from offline to online", async () => {
-  clearDatabase();
+workerTest(
+  "Worker - tracks relay recovery from offline to online",
+  async () => {
+    clearDatabase();
 
-  const testUrl = "wss://recovery-test.relay.com";
+    const testUrl = "wss://recovery-test.relay.com";
 
-  // Pre-populate with an offline relay that had retries
-  db.query(
-    "INSERT INTO relay_status (url, online, retries, checked_at, network) VALUES (?, ?, ?, ?, ?)",
-    [testUrl, 0, 5, Date.now() - 1000000, "clearnet"]
-  );
+    // Pre-populate with an offline relay that had retries
+    db.query(
+      "INSERT INTO relay_status (url, online, retries, checked_at, network) VALUES (?, ?, ?, ?, ?)",
+      [testUrl, 0, 5, Date.now() - 1000000, "clearnet"],
+    );
 
-  const { worker } = createTestWorker();
+    const { worker } = createTestWorker();
 
-  // Process the relay (will fail to connect, but tests the recovery logic)
-  await worker.processRelay(testUrl);
+    // Process the relay (will fail to connect, but tests the recovery logic)
+    await worker.processRelay(testUrl);
 
-  // The test verifies the worker doesn't crash when handling potential recovery scenarios
-  assert(true);
-});
+    // The test verifies the worker doesn't crash when handling potential recovery scenarios
+    assert(true);
+  },
+);
 
 /**
  * Test: Worker integrates with QueueManager for publishing
  */
-workerTest("Worker - integrates with QueueManager for publishing events", async () => {
-  clearDatabase();
+workerTest(
+  "Worker - integrates with QueueManager for publishing events",
+  async () => {
+    clearDatabase();
 
-  const { worker, queueManager } = createTestWorker();
+    const { worker, queueManager } = createTestWorker();
 
-  // Check that queue manager is accessible and functional
-  assertExists(queueManager);
+    // Check that queue manager is accessible and functional
+    assertExists(queueManager);
 
-  // Process a relay - should add publish jobs to the queue
-  await worker.processRelay("wss://publish-test.relay.com");
+    // Process a relay - should add publish jobs to the queue
+    await worker.processRelay("wss://publish-test.relay.com");
 
-  // Queue manager should have been used (no crash = success)
-  assert(true);
-});
+    // Queue manager should have been used (no crash = success)
+    assert(true);
+  },
+);

--- a/apps/relaymon/tests/unit/config-types.test.ts
+++ b/apps/relaymon/tests/unit/config-types.test.ts
@@ -275,13 +275,21 @@ Deno.test("Config validation - trustedRelayAssertions defaults are applied", () 
   );
   assertEquals(result.relaymon.trustedRelayAssertions?.refresh_interval, "1h");
   assertEquals(
+    result.relaymon.trustedRelayAssertions?.history_retention,
+    "30d",
+  );
+  assertEquals(
+    result.relaymon.trustedRelayAssertions?.max_observations_per_relay,
+    1000,
+  );
+  assertEquals(
     result.relaymon.trustedRelayAssertions?.publish_unreachable,
     true,
   );
   assertEquals(result.relaymon.trustedRelayAssertions?.publish_blocked, false);
   assertEquals(
     result.relaymon.trustedRelayAssertions?.algorithm?.version,
-    "relaymon-local-v1",
+    "relaymon-local-v2",
   );
 });
 

--- a/apps/relaymon/tests/unit/config-types.test.ts
+++ b/apps/relaymon/tests/unit/config-types.test.ts
@@ -5,11 +5,19 @@
  * Following Test-Driven Development: tests written BEFORE implementation.
  */
 
-import { assertEquals, assertExists, assertThrows } from "https://deno.land/std@0.218.2/assert/mod.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertThrows,
+} from "https://deno.land/std@0.218.2/assert/mod.ts";
 import { mockConfig } from "../helpers/fixtures.ts";
 
 // Import types that we're about to create
-import type { Config, MonitorConfig, RelaymonConfig } from "../../src/types/config.ts";
+import type {
+  Config,
+  MonitorConfig,
+  RelaymonConfig,
+} from "../../src/types/config.ts";
 import { validateConfig } from "../../src/types/config.ts";
 
 Deno.test("Config validation - valid config passes", () => {
@@ -18,19 +26,19 @@ Deno.test("Config validation - valid config passes", () => {
       slug: "test",
       info: {
         name: "Test Monitor",
-        about: "Test monitor"
+        about: "Test monitor",
       },
-      owner: "test-pubkey"
+      owner: "test-pubkey",
     },
     publisher: {
-      relays: ["wss://relay.test.com"]
+      relays: ["wss://relay.test.com"],
     },
     relaymon: {
       networks: ["clearnet"],
       retry: {
         expiry: [
-          { max: 3, delay: 60000 }
-        ]
+          { max: 3, delay: 60000 },
+        ],
       },
       seed: {
         interval: 60000,
@@ -38,9 +46,9 @@ Deno.test("Config validation - valid config passes", () => {
         options: {
           db: {
             path: "./test.db",
-            enableWAL: true
-          }
-        }
+            enableWAL: true,
+          },
+        },
       },
       checks: {
         enabled: ["open", "read"],
@@ -49,13 +57,13 @@ Deno.test("Config validation - valid config passes", () => {
           interval: 15000,
           timeout: {
             open: 30000,
-            read: 5000
+            read: 5000,
           },
           max: 200,
-          statusInterval: 20
-        }
-      }
-    }
+          statusInterval: 20,
+        },
+      },
+    },
   };
 
   const result = validateConfig(validConfig);
@@ -74,16 +82,16 @@ Deno.test("Config validation - missing monitor.slug throws", () => {
   const invalidConfig = {
     monitor: {
       info: { name: "Test", about: "Test" },
-      owner: "pubkey"
+      owner: "pubkey",
     },
     publisher: { relays: [] },
-    relaymon: {} as any
+    relaymon: {} as any,
   };
 
   assertThrows(
     () => validateConfig(invalidConfig as any),
     Error,
-    "monitor.slug"
+    "monitor.slug",
   );
 });
 
@@ -92,16 +100,16 @@ Deno.test("Config validation - missing monitor.info.name throws", () => {
     monitor: {
       slug: "test",
       info: { about: "Test" },
-      owner: "pubkey"
+      owner: "pubkey",
     },
     publisher: { relays: [] },
-    relaymon: {} as any
+    relaymon: {} as any,
   };
 
   assertThrows(
     () => validateConfig(invalidConfig as any),
     Error,
-    "monitor.info.name"
+    "monitor.info.name",
   );
 });
 
@@ -110,20 +118,20 @@ Deno.test("Config validation - missing relaymon.networks throws", () => {
     monitor: {
       slug: "test",
       info: { name: "Test", about: "Test" },
-      owner: "pubkey"
+      owner: "pubkey",
     },
     publisher: { relays: [] },
     relaymon: {
       retry: { expiry: [] },
       seed: { interval: 1000, sources: [], options: {} },
-      checks: { enabled: [], options: {} as any }
-    }
+      checks: { enabled: [], options: {} as any },
+    },
   };
 
   assertThrows(
     () => validateConfig(invalidConfig as any),
     Error,
-    "relaymon.networks"
+    "relaymon.networks",
   );
 });
 
@@ -132,21 +140,21 @@ Deno.test("Config validation - empty relaymon.networks throws", () => {
     monitor: {
       slug: "test",
       info: { name: "Test", about: "Test" },
-      owner: "pubkey"
+      owner: "pubkey",
     },
     publisher: { relays: [] },
     relaymon: {
       networks: [],
       retry: { expiry: [] },
       seed: { interval: 1000, sources: [], options: {} },
-      checks: { enabled: [], options: {} as any }
-    }
+      checks: { enabled: [], options: {} as any },
+    },
   };
 
   assertThrows(
     () => validateConfig(invalidConfig as any),
     Error,
-    "networks"
+    "networks",
   );
 });
 
@@ -155,21 +163,21 @@ Deno.test("Config validation - invalid network type throws", () => {
     monitor: {
       slug: "test",
       info: { name: "Test", about: "Test" },
-      owner: "pubkey"
+      owner: "pubkey",
     },
     publisher: { relays: [] },
     relaymon: {
       networks: ["invalid-network"],
       retry: { expiry: [] },
       seed: { interval: 1000, sources: [], options: {} },
-      checks: { enabled: [], options: {} as any }
-    }
+      checks: { enabled: [], options: {} as any },
+    },
   };
 
   assertThrows(
     () => validateConfig(invalidConfig as any),
     Error,
-    "Invalid network type"
+    "Invalid network type",
   );
 });
 
@@ -180,31 +188,31 @@ Deno.test("Config validation - optional fields handled correctly", () => {
       info: {
         name: "Test",
         about: "Test",
-        nip05: "test@example.com"  // optional
+        nip05: "test@example.com", // optional
       },
       owner: "pubkey",
-      geo: {  // optional
+      geo: { // optional
         city: "Test City",
         country: "Test Country",
         countryCode: "TC",
         lat: 0,
         lon: 0,
         region: "Test Region",
-        continent: "Test Continent"
-      }
+        continent: "Test Continent",
+      },
     },
     publisher: {
-      relays: ["wss://relay.test.com"]
+      relays: ["wss://relay.test.com"],
     },
     relaymon: {
       networks: ["clearnet"],
       retry: {
-        expiry: [{ max: 3, delay: 60000 }]
+        expiry: [{ max: 3, delay: 60000 }],
       },
       seed: {
         interval: 60000,
         sources: ["cache"],
-        options: {}
+        options: {},
       },
       checks: {
         enabled: ["open"],
@@ -212,28 +220,28 @@ Deno.test("Config validation - optional fields handled correctly", () => {
           expires: 86400000,
           interval: 15000,
           timeout: {
-            open: 30000
+            open: 30000,
           },
           max: 200,
-          statusInterval: 20
-        }
+          statusInterval: 20,
+        },
       },
-      ignorelist: {  // optional
+      ignorelist: { // optional
         enabled: true,
         interval: "6h",
         deletion_interval: "24h",
         relays: [],
-        pubkeys: []
+        pubkeys: [],
       },
-      deduplication: {  // optional
+      deduplication: { // optional
         reevaluation_interval: "24h",
-        nip11_cache_ttl: "24h"
-      }
+        nip11_cache_ttl: "24h",
+      },
     },
-    queue: {  // optional
-      workerConcurrency: 5
+    queue: { // optional
+      workerConcurrency: 5,
     },
-    logLevel: "info"  // optional
+    logLevel: "info", // optional
   };
 
   const result = validateConfig(configWithOptionals);
@@ -245,6 +253,57 @@ Deno.test("Config validation - optional fields handled correctly", () => {
   assertEquals(result.logLevel, "info");
 });
 
+Deno.test("Config validation - trustedRelayAssertions defaults are applied", () => {
+  const configWithTra = {
+    ...mockConfig,
+    relaymon: {
+      ...mockConfig.relaymon,
+      trustedRelayAssertions: {
+        enabled: true,
+      },
+    },
+  };
+
+  const result = validateConfig(configWithTra);
+
+  assertEquals(result.relaymon.trustedRelayAssertions?.enabled, true);
+  assertEquals(result.relaymon.trustedRelayAssertions?.relays, []);
+  assertEquals(result.relaymon.trustedRelayAssertions?.min_observations, 10);
+  assertEquals(
+    result.relaymon.trustedRelayAssertions?.material_change_threshold,
+    3,
+  );
+  assertEquals(result.relaymon.trustedRelayAssertions?.refresh_interval, "1h");
+  assertEquals(
+    result.relaymon.trustedRelayAssertions?.publish_unreachable,
+    true,
+  );
+  assertEquals(result.relaymon.trustedRelayAssertions?.publish_blocked, false);
+  assertEquals(
+    result.relaymon.trustedRelayAssertions?.algorithm?.version,
+    "relaymon-local-v1",
+  );
+});
+
+Deno.test("Config validation - trustedRelayAssertions validates relay list", () => {
+  const invalidConfig = {
+    ...mockConfig,
+    relaymon: {
+      ...mockConfig.relaymon,
+      trustedRelayAssertions: {
+        enabled: true,
+        relays: ["wss://relay.example.com", 123],
+      },
+    },
+  };
+
+  assertThrows(
+    () => validateConfig(invalidConfig as any),
+    Error,
+    "trustedRelayAssertions.relays",
+  );
+});
+
 Deno.test("Config validation - all network types accepted", () => {
   const networks = ["clearnet", "tor", "i2p", "lokinet"];
 
@@ -253,15 +312,15 @@ Deno.test("Config validation - all network types accepted", () => {
       monitor: {
         slug: "test",
         info: { name: "Test", about: "Test" },
-        owner: "pubkey"
+        owner: "pubkey",
       },
       publisher: { relays: [] },
       relaymon: {
         networks: [network],
         retry: { expiry: [] },
         seed: { interval: 1000, sources: [], options: {} },
-        checks: { enabled: [], options: {} as any }
-      }
+        checks: { enabled: [], options: {} as any },
+      },
     };
 
     const result = validateConfig(config as any);
@@ -274,7 +333,7 @@ Deno.test("Config validation - null config throws", () => {
   assertThrows(
     () => validateConfig(null as any),
     Error,
-    "Config must be an object"
+    "Config must be an object",
   );
 });
 
@@ -282,7 +341,7 @@ Deno.test("Config validation - undefined config throws", () => {
   assertThrows(
     () => validateConfig(undefined as any),
     Error,
-    "Config must be an object"
+    "Config must be an object",
   );
 });
 
@@ -290,7 +349,7 @@ Deno.test("Config validation - non-object config throws", () => {
   assertThrows(
     () => validateConfig("not an object" as any),
     Error,
-    "Config must be an object"
+    "Config must be an object",
   );
 });
 
@@ -298,6 +357,6 @@ Deno.test("Config validation - array config throws", () => {
   assertThrows(
     () => validateConfig([] as any),
     Error,
-    "Config must be an object"
+    "Config must be an object",
   );
 });

--- a/apps/relaymon/tests/unit/database.test.ts
+++ b/apps/relaymon/tests/unit/database.test.ts
@@ -1,12 +1,19 @@
-import { assertEquals, assertExists, assert } from "https://deno.land/std@0.218.2/assert/mod.ts";
 import {
-  initializeDB,
-  storeRelayInfo,
+  assert,
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.218.2/assert/mod.ts";
+import {
+  db,
+  getOnlineRelays,
+  getPublishedTrustedRelayAssertion,
   getRelayInfo,
   getRelaysWithSameInfo,
-  getOnlineRelays,
+  initializeDB,
   isRelayIgnored,
-  db
+  recordTrustedRelayObservation,
+  storePublishedTrustedRelayAssertion,
+  storeRelayInfo,
 } from "../../src/db/db.ts";
 import type { RelayInfo } from "../../src/types/relay.ts";
 
@@ -18,7 +25,7 @@ function dbTest(name: string, fn: () => void | Promise<void>) {
     name,
     sanitizeResources: false,
     sanitizeOps: false,
-    fn
+    fn,
   });
 }
 
@@ -45,7 +52,7 @@ function createMockRelayInfo(overrides: Partial<RelayInfo> = {}): RelayInfo {
     supported_nips: [1, 2, 11],
     software: "test-software",
     version: "1.0.0",
-    ...overrides
+    ...overrides,
   };
 }
 
@@ -62,15 +69,32 @@ dbTest("Database - initializeDB creates database file", () => {
 dbTest("Database - initializeDB creates relay_info table", () => {
   ensureGlobalTestDB();
 
-  const result = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='relay_info'");
+  const result = db.query(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name='relay_info'",
+  );
   assertEquals(result.length, 1, "relay_info table should exist");
 });
 
 dbTest("Database - relay_status table exists from @nostrwatch/db", () => {
   ensureGlobalTestDB();
 
-  const result = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='relay_status'");
+  const result = db.query(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name='relay_status'",
+  );
   assertEquals(result.length, 1, "relay_status table should exist");
+});
+
+dbTest("Database - relay_trust_assertion_state table exists", () => {
+  ensureGlobalTestDB();
+
+  const result = db.query(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name='relay_trust_assertion_state'",
+  );
+  assertEquals(
+    result.length,
+    1,
+    "relay_trust_assertion_state table should exist",
+  );
 });
 
 dbTest("Database - storeRelayInfo inserts new relay info", () => {
@@ -82,7 +106,10 @@ dbTest("Database - storeRelayInfo inserts new relay info", () => {
 
   storeRelayInfo(url, info, infoHash);
 
-  const result = db.query("SELECT url, info_hash FROM relay_info WHERE url = ?", [url]);
+  const result = db.query(
+    "SELECT url, info_hash FROM relay_info WHERE url = ?",
+    [url],
+  );
 
   assertEquals(result.length, 1, "Should have one row");
   assertEquals(result[0][0], url, "URL should match");
@@ -103,7 +130,9 @@ dbTest("Database - storeRelayInfo updates existing relay info", () => {
   storeRelayInfo(url, info2, "hash2");
 
   // Verify only one row exists with updated data
-  const result = db.query("SELECT info_hash FROM relay_info WHERE url = ?", [url]);
+  const result = db.query("SELECT info_hash FROM relay_info WHERE url = ?", [
+    url,
+  ]);
 
   assertEquals(result.length, 1, "Should have exactly one row");
   assertEquals(result[0][0], "hash2", "Info hash should be updated");
@@ -115,19 +144,29 @@ dbTest("Database - storeRelayInfo stores valid JSON", () => {
   const url = `wss://test-json-${Date.now()}.example.com`;
   const info = createMockRelayInfo({
     supported_nips: [1, 2, 11, 50],
-    name: "Test Relay with Special Chars: ñ, é, 中文"
+    name: "Test Relay with Special Chars: ñ, é, 中文",
   });
 
   storeRelayInfo(url, info, "hash123");
 
   // Verify JSON can be parsed back
-  const result = db.query("SELECT info_json FROM relay_info WHERE url = ?", [url]);
+  const result = db.query("SELECT info_json FROM relay_info WHERE url = ?", [
+    url,
+  ]);
 
   const storedJson = result[0][0] as string;
   const parsed = JSON.parse(storedJson);
 
-  assertEquals(parsed.name, info.name, "Name should match including special chars");
-  assertEquals(parsed.supported_nips, info.supported_nips, "NIPs array should match");
+  assertEquals(
+    parsed.name,
+    info.name,
+    "Name should match including special chars",
+  );
+  assertEquals(
+    parsed.supported_nips,
+    info.supported_nips,
+    "NIPs array should match",
+  );
 });
 
 dbTest("Database - getRelayInfo returns stored info", () => {
@@ -144,7 +183,11 @@ dbTest("Database - getRelayInfo returns stored info", () => {
   assertExists(retrieved, "Should return relay info");
   assertEquals(retrieved!.infoHash, infoHash, "Hash should match");
   assertEquals(retrieved!.info.name, info.name, "Name should match");
-  assertEquals(retrieved!.info.software, info.software, "Software should match");
+  assertEquals(
+    retrieved!.info.software,
+    info.software,
+    "Software should match",
+  );
 });
 
 dbTest("Database - getRelayInfo returns null for non-existent relay", () => {
@@ -163,7 +206,7 @@ dbTest("Database - getRelayInfo handles malformed JSON gracefully", () => {
   // Manually insert malformed JSON
   db.query(
     "INSERT INTO relay_info (url, info_json, info_hash, last_updated) VALUES (?, ?, ?, ?)",
-    [url, "{invalid json", "hash123", Math.floor(Date.now() / 1000)]
+    [url, "{invalid json", "hash123", Math.floor(Date.now() / 1000)],
   );
 
   const retrieved = getRelayInfo(url);
@@ -184,24 +227,45 @@ dbTest("Database - getRelaysWithSameInfo returns matching relays", () => {
   storeRelayInfo(`wss://relay3-${timestamp}.example.com`, info, sharedHash);
 
   // Store one with different hash
-  storeRelayInfo(`wss://different-${timestamp}.example.com`, info, `different-hash-${timestamp}`);
+  storeRelayInfo(
+    `wss://different-${timestamp}.example.com`,
+    info,
+    `different-hash-${timestamp}`,
+  );
 
   const relays = getRelaysWithSameInfo(sharedHash);
 
   assertEquals(relays.length, 3, "Should return 3 relays with same hash");
-  assert(relays.includes(`wss://relay1-${timestamp}.example.com`), "Should include relay1");
-  assert(relays.includes(`wss://relay2-${timestamp}.example.com`), "Should include relay2");
-  assert(relays.includes(`wss://relay3-${timestamp}.example.com`), "Should include relay3");
-  assert(!relays.includes(`wss://different-${timestamp}.example.com`), "Should not include different relay");
+  assert(
+    relays.includes(`wss://relay1-${timestamp}.example.com`),
+    "Should include relay1",
+  );
+  assert(
+    relays.includes(`wss://relay2-${timestamp}.example.com`),
+    "Should include relay2",
+  );
+  assert(
+    relays.includes(`wss://relay3-${timestamp}.example.com`),
+    "Should include relay3",
+  );
+  assert(
+    !relays.includes(`wss://different-${timestamp}.example.com`),
+    "Should not include different relay",
+  );
 });
 
-dbTest("Database - getRelaysWithSameInfo returns empty array for non-existent hash", () => {
-  ensureGlobalTestDB();
+dbTest(
+  "Database - getRelaysWithSameInfo returns empty array for non-existent hash",
+  () => {
+    ensureGlobalTestDB();
 
-  const relays = getRelaysWithSameInfo("totally-nonexistent-hash-unique-12345");
+    const relays = getRelaysWithSameInfo(
+      "totally-nonexistent-hash-unique-12345",
+    );
 
-  assertEquals(relays, [], "Should return empty array");
-});
+    assertEquals(relays, [], "Should return empty array");
+  },
+);
 
 dbTest("Database - getOnlineRelays returns only online relays", () => {
   ensureGlobalTestDB();
@@ -209,14 +273,22 @@ dbTest("Database - getOnlineRelays returns only online relays", () => {
   const timestamp = Date.now();
 
   // Insert test relays
-  db.query("INSERT OR REPLACE INTO relay_status (url, network, online) VALUES (?, ?, ?)",
-    [`wss://online1-${timestamp}.example.com`, "clearnet", 1]);
-  db.query("INSERT OR REPLACE INTO relay_status (url, network, online) VALUES (?, ?, ?)",
-    [`wss://online2-${timestamp}.example.com`, "clearnet", 1]);
-  db.query("INSERT OR REPLACE INTO relay_status (url, network, online) VALUES (?, ?, ?)",
-    [`wss://offline1-${timestamp}.example.com`, "clearnet", 0]);
-  db.query("INSERT OR REPLACE INTO relay_status (url, network, online) VALUES (?, ?, ?)",
-    [`wss://offline2-${timestamp}.example.com`, "clearnet", -1]);
+  db.query(
+    "INSERT OR REPLACE INTO relay_status (url, network, online) VALUES (?, ?, ?)",
+    [`wss://online1-${timestamp}.example.com`, "clearnet", 1],
+  );
+  db.query(
+    "INSERT OR REPLACE INTO relay_status (url, network, online) VALUES (?, ?, ?)",
+    [`wss://online2-${timestamp}.example.com`, "clearnet", 1],
+  );
+  db.query(
+    "INSERT OR REPLACE INTO relay_status (url, network, online) VALUES (?, ?, ?)",
+    [`wss://offline1-${timestamp}.example.com`, "clearnet", 0],
+  );
+  db.query(
+    "INSERT OR REPLACE INTO relay_status (url, network, online) VALUES (?, ?, ?)",
+    [`wss://offline2-${timestamp}.example.com`, "clearnet", -1],
+  );
 
   const onlineRelays = getOnlineRelays();
 
@@ -224,10 +296,22 @@ dbTest("Database - getOnlineRelays returns only online relays", () => {
   // canonicalized version (via the barrel re-export at db.ts:626), which
   // normalizeURL-wraps every row. normalizeURL appends a trailing slash to
   // bare-host URLs, so assertions use the canonical form with trailing slash.
-  assert(onlineRelays.includes(`wss://online1-${timestamp}.example.com/`), "Should include online1 (canonicalized)");
-  assert(onlineRelays.includes(`wss://online2-${timestamp}.example.com/`), "Should include online2 (canonicalized)");
-  assert(!onlineRelays.includes(`wss://offline1-${timestamp}.example.com/`), "Should not include offline1");
-  assert(!onlineRelays.includes(`wss://offline2-${timestamp}.example.com/`), "Should not include offline2");
+  assert(
+    onlineRelays.includes(`wss://online1-${timestamp}.example.com/`),
+    "Should include online1 (canonicalized)",
+  );
+  assert(
+    onlineRelays.includes(`wss://online2-${timestamp}.example.com/`),
+    "Should include online2 (canonicalized)",
+  );
+  assert(
+    !onlineRelays.includes(`wss://offline1-${timestamp}.example.com/`),
+    "Should not include offline1",
+  );
+  assert(
+    !onlineRelays.includes(`wss://offline2-${timestamp}.example.com/`),
+    "Should not include offline2",
+  );
 });
 
 dbTest("Database - isRelayIgnored returns true for ignored relay", () => {
@@ -236,7 +320,10 @@ dbTest("Database - isRelayIgnored returns true for ignored relay", () => {
   const timestamp = Date.now();
   const url = `wss://ignored-${timestamp}.example.com`;
 
-  db.query("INSERT OR REPLACE INTO relay_status (url, network, ignore) VALUES (?, ?, ?)", [url, "clearnet", 1]);
+  db.query(
+    "INSERT OR REPLACE INTO relay_status (url, network, ignore) VALUES (?, ?, ?)",
+    [url, "clearnet", 1],
+  );
 
   const ignored = isRelayIgnored(url);
 
@@ -249,7 +336,10 @@ dbTest("Database - isRelayIgnored returns false for non-ignored relay", () => {
   const timestamp = Date.now();
   const url = `wss://not-ignored-${timestamp}.example.com`;
 
-  db.query("INSERT OR REPLACE INTO relay_status (url, network, ignore) VALUES (?, ?, ?)", [url, "clearnet", 0]);
+  db.query(
+    "INSERT OR REPLACE INTO relay_status (url, network, ignore) VALUES (?, ?, ?)",
+    [url, "clearnet", 0],
+  );
 
   const ignored = isRelayIgnored(url);
 
@@ -259,7 +349,9 @@ dbTest("Database - isRelayIgnored returns false for non-ignored relay", () => {
 dbTest("Database - isRelayIgnored returns false for non-existent relay", () => {
   ensureGlobalTestDB();
 
-  const ignored = isRelayIgnored("wss://totally-nonexistent-fake-relay-12345.example.com");
+  const ignored = isRelayIgnored(
+    "wss://totally-nonexistent-fake-relay-12345.example.com",
+  );
 
   assertEquals(ignored, false, "Should return false for non-existent relay");
 });
@@ -273,16 +365,22 @@ dbTest("Database - relay_info timestamp is updated on store", async () => {
   storeRelayInfo(url, info, "hash1");
 
   // Get first timestamp
-  const result1 = db.query("SELECT last_updated FROM relay_info WHERE url = ?", [url]);
+  const result1 = db.query(
+    "SELECT last_updated FROM relay_info WHERE url = ?",
+    [url],
+  );
   const timestamp1 = result1[0][0] as number;
 
   // Wait a bit to ensure different timestamp
-  await new Promise(resolve => setTimeout(resolve, 100));
+  await new Promise((resolve) => setTimeout(resolve, 100));
 
   // Update
   storeRelayInfo(url, info, "hash2");
 
-  const result2 = db.query("SELECT last_updated FROM relay_info WHERE url = ?", [url]);
+  const result2 = db.query(
+    "SELECT last_updated FROM relay_info WHERE url = ?",
+    [url],
+  );
   const timestamp2 = result2[0][0] as number;
 
   assert(timestamp2 >= timestamp1, "Timestamp should be updated or same");
@@ -314,25 +412,83 @@ dbTest("Database - relay_status supports network types", () => {
 
   const timestamp = Date.now();
 
-  db.query("INSERT OR REPLACE INTO relay_status (url, network) VALUES (?, ?)",
-    [`wss://clearnet-${timestamp}.example.com`, "clearnet"]);
-  db.query("INSERT OR REPLACE INTO relay_status (url, network) VALUES (?, ?)",
-    [`ws://onion-${timestamp}.onion`, "tor"]);
-  db.query("INSERT OR REPLACE INTO relay_status (url, network) VALUES (?, ?)",
-    [`ws://i2p-${timestamp}.i2p`, "i2p"]);
+  db.query("INSERT OR REPLACE INTO relay_status (url, network) VALUES (?, ?)", [
+    `wss://clearnet-${timestamp}.example.com`,
+    "clearnet",
+  ]);
+  db.query("INSERT OR REPLACE INTO relay_status (url, network) VALUES (?, ?)", [
+    `ws://onion-${timestamp}.onion`,
+    "tor",
+  ]);
+  db.query("INSERT OR REPLACE INTO relay_status (url, network) VALUES (?, ?)", [
+    `ws://i2p-${timestamp}.i2p`,
+    "i2p",
+  ]);
 
-  const result = db.query(`
+  const result = db.query(
+    `
     SELECT url, network FROM relay_status
     WHERE url IN (?, ?, ?)
     ORDER BY network
-  `, [
-    `wss://clearnet-${timestamp}.example.com`,
-    `ws://i2p-${timestamp}.i2p`,
-    `ws://onion-${timestamp}.onion`
-  ]);
+  `,
+    [
+      `wss://clearnet-${timestamp}.example.com`,
+      `ws://i2p-${timestamp}.i2p`,
+      `ws://onion-${timestamp}.onion`,
+    ],
+  );
 
   assertEquals(result.length, 3, "Should have 3 relays");
   assertEquals(result[0][1], "clearnet", "First should be clearnet");
   assertEquals(result[1][1], "i2p", "Second should be i2p");
   assertEquals(result[2][1], "tor", "Third should be tor");
 });
+
+dbTest(
+  "Database - trusted relay assertion state accumulates observations and stores published state",
+  () => {
+    ensureGlobalTestDB();
+
+    const timestamp = Date.now();
+    const url = `wss://tra-${timestamp}.example.com`;
+
+    const first = recordTrustedRelayObservation(url, {
+      online: true,
+      open: { duration: 120 },
+      read: { duration: 180 },
+    });
+    const second = recordTrustedRelayObservation(url, {
+      online: false,
+      open: { duration: 800 },
+    });
+
+    assertEquals(first.observations, 1);
+    assertEquals(second.observations, 2);
+    assertEquals(second.reachableObservations, 1);
+    assertEquals(second.totalRttOpen, 920);
+    assertEquals(second.rttOpenSamples, 2);
+    assertExists(second.lastOnlineAt);
+
+    assertEquals(getPublishedTrustedRelayAssertion(url), null);
+
+    storePublishedTrustedRelayAssertion(url, {
+      status: "evaluated",
+      score: 82,
+      reliability: 90,
+      quality: 80,
+      accessibility: 70,
+      confidence: "low",
+    }, "event-id-123");
+
+    const published = getPublishedTrustedRelayAssertion(url);
+    assertExists(published);
+    assertEquals(published!.status, "evaluated");
+    assertEquals(published!.score, 82);
+    assertEquals(published!.reliability, 90);
+    assertEquals(published!.quality, 80);
+    assertEquals(published!.accessibility, 70);
+    assertEquals(published!.confidence, "low");
+    assertEquals(published!.eventId, "event-id-123");
+    assertExists(published!.publishedAt);
+  },
+);

--- a/apps/relaymon/tests/unit/database.test.ts
+++ b/apps/relaymon/tests/unit/database.test.ts
@@ -9,6 +9,7 @@ import {
   getPublishedTrustedRelayAssertion,
   getRelayInfo,
   getRelaysWithSameInfo,
+  getTrustedRelayObservationHistory,
   initializeDB,
   isRelayIgnored,
   recordTrustedRelayObservation,
@@ -468,6 +469,7 @@ dbTest(
     assertEquals(second.totalRttOpen, 920);
     assertEquals(second.rttOpenSamples, 2);
     assertExists(second.lastOnlineAt);
+    assertEquals(getTrustedRelayObservationHistory(url), []);
 
     assertEquals(getPublishedTrustedRelayAssertion(url), null);
 
@@ -490,5 +492,132 @@ dbTest(
     assertEquals(published!.confidence, "low");
     assertEquals(published!.eventId, "event-id-123");
     assertExists(published!.publishedAt);
+  },
+);
+
+dbTest(
+  "Database - trusted relay observation history is gated and retained for TRA publishing",
+  () => {
+    ensureGlobalTestDB();
+
+    const timestamp = Date.now();
+    const url = `wss://tra-history-${timestamp}.example.com`;
+    const operatorPubkey =
+      "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+    recordTrustedRelayObservation(
+      url,
+      {
+        checked_at: 1_700_000_000,
+        online: true,
+        open: { duration: 90 },
+        read: { duration: 120 },
+        write: { duration: 150 },
+        network: "clearnet",
+        info: { data: { pubkey: operatorPubkey, name: "Example Relay" } },
+        ssl: { data: { valid: true } },
+        dns: {
+          data: {
+            address: "203.0.113.10",
+            as: "Example Network",
+            asn: 64500,
+          },
+        },
+        geo: {
+          data: {
+            countryCode: "de",
+            region: "Bavaria",
+            isp: "Hetzner Online GmbH",
+          },
+        },
+      },
+      {
+        recordHistory: true,
+        historyRetentionMs: "30d",
+        maxObservationsPerRelay: 2,
+      },
+    );
+    recordTrustedRelayObservation(
+      url,
+      {
+        checked_at: 1_700_000_060,
+        online: true,
+        open: { duration: 100 },
+        read: { duration: 130 },
+        write: { duration: 160 },
+        network: "clearnet",
+        info: { data: { pubkey: operatorPubkey, name: "Example Relay" } },
+        ssl: { data: { valid: true } },
+        dns: {
+          data: {
+            address: "203.0.113.10",
+            as: "Example Network",
+            asn: 64500,
+          },
+        },
+        geo: {
+          data: {
+            countryCode: "de",
+            region: "Bavaria",
+            isp: "Hetzner Online GmbH",
+          },
+        },
+      },
+      {
+        recordHistory: true,
+        historyRetentionMs: "30d",
+        maxObservationsPerRelay: 2,
+      },
+    );
+    const state = recordTrustedRelayObservation(
+      url,
+      {
+        checked_at: 1_700_000_120,
+        online: false,
+        open: { duration: 900 },
+        read: { duration: 1100 },
+        network: "clearnet",
+        info: { data: { pubkey: operatorPubkey, name: "Example Relay" } },
+        ssl: { data: { valid: false } },
+        dns: {
+          data: {
+            address: "203.0.113.10",
+            as: "Example Network",
+            asn: 64500,
+          },
+        },
+        geo: {
+          data: {
+            countryCode: "de",
+            region: "Bavaria",
+            isp: "Hetzner Online GmbH",
+          },
+        },
+      },
+      {
+        recordHistory: true,
+        historyRetentionMs: "30d",
+        maxObservationsPerRelay: 2,
+      },
+    );
+
+    const history = getTrustedRelayObservationHistory(url);
+    assertEquals(history.length, 2);
+    assertEquals(state.history?.length, 2);
+    assertEquals(history[0].observedAt, 1_700_000_060);
+    assertEquals(history[0].online, true);
+    assertEquals(history[0].rttWrite, 160);
+    assertEquals(history[0].network, "clearnet");
+    assertEquals(history[0].nip11Present, true);
+    assertEquals(history[0].operatorPubkey, operatorPubkey);
+    assertEquals(history[0].sslValid, true);
+    assertEquals(history[0].dnsAddress, "203.0.113.10");
+    assertEquals(history[0].dnsAs, "Example Network");
+    assertEquals(history[0].dnsAsn, "64500");
+    assertEquals(history[0].countryCode, "DE");
+    assertEquals(history[0].region, "Bavaria");
+    assertEquals(history[0].isHosting, true);
+    assertEquals(history[1].online, false);
+    assertEquals(history[1].sslValid, false);
   },
 );

--- a/apps/relaymon/tests/unit/deletion.test.ts
+++ b/apps/relaymon/tests/unit/deletion.test.ts
@@ -1,7 +1,11 @@
-import { assertEquals, assertExists, assert } from "https://deno.land/std@0.218.2/assert/mod.ts";
-import { Kind5Event, deleteRelayCheckEvent } from "../../src/utils/deletion.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.218.2/assert/mod.ts";
+import { deleteRelayCheckEvent, Kind5Event } from "../../src/utils/deletion.ts";
 import { getPublicKey, nip19 } from "npm:nostr-tools";
-import { hexToBytes } from "npm:@noble/hashes/utils";
+import { hexToBytes } from "@noble/hashes/utils";
 import type { Config } from "../../src/types/config.ts";
 
 /**
@@ -13,65 +17,68 @@ function deletionTest(name: string, fn: () => void | Promise<void>) {
     name,
     sanitizeResources: false,
     sanitizeOps: false,
-    fn
+    fn,
   });
 }
 
 /**
  * Create a minimal mock config for testing deletion events
  */
-function createMockConfig(relays: string[] = ["wss://relay.example.com"]): Config {
+function createMockConfig(
+  relays: string[] = ["wss://relay.example.com"],
+): Config {
   return {
     monitor: {
       slug: "test-monitor",
       info: {
         name: "Test Monitor",
         description: "Test",
-        pubkey: "test-pubkey"
+        pubkey: "test-pubkey",
       },
       owner: "test-owner",
       relays: relays,
       geo: {
-        enabled: false
-      }
+        enabled: false,
+      },
     },
     relaymon: {
       networks: ["clearnet"],
       seed: {
         enabled: false,
-        interval: 3600000
+        interval: 3600000,
       },
       checks: {
         enabled: true,
         options: {
           expires: 86400000,
-          interval: 3600000
-        }
+          interval: 3600000,
+        },
       },
       retry: {
         enabled: false,
-        expiry: []
+        expiry: [],
       },
       deduplication: {
-        enabled: false
+        enabled: false,
       },
       ignorelist: {
         enabled: false,
         interval: "6h",
         deletion_interval: "24h",
         relays: [],
-        pubkeys: []
-      }
+        pubkeys: [],
+      },
     },
     publisher: {
-      relays: relays
-    }
+      relays: relays,
+    },
   } as Config;
 }
 
 // Use a valid test private key and derive pubkey from it
-const TEST_PRIVKEY = "0000000000000000000000000000000000000000000000000000000000000001";
-const TEST_PUBKEY = getPublicKey(TEST_PRIVKEY);
+const TEST_PRIVKEY =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+const TEST_PUBKEY = getPublicKey(hexToBytes(TEST_PRIVKEY));
 const TEST_NSEC = nip19.nsecEncode(hexToBytes(TEST_PRIVKEY));
 
 // Test suite
@@ -82,7 +89,7 @@ deletionTest("Kind5Event - constructor creates event with correct kind", () => {
   const generated = event.generateEvent({
     relayUrl: "wss://relay.example.com",
     pubkey: TEST_PUBKEY,
-    content: "Test deletion"
+    content: "Test deletion",
   });
 
   assertEquals(generated.kind, 5);
@@ -95,11 +102,11 @@ deletionTest("Kind5Event - generateEvent creates proper a-tag format", () => {
   const generated = event.generateEvent({
     relayUrl,
     pubkey: TEST_PUBKEY,
-    content: "Test deletion reason"
+    content: "Test deletion reason",
   });
 
   // Check a-tag format: 30166:<pubkey>:<relay-url>
-  const aTag = generated.tags.find(tag => tag[0] === "a");
+  const aTag = generated.tags.find((tag) => tag[0] === "a");
   assertExists(aTag, "a-tag should exist");
   assertEquals(aTag[1], `30166:${TEST_PUBKEY}:${relayUrl}`);
 });
@@ -110,11 +117,11 @@ deletionTest("Kind5Event - generateEvent includes k-tag for kind 30166", () => {
   const generated = event.generateEvent({
     relayUrl: "wss://relay.example.com",
     pubkey: TEST_PUBKEY,
-    content: "Test deletion"
+    content: "Test deletion",
   });
 
   // Check k-tag for the kind being deleted
-  const kTag = generated.tags.find(tag => tag[0] === "k");
+  const kTag = generated.tags.find((tag) => tag[0] === "k");
   assertExists(kTag, "k-tag should exist");
   assertEquals(kTag[1], "30166");
 });
@@ -126,7 +133,7 @@ deletionTest("Kind5Event - generateEvent includes content", () => {
   const generated = event.generateEvent({
     relayUrl: "wss://relay.example.com",
     pubkey: TEST_PUBKEY,
-    content
+    content,
   });
 
   assertEquals(generated.content, content);
@@ -138,7 +145,7 @@ deletionTest("Kind5Event - generateEvent includes pubkey", () => {
   const generated = event.generateEvent({
     relayUrl: "wss://relay.example.com",
     pubkey: TEST_PUBKEY,
-    content: "Test"
+    content: "Test",
   });
 
   assertEquals(generated.pubkey, TEST_PUBKEY);
@@ -150,7 +157,7 @@ deletionTest("Kind5Event - generateEvent creates event ID", () => {
   const generated = event.generateEvent({
     relayUrl: "wss://relay.example.com",
     pubkey: TEST_PUBKEY,
-    content: "Test"
+    content: "Test",
   });
 
   assertExists(generated.id, "Event ID should be generated");
@@ -164,203 +171,237 @@ deletionTest("Kind5Event - generateEvent includes created_at timestamp", () => {
   const generated = event.generateEvent({
     relayUrl: "wss://relay.example.com",
     pubkey: TEST_PUBKEY,
-    content: "Test"
+    content: "Test",
   });
   const after = Math.floor(Date.now() / 1000);
 
   assertExists(generated.created_at, "created_at should exist");
-  assert(generated.created_at >= before && generated.created_at <= after + 1, "created_at should be current timestamp");
+  assert(
+    generated.created_at >= before && generated.created_at <= after + 1,
+    "created_at should be current timestamp",
+  );
 });
 
-deletionTest("Kind5Event - generateEvent creates different IDs for different relays", () => {
-  const event = new Kind5Event(TEST_PUBKEY);
+deletionTest(
+  "Kind5Event - generateEvent creates different IDs for different relays",
+  () => {
+    const event = new Kind5Event(TEST_PUBKEY);
 
-  const event1 = event.generateEvent({
-    relayUrl: "wss://relay1.example.com",
-    pubkey: TEST_PUBKEY,
-    content: "Test"
-  });
-
-  const event2 = event.generateEvent({
-    relayUrl: "wss://relay2.example.com",
-    pubkey: TEST_PUBKEY,
-    content: "Test"
-  });
-
-  assert(event1.id !== event2.id, "Different relay URLs should produce different event IDs");
-});
-
-deletionTest("deleteRelayCheckEvent - returns early if RELAYMON_NSEC missing", async () => {
-  const originalEnv = Deno.env.get("RELAYMON_NSEC");
-  Deno.env.delete("RELAYMON_NSEC");
-
-  try {
-    const config = createMockConfig();
-
-    // Should return without error, just log a warning
-    await deleteRelayCheckEvent(
-      "wss://relay.example.com",
-      "Test deletion",
-      config
-    );
-
-    // If we get here, the function returned early as expected
-    assert(true, "Function should return early without privkey");
-  } finally {
-    // Restore environment
-    if (originalEnv) {
-      Deno.env.set("RELAYMON_NSEC", originalEnv);
-    }
-  }
-});
-
-deletionTest("deleteRelayCheckEvent - returns early if config.publisher.relays is empty", async () => {
-  // Set up environment
-  const testPrivkey = "0000000000000000000000000000000000000000000000000000000000000001";
-  const originalEnv = Deno.env.get("RELAYMON_NSEC");
-  Deno.env.set("RELAYMON_NSEC", nip19.nsecEncode(hexToBytes(testPrivkey)));
-
-  try {
-    const config = createMockConfig([]);
-
-    // Should return without error, just log a warning
-    await deleteRelayCheckEvent(
-      "wss://relay.example.com",
-      "Test deletion",
-      config
-    );
-
-    // If we get here, the function returned early as expected
-    assert(true, "Function should return early without relays");
-  } finally {
-    // Restore environment
-    if (originalEnv) {
-      Deno.env.set("RELAYMON_NSEC", originalEnv);
-    } else {
-      Deno.env.delete("RELAYMON_NSEC");
-    }
-  }
-});
-
-deletionTest("deleteRelayCheckEvent - returns early if config.publisher.relays is not an array", async () => {
-  // Set up environment
-  const testPrivkey = "0000000000000000000000000000000000000000000000000000000000000001";
-  const originalEnv = Deno.env.get("RELAYMON_NSEC");
-  Deno.env.set("RELAYMON_NSEC", nip19.nsecEncode(hexToBytes(testPrivkey)));
-
-  try {
-    const config = createMockConfig();
-    // Intentionally break the relays array
-    (config.publisher as any).relays = null;
-
-    // Should return without error, just log a warning
-    await deleteRelayCheckEvent(
-      "wss://relay.example.com",
-      "Test deletion",
-      config
-    );
-
-    // If we get here, the function returned early as expected
-    assert(true, "Function should return early without valid relays");
-  } finally {
-    // Restore environment
-    if (originalEnv) {
-      Deno.env.set("RELAYMON_NSEC", originalEnv);
-    } else {
-      Deno.env.delete("RELAYMON_NSEC");
-    }
-  }
-});
-
-deletionTest("deleteRelayCheckEvent - skips duplicate deletion for same relay", async () => {
-  // Set up environment
-  const testPrivkey = "0000000000000000000000000000000000000000000000000000000000000001";
-  const originalEnv = Deno.env.get("RELAYMON_NSEC");
-  Deno.env.set("RELAYMON_NSEC", nip19.nsecEncode(hexToBytes(testPrivkey)));
-
-  try {
-    const config = createMockConfig();
-    const relayUrl = "wss://duplicate-test.example.com";
-
-    // Mock Publisher to avoid actual network calls
-    const mockPublisher = {
-      publishEvent: async () => {
-        // Mock successful publish
-      }
-    };
-
-    // Temporarily replace Publisher import (this is a simplified test)
-    // In reality, the first call would add to deletedRelays set
-    // The second call should detect it and skip
-
-    // First call - should proceed
-    await deleteRelayCheckEvent(relayUrl, "First deletion", config);
-
-    // Second call - should skip (detected in deletedRelays set)
-    await deleteRelayCheckEvent(relayUrl, "Second deletion", config);
-
-    // If we get here without errors, the duplicate detection worked
-    assert(true, "Duplicate deletion should be handled gracefully");
-  } finally {
-    // Restore environment
-    if (originalEnv) {
-      Deno.env.set("RELAYMON_NSEC", originalEnv);
-    } else {
-      Deno.env.delete("RELAYMON_NSEC");
-    }
-  }
-});
-
-deletionTest("deleteRelayCheckEvent - derives correct pubkey from privkey", async () => {
-  // Set up environment with a known test key
-  const expectedPubkey = getPublicKey(TEST_PRIVKEY);
-  const originalEnv = Deno.env.get("RELAYMON_NSEC");
-  Deno.env.set("RELAYMON_NSEC", TEST_NSEC);
-
-  try {
-    const config = createMockConfig();
-
-    // Create an event to check the pubkey
-    const event = new Kind5Event(expectedPubkey);
-    const generated = event.generateEvent({
-      relayUrl: "wss://relay.example.com",
-      pubkey: expectedPubkey,
-      content: "Test"
-    });
-
-    assertEquals(generated.pubkey, expectedPubkey);
-  } finally {
-    // Restore environment
-    if (originalEnv) {
-      Deno.env.set("RELAYMON_NSEC", originalEnv);
-    } else {
-      Deno.env.delete("RELAYMON_NSEC");
-    }
-  }
-});
-
-deletionTest("Kind5Event - handles different relay URL formats in a-tag", () => {
-  const event = new Kind5Event(TEST_PUBKEY);
-
-  const relayUrls = [
-    "wss://relay.example.com",
-    "wss://relay.example.com/path",
-    "ws://relay.example.com",
-    "wss://relay.example.com:8080",
-  ];
-
-  for (const relayUrl of relayUrls) {
-    const generated = event.generateEvent({
-      relayUrl,
+    const event1 = event.generateEvent({
+      relayUrl: "wss://relay1.example.com",
       pubkey: TEST_PUBKEY,
-      content: "Test"
+      content: "Test",
     });
 
-    const aTag = generated.tags.find(tag => tag[0] === "a");
-    assertExists(aTag, `a-tag should exist for ${relayUrl}`);
-    assertEquals(aTag[1], `30166:${TEST_PUBKEY}:${relayUrl}`, `a-tag should contain relay URL: ${relayUrl}`);
-  }
-});
+    const event2 = event.generateEvent({
+      relayUrl: "wss://relay2.example.com",
+      pubkey: TEST_PUBKEY,
+      content: "Test",
+    });
+
+    assert(
+      event1.id !== event2.id,
+      "Different relay URLs should produce different event IDs",
+    );
+  },
+);
+
+deletionTest(
+  "deleteRelayCheckEvent - returns early if RELAYMON_NSEC missing",
+  async () => {
+    const originalEnv = Deno.env.get("RELAYMON_NSEC");
+    Deno.env.delete("RELAYMON_NSEC");
+
+    try {
+      const config = createMockConfig();
+
+      // Should return without error, just log a warning
+      await deleteRelayCheckEvent(
+        "wss://relay.example.com",
+        "Test deletion",
+        config,
+      );
+
+      // If we get here, the function returned early as expected
+      assert(true, "Function should return early without privkey");
+    } finally {
+      // Restore environment
+      if (originalEnv) {
+        Deno.env.set("RELAYMON_NSEC", originalEnv);
+      }
+    }
+  },
+);
+
+deletionTest(
+  "deleteRelayCheckEvent - returns early if config.publisher.relays is empty",
+  async () => {
+    // Set up environment
+    const testPrivkey =
+      "0000000000000000000000000000000000000000000000000000000000000001";
+    const originalEnv = Deno.env.get("RELAYMON_NSEC");
+    Deno.env.set("RELAYMON_NSEC", nip19.nsecEncode(hexToBytes(testPrivkey)));
+
+    try {
+      const config = createMockConfig([]);
+
+      // Should return without error, just log a warning
+      await deleteRelayCheckEvent(
+        "wss://relay.example.com",
+        "Test deletion",
+        config,
+      );
+
+      // If we get here, the function returned early as expected
+      assert(true, "Function should return early without relays");
+    } finally {
+      // Restore environment
+      if (originalEnv) {
+        Deno.env.set("RELAYMON_NSEC", originalEnv);
+      } else {
+        Deno.env.delete("RELAYMON_NSEC");
+      }
+    }
+  },
+);
+
+deletionTest(
+  "deleteRelayCheckEvent - returns early if config.publisher.relays is not an array",
+  async () => {
+    // Set up environment
+    const testPrivkey =
+      "0000000000000000000000000000000000000000000000000000000000000001";
+    const originalEnv = Deno.env.get("RELAYMON_NSEC");
+    Deno.env.set("RELAYMON_NSEC", nip19.nsecEncode(hexToBytes(testPrivkey)));
+
+    try {
+      const config = createMockConfig();
+      // Intentionally break the relays array
+      (config.publisher as any).relays = null;
+
+      // Should return without error, just log a warning
+      await deleteRelayCheckEvent(
+        "wss://relay.example.com",
+        "Test deletion",
+        config,
+      );
+
+      // If we get here, the function returned early as expected
+      assert(true, "Function should return early without valid relays");
+    } finally {
+      // Restore environment
+      if (originalEnv) {
+        Deno.env.set("RELAYMON_NSEC", originalEnv);
+      } else {
+        Deno.env.delete("RELAYMON_NSEC");
+      }
+    }
+  },
+);
+
+deletionTest(
+  "deleteRelayCheckEvent - skips duplicate deletion for same relay",
+  async () => {
+    // Set up environment
+    const testPrivkey =
+      "0000000000000000000000000000000000000000000000000000000000000001";
+    const originalEnv = Deno.env.get("RELAYMON_NSEC");
+    Deno.env.set("RELAYMON_NSEC", nip19.nsecEncode(hexToBytes(testPrivkey)));
+
+    try {
+      const config = createMockConfig();
+      const relayUrl = "wss://duplicate-test.example.com";
+
+      // Mock Publisher to avoid actual network calls
+      const mockPublisher = {
+        publishEvent: async () => {
+          // Mock successful publish
+        },
+      };
+
+      // Temporarily replace Publisher import (this is a simplified test)
+      // In reality, the first call would add to deletedRelays set
+      // The second call should detect it and skip
+
+      // First call - should proceed
+      await deleteRelayCheckEvent(relayUrl, "First deletion", config);
+
+      // Second call - should skip (detected in deletedRelays set)
+      await deleteRelayCheckEvent(relayUrl, "Second deletion", config);
+
+      // If we get here without errors, the duplicate detection worked
+      assert(true, "Duplicate deletion should be handled gracefully");
+    } finally {
+      // Restore environment
+      if (originalEnv) {
+        Deno.env.set("RELAYMON_NSEC", originalEnv);
+      } else {
+        Deno.env.delete("RELAYMON_NSEC");
+      }
+    }
+  },
+);
+
+deletionTest(
+  "deleteRelayCheckEvent - derives correct pubkey from privkey",
+  async () => {
+    // Set up environment with a known test key
+    const expectedPubkey = getPublicKey(hexToBytes(TEST_PRIVKEY));
+    const originalEnv = Deno.env.get("RELAYMON_NSEC");
+    Deno.env.set("RELAYMON_NSEC", TEST_NSEC);
+
+    try {
+      const config = createMockConfig();
+
+      // Create an event to check the pubkey
+      const event = new Kind5Event(expectedPubkey);
+      const generated = event.generateEvent({
+        relayUrl: "wss://relay.example.com",
+        pubkey: expectedPubkey,
+        content: "Test",
+      });
+
+      assertEquals(generated.pubkey, expectedPubkey);
+    } finally {
+      // Restore environment
+      if (originalEnv) {
+        Deno.env.set("RELAYMON_NSEC", originalEnv);
+      } else {
+        Deno.env.delete("RELAYMON_NSEC");
+      }
+    }
+  },
+);
+
+deletionTest(
+  "Kind5Event - handles different relay URL formats in a-tag",
+  () => {
+    const event = new Kind5Event(TEST_PUBKEY);
+
+    const relayUrls = [
+      "wss://relay.example.com",
+      "wss://relay.example.com/path",
+      "ws://relay.example.com",
+      "wss://relay.example.com:8080",
+    ];
+
+    for (const relayUrl of relayUrls) {
+      const generated = event.generateEvent({
+        relayUrl,
+        pubkey: TEST_PUBKEY,
+        content: "Test",
+      });
+
+      const aTag = generated.tags.find((tag) => tag[0] === "a");
+      assertExists(aTag, `a-tag should exist for ${relayUrl}`);
+      assertEquals(
+        aTag[1],
+        `30166:${TEST_PUBKEY}:${relayUrl}`,
+        `a-tag should contain relay URL: ${relayUrl}`,
+      );
+    }
+  },
+);
 
 deletionTest("Kind5Event - event structure matches NIP-09 spec", () => {
   const relayUrl = "wss://relay.example.com";
@@ -370,7 +411,7 @@ deletionTest("Kind5Event - event structure matches NIP-09 spec", () => {
   const generated = event.generateEvent({
     relayUrl,
     pubkey: TEST_PUBKEY,
-    content
+    content,
   });
 
   // NIP-09 deletion event structure validation

--- a/apps/relaymon/tests/unit/ignorelist-sync.test.ts
+++ b/apps/relaymon/tests/unit/ignorelist-sync.test.ts
@@ -1,10 +1,15 @@
-import { assertEquals, assertExists, assert } from "https://deno.land/std@0.218.2/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.218.2/assert/mod.ts";
 import { IgnoreListSync } from "../../src/utils/IgnoreListSync.ts";
 import type { Config } from "../../src/types/config.ts";
 import { mockConfig } from "../helpers/fixtures.ts";
 import { DB } from "https://deno.land/x/sqlite/mod.ts";
 import { initDB } from "../../src/db/db.ts";
 import { getPublicKey } from "npm:nostr-tools";
+import { hexToBytes } from "@noble/hashes/utils";
 
 /**
  * Test helper to disable resource/ops sanitization
@@ -14,13 +19,14 @@ function ignoreListTest(name: string, fn: () => void | Promise<void>) {
     name,
     sanitizeResources: false,
     sanitizeOps: false,
-    fn
+    fn,
   });
 }
 
 // Test constants
-const TEST_PRIVKEY = "0000000000000000000000000000000000000000000000000000000000000001";
-const TEST_PUBKEY = getPublicKey(TEST_PRIVKEY);
+const TEST_PRIVKEY =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+const TEST_PUBKEY = getPublicKey(hexToBytes(TEST_PRIVKEY));
 const TEST_META_RELAYS = ["wss://meta1.example.com", "wss://meta2.example.com"];
 
 // Initialize a global test database
@@ -51,16 +57,16 @@ function createTestConfig(overrides: any = {}): Config {
         interval: "6h",
         deletion_interval: "24h",
         relays: ["wss://ignore-relay.example.com"],
-        pubkeys: [TEST_PUBKEY]
-      }
-    }
+        pubkeys: [TEST_PUBKEY],
+      },
+    },
   };
 
   // Deep merge overrides
   if (overrides.relaymon?.ignorelist) {
     baseConfig.relaymon.ignorelist = {
       ...baseConfig.relaymon.ignorelist,
-      ...overrides.relaymon.ignorelist
+      ...overrides.relaymon.ignorelist,
     };
   }
 
@@ -70,7 +76,9 @@ function createTestConfig(overrides: any = {}): Config {
 /**
  * Create a test database with relay_status table
  */
-function createTestDBWithRelays(relays: Array<{ url: string; ignore: number }>): string {
+function createTestDBWithRelays(
+  relays: Array<{ url: string; ignore: number }>,
+): string {
   const dbPath = `/tmp/test-ignorelist-db-${Date.now()}.db`;
   const db = new DB(dbPath);
 
@@ -90,7 +98,7 @@ function createTestDBWithRelays(relays: Array<{ url: string; ignore: number }>):
   for (const relay of relays) {
     db.execute(
       `INSERT INTO relay_status (url, ignore) VALUES (?, ?)`,
-      [relay.url, relay.ignore]
+      [relay.url, relay.ignore],
     );
   }
 
@@ -111,60 +119,75 @@ function cleanupTestDB(dbPath: string) {
 
 // Test suite
 
-ignoreListTest("IgnoreListSync - constructor creates instance when enabled", () => {
-  ensureTestDB();
-  const config = createTestConfig();
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+ignoreListTest(
+  "IgnoreListSync - constructor creates instance when enabled",
+  () => {
+    ensureTestDB();
+    const config = createTestConfig();
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  assertExists(sync, "IgnoreListSync should be created");
-});
+    assertExists(sync, "IgnoreListSync should be created");
+  },
+);
 
-ignoreListTest("IgnoreListSync - constructor creates instance when disabled", () => {
-  ensureTestDB();
-  const config = createTestConfig({
-    relaymon: {
-      ignorelist: { enabled: false }
-    }
-  });
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+ignoreListTest(
+  "IgnoreListSync - constructor creates instance when disabled",
+  () => {
+    ensureTestDB();
+    const config = createTestConfig({
+      relaymon: {
+        ignorelist: { enabled: false },
+      },
+    });
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  assertExists(sync, "IgnoreListSync should be created even when disabled");
-});
+    assertExists(sync, "IgnoreListSync should be created even when disabled");
+  },
+);
 
-ignoreListTest("IgnoreListSync - getRelaysForKind10002 returns relays when enabled", () => {
-  ensureTestDB();
-  const config = createTestConfig();
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+ignoreListTest(
+  "IgnoreListSync - getRelaysForKind10002 returns relays when enabled",
+  () => {
+    ensureTestDB();
+    const config = createTestConfig();
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  const relays = sync.getRelaysForKind10002();
-  assert(Array.isArray(relays), "Should return array");
-  assert(relays.length > 0, "Should return configured relays when enabled");
-});
+    const relays = sync.getRelaysForKind10002();
+    assert(Array.isArray(relays), "Should return array");
+    assert(relays.length > 0, "Should return configured relays when enabled");
+  },
+);
 
-ignoreListTest("IgnoreListSync - getRelaysForKind10002 returns empty array when disabled", () => {
-  ensureTestDB();
-  const config = createTestConfig({
-    relaymon: {
-      ignorelist: { enabled: false }
-    }
-  });
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+ignoreListTest(
+  "IgnoreListSync - getRelaysForKind10002 returns empty array when disabled",
+  () => {
+    ensureTestDB();
+    const config = createTestConfig({
+      relaymon: {
+        ignorelist: { enabled: false },
+      },
+    });
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  const relays = sync.getRelaysForKind10002();
-  assertEquals(relays, [], "Should return empty array when disabled");
-});
+    const relays = sync.getRelaysForKind10002();
+    assertEquals(relays, [], "Should return empty array when disabled");
+  },
+);
 
-ignoreListTest("IgnoreListSync - addToIgnoreList adds relay to local list", () => {
-  ensureTestDB();
-  const config = createTestConfig();
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+ignoreListTest(
+  "IgnoreListSync - addToIgnoreList adds relay to local list",
+  () => {
+    ensureTestDB();
+    const config = createTestConfig();
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  const testRelay = "wss://test-relay.example.com";
-  sync.addToIgnoreList(testRelay);
+    const testRelay = "wss://test-relay.example.com";
+    sync.addToIgnoreList(testRelay);
 
-  const isIgnored = sync.isIgnored(testRelay);
-  assertEquals(isIgnored, true, "Added relay should be ignored");
-});
+    const isIgnored = sync.isIgnored(testRelay);
+    assertEquals(isIgnored, true, "Added relay should be ignored");
+  },
+);
 
 ignoreListTest("IgnoreListSync - addToIgnoreList normalizes URLs", () => {
   ensureTestDB();
@@ -179,52 +202,61 @@ ignoreListTest("IgnoreListSync - addToIgnoreList normalizes URLs", () => {
   assertEquals(isIgnored, true, "Should normalize URLs when checking");
 });
 
-ignoreListTest("IgnoreListSync - removeFromIgnoreList removes relay from local list", () => {
-  ensureTestDB();
-  const config = createTestConfig();
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+ignoreListTest(
+  "IgnoreListSync - removeFromIgnoreList removes relay from local list",
+  () => {
+    ensureTestDB();
+    const config = createTestConfig();
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  const testRelay = "wss://test-relay.example.com";
-  sync.addToIgnoreList(testRelay);
+    const testRelay = "wss://test-relay.example.com";
+    sync.addToIgnoreList(testRelay);
 
-  // Note: removeFromIgnoreList only removes from localIgnoredRelays,
-  // but the relay remains in the merged ignoredRelays set until next sync
-  sync.removeFromIgnoreList(testRelay);
+    // Note: removeFromIgnoreList only removes from localIgnoredRelays,
+    // but the relay remains in the merged ignoredRelays set until next sync
+    sync.removeFromIgnoreList(testRelay);
 
-  // The relay is still in ignoredRelays (merged set), this is expected behavior
-  // The local list has been updated, but merged set persists until sync
-  assert(true, "removeFromIgnoreList should execute without error");
-});
+    // The relay is still in ignoredRelays (merged set), this is expected behavior
+    // The local list has been updated, but merged set persists until sync
+    assert(true, "removeFromIgnoreList should execute without error");
+  },
+);
 
-ignoreListTest("IgnoreListSync - isIgnored returns false for non-ignored relay", () => {
-  ensureTestDB();
-  const config = createTestConfig();
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+ignoreListTest(
+  "IgnoreListSync - isIgnored returns false for non-ignored relay",
+  () => {
+    ensureTestDB();
+    const config = createTestConfig();
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  const isIgnored = sync.isIgnored("wss://never-added.example.com");
-  assertEquals(isIgnored, false, "Non-ignored relay should return false");
-});
+    const isIgnored = sync.isIgnored("wss://never-added.example.com");
+    assertEquals(isIgnored, false, "Non-ignored relay should return false");
+  },
+);
 
-ignoreListTest("IgnoreListSync - loadLocalIgnoresFromDB handles database read", async () => {
-  ensureTestDB();
+ignoreListTest(
+  "IgnoreListSync - loadLocalIgnoresFromDB handles database read",
+  async () => {
+    ensureTestDB();
 
-  const config = createTestConfig();
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+    const config = createTestConfig();
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  // Note: The constructor already calls loadLocalIgnoresFromDB()
-  // We're testing that calling it again doesn't throw
-  await sync.loadLocalIgnoresFromDB();
+    // Note: The constructor already calls loadLocalIgnoresFromDB()
+    // We're testing that calling it again doesn't throw
+    await sync.loadLocalIgnoresFromDB();
 
-  // Should execute without error
-  assert(true, "loadLocalIgnoresFromDB should execute without error");
-});
+    // Should execute without error
+    assert(true, "loadLocalIgnoresFromDB should execute without error");
+  },
+);
 
 ignoreListTest("IgnoreListSync - sync does nothing when disabled", async () => {
   ensureTestDB();
   const config = createTestConfig({
     relaymon: {
-      ignorelist: { enabled: false }
-    }
+      ignorelist: { enabled: false },
+    },
   });
   const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
@@ -233,74 +265,95 @@ ignoreListTest("IgnoreListSync - sync does nothing when disabled", async () => {
   assert(true, "sync should complete without error when disabled");
 });
 
-ignoreListTest("IgnoreListSync - sync does nothing with no pubkeys configured", async () => {
-  ensureTestDB();
-  const config = createTestConfig({
-    relaymon: {
-      ignorelist: {
-        enabled: true,
-        pubkeys: []
-      }
-    }
-  });
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+ignoreListTest(
+  "IgnoreListSync - sync does nothing with no pubkeys configured",
+  async () => {
+    ensureTestDB();
+    const config = createTestConfig({
+      relaymon: {
+        ignorelist: {
+          enabled: true,
+          pubkeys: [],
+        },
+      },
+    });
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  // Should not throw
-  await sync.sync();
-  assert(true, "sync should complete without error when no pubkeys configured");
-});
+    // Should not throw
+    await sync.sync();
+    assert(
+      true,
+      "sync should complete without error when no pubkeys configured",
+    );
+  },
+);
 
-ignoreListTest("IgnoreListSync - publish does nothing when disabled", async () => {
-  ensureTestDB();
-  const config = createTestConfig({
-    relaymon: {
-      ignorelist: { enabled: false }
-    }
-  });
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+ignoreListTest(
+  "IgnoreListSync - publish does nothing when disabled",
+  async () => {
+    ensureTestDB();
+    const config = createTestConfig({
+      relaymon: {
+        ignorelist: { enabled: false },
+      },
+    });
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  // Should not throw
-  await sync.publish(TEST_PRIVKEY);
-  assert(true, "publish should complete without error when disabled");
-});
+    // Should not throw
+    await sync.publish(TEST_PRIVKEY);
+    assert(true, "publish should complete without error when disabled");
+  },
+);
 
-ignoreListTest("IgnoreListSync - publish skips when ignore list hasn't changed", async () => {
-  ensureTestDB();
-  const config = createTestConfig();
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+ignoreListTest(
+  "IgnoreListSync - publish skips when ignore list hasn't changed",
+  async () => {
+    ensureTestDB();
+    const config = createTestConfig();
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  // Don't add any relays, so list hasn't changed
-  await sync.publish(TEST_PRIVKEY);
-  assert(true, "publish should skip when list hasn't changed");
-});
+    // Don't add any relays, so list hasn't changed
+    await sync.publish(TEST_PRIVKEY);
+    assert(true, "publish should skip when list hasn't changed");
+  },
+);
 
-ignoreListTest("IgnoreListSync - publish attempts to publish after list changes", async () => {
-  ensureTestDB();
-  const config = createTestConfig();
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+ignoreListTest(
+  "IgnoreListSync - publish attempts to publish after list changes",
+  async () => {
+    ensureTestDB();
+    const config = createTestConfig();
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  // Add a relay to trigger list change
-  sync.addToIgnoreList("wss://test-relay.example.com");
+    // Add a relay to trigger list change
+    sync.addToIgnoreList("wss://test-relay.example.com");
 
-  // This will attempt to publish (will fail since we don't have real relays)
-  // But we're testing that it attempts without throwing
-  await sync.publish(TEST_PRIVKEY);
-  assert(true, "publish should attempt to publish when list has changed");
-});
+    // This will attempt to publish (will fail since we don't have real relays)
+    // But we're testing that it attempts without throwing
+    await sync.publish(TEST_PRIVKEY);
+    assert(true, "publish should attempt to publish when list has changed");
+  },
+);
 
-ignoreListTest("IgnoreListSync - publishDeletions does nothing when disabled", async () => {
-  ensureTestDB();
-  const config = createTestConfig({
-    relaymon: {
-      ignorelist: { enabled: false }
-    }
-  });
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+ignoreListTest(
+  "IgnoreListSync - publishDeletions does nothing when disabled",
+  async () => {
+    ensureTestDB();
+    const config = createTestConfig({
+      relaymon: {
+        ignorelist: { enabled: false },
+      },
+    });
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  // Should not throw
-  await sync.publishDeletions(TEST_PRIVKEY);
-  assert(true, "publishDeletions should complete without error when disabled");
-});
+    // Should not throw
+    await sync.publishDeletions(TEST_PRIVKEY);
+    assert(
+      true,
+      "publishDeletions should complete without error when disabled",
+    );
+  },
+);
 
 ignoreListTest("IgnoreListSync - close closes pool connections", () => {
   ensureTestDB();
@@ -312,43 +365,49 @@ ignoreListTest("IgnoreListSync - close closes pool connections", () => {
   assert(true, "close should execute without error");
 });
 
-ignoreListTest("IgnoreListSync - handles multiple relays in ignore list", () => {
-  ensureTestDB();
-  const config = createTestConfig();
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+ignoreListTest(
+  "IgnoreListSync - handles multiple relays in ignore list",
+  () => {
+    ensureTestDB();
+    const config = createTestConfig();
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  const relays = [
-    "wss://relay1.example.com",
-    "wss://relay2.example.com",
-    "wss://relay3.example.com"
-  ];
+    const relays = [
+      "wss://relay1.example.com",
+      "wss://relay2.example.com",
+      "wss://relay3.example.com",
+    ];
 
-  // Add multiple relays
-  for (const relay of relays) {
-    sync.addToIgnoreList(relay);
-  }
+    // Add multiple relays
+    for (const relay of relays) {
+      sync.addToIgnoreList(relay);
+    }
 
-  // Check all are ignored
-  for (const relay of relays) {
-    assertEquals(sync.isIgnored(relay), true, `${relay} should be ignored`);
-  }
-});
+    // Check all are ignored
+    for (const relay of relays) {
+      assertEquals(sync.isIgnored(relay), true, `${relay} should be ignored`);
+    }
+  },
+);
 
-ignoreListTest("IgnoreListSync - dedups when adding same relay multiple times", () => {
-  ensureTestDB();
-  const config = createTestConfig();
-  const sync = new IgnoreListSync(config, TEST_META_RELAYS);
+ignoreListTest(
+  "IgnoreListSync - dedups when adding same relay multiple times",
+  () => {
+    ensureTestDB();
+    const config = createTestConfig();
+    const sync = new IgnoreListSync(config, TEST_META_RELAYS);
 
-  const testRelay = "wss://test-relay.example.com";
+    const testRelay = "wss://test-relay.example.com";
 
-  // Add same relay multiple times
-  sync.addToIgnoreList(testRelay);
-  sync.addToIgnoreList(testRelay);
-  sync.addToIgnoreList(testRelay);
+    // Add same relay multiple times
+    sync.addToIgnoreList(testRelay);
+    sync.addToIgnoreList(testRelay);
+    sync.addToIgnoreList(testRelay);
 
-  // Should still be in list only once
-  assertEquals(sync.isIgnored(testRelay), true);
-});
+    // Should still be in list only once
+    assertEquals(sync.isIgnored(testRelay), true);
+  },
+);
 
 ignoreListTest("IgnoreListSync - handles invalid relay URLs gracefully", () => {
   ensureTestDB();

--- a/apps/relaymon/tests/unit/kind1066.test.ts
+++ b/apps/relaymon/tests/unit/kind1066.test.ts
@@ -1,4 +1,8 @@
-import { assertEquals, assertExists, assert } from "https://deno.land/std@0.218.2/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.218.2/assert/mod.ts";
 import { Kind1066 } from "../../src/delta/kind1066.ts";
 import type { Kind1066EventData } from "../../src/delta/kind1066.ts";
 
@@ -10,13 +14,15 @@ function kind1066Test(name: string, fn: () => void | Promise<void>) {
     name,
     sanitizeResources: false,
     sanitizeOps: false,
-    fn
+    fn,
   });
 }
 
 // Test pubkey (not a real key, just for testing)
-const TEST_PUBKEY = "0000000000000000000000000000000000000000000000000000000000000001";
-const TEST_PRIVKEY = "0000000000000000000000000000000000000000000000000000000000000001";
+const TEST_PUBKEY =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+const TEST_PRIVKEY =
+  "0000000000000000000000000000000000000000000000000000000000000001";
 
 kind1066Test("Kind 1066: Generate online event with deltas", () => {
   const builder = new Kind1066(TEST_PUBKEY);
@@ -27,8 +33,8 @@ kind1066Test("Kind 1066: Generate online event with deltas", () => {
     deltas: [
       { key: "name", value: "New Name", type: "change" },
       { key: "+supported_nips", value: "50", type: "add" },
-      { key: "-supported_nips", value: "42", type: "remove" }
-    ]
+      { key: "-supported_nips", value: "42", type: "remove" },
+    ],
   };
 
   const event = builder.generateEvent(data);
@@ -40,11 +46,26 @@ kind1066Test("Kind 1066: Generate online event with deltas", () => {
 
   // Check tags
   const tags = event.tags;
-  assert(tags.some(t => t[0] === "r" && t[1] === data.url), "Should have 'r' tag with URL");
-  assert(tags.some(t => t[0] === "rtt-open" && t[1] === "123"), "Should have rtt-open tag");
-  assert(tags.some(t => t[0] === "name" && t[1] === "New Name"), "Should have name change tag");
-  assert(tags.some(t => t[0] === "+supported_nips" && t[1] === "50"), "Should have NIP addition tag");
-  assert(tags.some(t => t[0] === "-supported_nips" && t[1] === "42"), "Should have NIP removal tag");
+  assert(
+    tags.some((t) => t[0] === "r" && t[1] === data.url),
+    "Should have 'r' tag with URL",
+  );
+  assert(
+    tags.some((t) => t[0] === "rtt-open" && t[1] === "123"),
+    "Should have rtt-open tag",
+  );
+  assert(
+    tags.some((t) => t[0] === "name" && t[1] === "New Name"),
+    "Should have name change tag",
+  );
+  assert(
+    tags.some((t) => t[0] === "+supported_nips" && t[1] === "50"),
+    "Should have NIP addition tag",
+  );
+  assert(
+    tags.some((t) => t[0] === "-supported_nips" && t[1] === "42"),
+    "Should have NIP removal tag",
+  );
 });
 
 kind1066Test("Kind 1066: Generate offline event with retry count", () => {
@@ -54,8 +75,8 @@ kind1066Test("Kind 1066: Generate offline event with retry count", () => {
     online: false,
     retryCount: 5,
     deltas: [
-      { key: "name", value: "Should Not Appear", type: "change" }
-    ]
+      { key: "name", value: "Should Not Appear", type: "change" },
+    ],
   };
 
   const event = builder.generateEvent(data);
@@ -64,10 +85,22 @@ kind1066Test("Kind 1066: Generate offline event with retry count", () => {
 
   // Check tags
   const tags = event.tags;
-  assert(tags.some(t => t[0] === "r" && t[1] === data.url), "Should have 'r' tag with URL");
-  assert(tags.some(t => t[0] === "retry" && t[1] === "5"), "Should have retry tag");
-  assert(!tags.some(t => t[0] === "rtt-open"), "Should NOT have rtt-open for offline relay");
-  assert(!tags.some(t => t[0] === "name"), "Should NOT have delta tags for offline relay");
+  assert(
+    tags.some((t) => t[0] === "r" && t[1] === data.url),
+    "Should have 'r' tag with URL",
+  );
+  assert(
+    tags.some((t) => t[0] === "retry" && t[1] === "5"),
+    "Should have retry tag",
+  );
+  assert(
+    !tags.some((t) => t[0] === "rtt-open"),
+    "Should NOT have rtt-open for offline relay",
+  );
+  assert(
+    !tags.some((t) => t[0] === "name"),
+    "Should NOT have delta tags for offline relay",
+  );
 });
 
 kind1066Test("Kind 1066: Online event without deltas", () => {
@@ -76,15 +109,20 @@ kind1066Test("Kind 1066: Online event without deltas", () => {
     url: "wss://test.relay.example.com",
     online: true,
     rttOpen: 456,
-    deltas: [] // No changes
+    deltas: [], // No changes
   };
 
   const event = builder.generateEvent(data);
 
   const tags = event.tags;
-  assert(tags.some(t => t[0] === "r"), "Should have 'r' tag");
-  assert(tags.some(t => t[0] === "rtt-open"), "Should have rtt-open tag");
-  assertEquals(tags.length, 2, "Should only have 'r' and 'rtt-open' tags when no deltas");
+  assert(tags.some((t) => t[0] === "r"), "Should have 'r' tag");
+  assert(tags.some((t) => t[0] === "rtt-open"), "Should have rtt-open tag");
+  assert(tags.some((t) => t[0] === "client"), "Should have client tag");
+  assertEquals(
+    tags.length,
+    3,
+    "Should only have 'r', 'rtt-open', and 'client' tags when no deltas",
+  );
 });
 
 kind1066Test("Kind 1066: Online event without rtt-open", () => {
@@ -94,15 +132,18 @@ kind1066Test("Kind 1066: Online event without rtt-open", () => {
     online: true,
     // rttOpen: undefined
     deltas: [
-      { key: "name", value: "Test", type: "change" }
-    ]
+      { key: "name", value: "Test", type: "change" },
+    ],
   };
 
   const event = builder.generateEvent(data);
 
   const tags = event.tags;
-  assert(!tags.some(t => t[0] === "rtt-open"), "Should NOT have rtt-open when undefined");
-  assert(tags.some(t => t[0] === "name"), "Should still have delta tags");
+  assert(
+    !tags.some((t) => t[0] === "rtt-open"),
+    "Should NOT have rtt-open when undefined",
+  );
+  assert(tags.some((t) => t[0] === "name"), "Should still have delta tags");
 });
 
 kind1066Test("Kind 1066: Offline event with retry count 0", () => {
@@ -111,13 +152,16 @@ kind1066Test("Kind 1066: Offline event with retry count 0", () => {
     url: "wss://test.relay.example.com",
     online: false,
     retryCount: 0,
-    deltas: []
+    deltas: [],
   };
 
   const event = builder.generateEvent(data);
 
   const tags = event.tags;
-  assert(tags.some(t => t[0] === "retry" && t[1] === "0"), "Should have retry tag with 0");
+  assert(
+    tags.some((t) => t[0] === "retry" && t[1] === "0"),
+    "Should have retry tag with 0",
+  );
 });
 
 kind1066Test("Kind 1066: Event structure validation", () => {
@@ -126,7 +170,7 @@ kind1066Test("Kind 1066: Event structure validation", () => {
     url: "wss://test.relay.example.com",
     online: true,
     rttOpen: 100,
-    deltas: []
+    deltas: [],
   };
 
   const event = builder.generateEvent(data);
@@ -155,17 +199,33 @@ kind1066Test("Kind 1066: Multiple delta types in one event", () => {
       { key: "name", value: "Updated Name", type: "change" },
       { key: "+contact", value: "new@example.com", type: "add" },
       { key: "-software", value: "old-software", type: "remove" },
-      { key: "limitation.max_message_length", value: "5000", type: "change" }
-    ]
+      { key: "limitation.max_message_length", value: "5000", type: "change" },
+    ],
   };
 
   const event = builder.generateEvent(data);
 
   const tags = event.tags;
-  assertEquals(tags.filter(t => t[0] === "name").length, 1, "Should have name tag");
-  assertEquals(tags.filter(t => t[0] === "+contact").length, 1, "Should have contact addition tag");
-  assertEquals(tags.filter(t => t[0] === "-software").length, 1, "Should have software removal tag");
-  assertEquals(tags.filter(t => t[0] === "limitation.max_message_length").length, 1, "Should have nested field change tag");
+  assertEquals(
+    tags.filter((t) => t[0] === "name").length,
+    1,
+    "Should have name tag",
+  );
+  assertEquals(
+    tags.filter((t) => t[0] === "+contact").length,
+    1,
+    "Should have contact addition tag",
+  );
+  assertEquals(
+    tags.filter((t) => t[0] === "-software").length,
+    1,
+    "Should have software removal tag",
+  );
+  assertEquals(
+    tags.filter((t) => t[0] === "limitation.max_message_length").length,
+    1,
+    "Should have nested field change tag",
+  );
 });
 
 kind1066Test("Kind 1066: Operational status 'init' for first check", () => {
@@ -175,36 +235,54 @@ kind1066Test("Kind 1066: Operational status 'init' for first check", () => {
     online: true,
     rttOpen: 150,
     deltas: [
-      { key: "+name", value: "New Relay", type: "add" }
+      { key: "+name", value: "New Relay", type: "add" },
     ],
-    operationalStatus: "init"
+    operationalStatus: "init",
   };
 
   const event = builder.generateEvent(data);
 
   const tags = event.tags;
-  assert(tags.some(t => t[0] === "O" && t[1] === "init"), "Should have O:init tag for first check");
-  assert(tags.some(t => t[0] === "r" && t[1] === data.url), "Should have r tag");
-  assert(tags.some(t => t[0] === "rtt-open"), "Should have rtt-open tag");
+  assert(
+    tags.some((t) => t[0] === "O" && t[1] === "init"),
+    "Should have O:init tag for first check",
+  );
+  assert(
+    tags.some((t) => t[0] === "r" && t[1] === data.url),
+    "Should have r tag",
+  );
+  assert(tags.some((t) => t[0] === "rtt-open"), "Should have rtt-open tag");
 });
 
-kind1066Test("Kind 1066: Operational status 'down' when relay goes offline", () => {
-  const builder = new Kind1066(TEST_PUBKEY);
-  const data: Kind1066EventData = {
-    url: "wss://failing.relay.example.com",
-    online: false,
-    retryCount: 1,
-    deltas: [],
-    operationalStatus: "down"
-  };
+kind1066Test(
+  "Kind 1066: Operational status 'down' when relay goes offline",
+  () => {
+    const builder = new Kind1066(TEST_PUBKEY);
+    const data: Kind1066EventData = {
+      url: "wss://failing.relay.example.com",
+      online: false,
+      retryCount: 1,
+      deltas: [],
+      operationalStatus: "down",
+    };
 
-  const event = builder.generateEvent(data);
+    const event = builder.generateEvent(data);
 
-  const tags = event.tags;
-  assert(tags.some(t => t[0] === "O" && t[1] === "down"), "Should have O:down tag when relay goes offline");
-  assert(tags.some(t => t[0] === "retry" && t[1] === "1"), "Should have retry tag");
-  assert(!tags.some(t => t[0] === "rtt-open"), "Should NOT have rtt-open when offline");
-});
+    const tags = event.tags;
+    assert(
+      tags.some((t) => t[0] === "O" && t[1] === "down"),
+      "Should have O:down tag when relay goes offline",
+    );
+    assert(
+      tags.some((t) => t[0] === "retry" && t[1] === "1"),
+      "Should have retry tag",
+    );
+    assert(
+      !tags.some((t) => t[0] === "rtt-open"),
+      "Should NOT have rtt-open when offline",
+    );
+  },
+);
 
 kind1066Test("Kind 1066: Operational status 'up' when relay recovers", () => {
   const builder = new Kind1066(TEST_PUBKEY);
@@ -213,38 +291,47 @@ kind1066Test("Kind 1066: Operational status 'up' when relay recovers", () => {
     online: true,
     rttOpen: 250,
     deltas: [
-      { key: "name", value: "Recovered Relay", type: "change" }
+      { key: "name", value: "Recovered Relay", type: "change" },
     ],
-    operationalStatus: "up"
+    operationalStatus: "up",
   };
 
   const event = builder.generateEvent(data);
 
   const tags = event.tags;
-  assert(tags.some(t => t[0] === "O" && t[1] === "up"), "Should have O:up tag when relay recovers");
-  assert(tags.some(t => t[0] === "rtt-open"), "Should have rtt-open tag");
-  assert(tags.some(t => t[0] === "name"), "Should have delta tags");
+  assert(
+    tags.some((t) => t[0] === "O" && t[1] === "up"),
+    "Should have O:up tag when relay recovers",
+  );
+  assert(tags.some((t) => t[0] === "rtt-open"), "Should have rtt-open tag");
+  assert(tags.some((t) => t[0] === "name"), "Should have delta tags");
 });
 
-kind1066Test("Kind 1066: No operational status tag when no state change", () => {
-  const builder = new Kind1066(TEST_PUBKEY);
-  const data: Kind1066EventData = {
-    url: "wss://stable.relay.example.com",
-    online: true,
-    rttOpen: 100,
-    deltas: [
-      { key: "name", value: "Stable Relay", type: "change" }
-    ]
-    // No operationalStatus = no state change
-  };
+kind1066Test(
+  "Kind 1066: No operational status tag when no state change",
+  () => {
+    const builder = new Kind1066(TEST_PUBKEY);
+    const data: Kind1066EventData = {
+      url: "wss://stable.relay.example.com",
+      online: true,
+      rttOpen: 100,
+      deltas: [
+        { key: "name", value: "Stable Relay", type: "change" },
+      ],
+      // No operationalStatus = no state change
+    };
 
-  const event = builder.generateEvent(data);
+    const event = builder.generateEvent(data);
 
-  const tags = event.tags;
-  assert(!tags.some(t => t[0] === "O"), "Should NOT have O tag when no state change");
-  assert(tags.some(t => t[0] === "r"), "Should have r tag");
-  assert(tags.some(t => t[0] === "rtt-open"), "Should have rtt-open tag");
-});
+    const tags = event.tags;
+    assert(
+      !tags.some((t) => t[0] === "O"),
+      "Should NOT have O tag when no state change",
+    );
+    assert(tags.some((t) => t[0] === "r"), "Should have r tag");
+    assert(tags.some((t) => t[0] === "rtt-open"), "Should have rtt-open tag");
+  },
+);
 
 kind1066Test("Kind 1066: Operational status with period tags", () => {
   const builder = new Kind1066(TEST_PUBKEY);
@@ -254,21 +341,33 @@ kind1066Test("Kind 1066: Operational status with period tags", () => {
     rttOpen: 120,
     deltas: [],
     periods: ["6h", "1d", "7d"],
-    operationalStatus: "up"
+    operationalStatus: "up",
   };
 
   const event = builder.generateEvent(data);
 
   const tags = event.tags;
-  assert(tags.some(t => t[0] === "O" && t[1] === "up"), "Should have O:up tag");
-  assert(tags.some(t => t[0] === "T" && t[1] === "6h"), "Should have T:6h tag");
-  assert(tags.some(t => t[0] === "T" && t[1] === "1d"), "Should have T:1d tag");
-  assert(tags.some(t => t[0] === "T" && t[1] === "7d"), "Should have T:7d tag");
+  assert(
+    tags.some((t) => t[0] === "O" && t[1] === "up"),
+    "Should have O:up tag",
+  );
+  assert(
+    tags.some((t) => t[0] === "T" && t[1] === "6h"),
+    "Should have T:6h tag",
+  );
+  assert(
+    tags.some((t) => t[0] === "T" && t[1] === "1d"),
+    "Should have T:1d tag",
+  );
+  assert(
+    tags.some((t) => t[0] === "T" && t[1] === "7d"),
+    "Should have T:7d tag",
+  );
 
   // Verify tag ordering: r, O, T, then other tags
-  const rIndex = tags.findIndex(t => t[0] === "r");
-  const oIndex = tags.findIndex(t => t[0] === "O");
-  const firstTIndex = tags.findIndex(t => t[0] === "T");
+  const rIndex = tags.findIndex((t) => t[0] === "r");
+  const oIndex = tags.findIndex((t) => t[0] === "O");
+  const firstTIndex = tags.findIndex((t) => t[0] === "T");
 
   assert(rIndex < oIndex, "r tag should come before O tag");
   assert(oIndex < firstTIndex, "O tag should come before T tags");

--- a/apps/relaymon/tests/unit/kind30385.test.ts
+++ b/apps/relaymon/tests/unit/kind30385.test.ts
@@ -1,0 +1,296 @@
+import {
+  assert,
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.218.2/assert/mod.ts";
+import { hexToBytes } from "@noble/hashes/utils";
+import { getPublicKey, verifyEvent } from "npm:nostr-tools";
+import type { TrustedRelayAssertionsConfig } from "../../src/types/config.ts";
+import type { RelayCheckResult } from "../../src/types/relay.ts";
+import {
+  buildTrustedRelayAssertion,
+  hasTrustedRelayMaterialChange,
+  Kind30385,
+  normalizeRelayUrl,
+} from "../../src/tra/kind30385.ts";
+import type { TrustedRelayObservationState } from "../../src/db/db.ts";
+
+function traTest(name: string, fn: () => void | Promise<void>) {
+  Deno.test({
+    name,
+    sanitizeResources: false,
+    sanitizeOps: false,
+    fn,
+  });
+}
+
+const TEST_PRIVKEY =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+const TEST_PUBKEY = getPublicKey(hexToBytes(TEST_PRIVKEY));
+const RELAY_PUBKEY =
+  "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+const config: TrustedRelayAssertionsConfig = {
+  enabled: true,
+  min_observations: 2,
+  material_change_threshold: 3,
+  refresh_interval: 3600000,
+  publish_unreachable: true,
+  publish_blocked: false,
+  algorithm: {
+    version: "relaymon-local-test",
+    url: "https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md",
+  },
+};
+
+function history(
+  overrides: Partial<TrustedRelayObservationState> = {},
+): TrustedRelayObservationState {
+  return {
+    url: "wss://relay.example.com",
+    firstSeen: 1_700_000_000,
+    lastObserved: 1_700_000_120,
+    observations: 3,
+    reachableObservations: 3,
+    totalRttOpen: 360,
+    rttOpenSamples: 3,
+    totalRttRead: 450,
+    rttReadSamples: 3,
+    lastOnlineAt: 1_700_000_120,
+    ...overrides,
+  };
+}
+
+function result(overrides: Partial<RelayCheckResult> = {}): RelayCheckResult {
+  return {
+    url: "wss://Relay.Example.com/",
+    hostname: "relay.example.com",
+    protocol: "wss:",
+    network: "clearnet",
+    checked_at: 1_700_000_120,
+    online: true,
+    ignore: false,
+    parent: "",
+    open: { data: true, duration: 110 },
+    read: { data: true, duration: 140 },
+    info: {
+      duration: 50,
+      data: {
+        name: "Example Relay",
+        description: "A relay for tests",
+        contact: "ops@example.com",
+        pubkey: RELAY_PUBKEY,
+        supported_nips: [1, 9, 11, 50],
+        software: "strfry",
+        version: "1.0.0",
+        limitation: {
+          auth_required: false,
+          payment_required: false,
+          max_subscriptions: 20,
+          max_filters: 10,
+          max_content_length: 65536,
+        },
+      },
+    },
+    geo: {
+      duration: 25,
+      data: {
+        countryCode: "de",
+        region: "Bavaria",
+        isp: "Hetzner Online GmbH",
+      },
+    },
+    ssl: {
+      duration: 20,
+      data: { valid: true },
+    },
+    ...overrides,
+  } as RelayCheckResult;
+}
+
+traTest(
+  "Kind30385 - normalizeRelayUrl lowercases and removes trailing slash",
+  () => {
+    assertEquals(
+      normalizeRelayUrl("WSS://Relay.Example.com/"),
+      "wss://relay.example.com",
+    );
+  },
+);
+
+traTest(
+  "Kind30385 - buildTrustedRelayAssertion creates evaluated assertion with NIP tags",
+  () => {
+    const assertion = buildTrustedRelayAssertion(result(), history(), config);
+
+    assertEquals(assertion.relayUrl, "wss://relay.example.com");
+    assertEquals(assertion.status, "evaluated");
+    assertEquals(assertion.algorithm, "relaymon-local-test");
+    assertEquals(assertion.operator, RELAY_PUBKEY);
+    assertEquals(assertion.operatorVerified, "nip11");
+    assertEquals(assertion.operatorConfidence, 70);
+    assertEquals(assertion.policy, "open");
+    assertEquals(assertion.countryCode, "DE");
+    assertEquals(assertion.region, "Bavaria");
+    assertEquals(assertion.isHosting, true);
+    assertEquals(assertion.network, "clearnet");
+    assertExists(assertion.score);
+    assert(assertion.score >= 0 && assertion.score <= 100);
+  },
+);
+
+traTest(
+  "Kind30385 - insufficient observations produce insufficient_data status",
+  () => {
+    const assertion = buildTrustedRelayAssertion(
+      result(),
+      history({ observations: 1, reachableObservations: 1 }),
+      config,
+    );
+
+    assertEquals(assertion.status, "insufficient_data");
+    assertEquals(assertion.confidence, "low");
+  },
+);
+
+traTest("Kind30385 - offline relay produces unreachable status", () => {
+  const assertion = buildTrustedRelayAssertion(
+    result({ online: false, open: { data: false, duration: 1000 } }),
+    history({ reachableObservations: 2 }),
+    config,
+  );
+
+  assertEquals(assertion.status, "unreachable");
+  assertExists(assertion.score);
+});
+
+traTest(
+  "Kind30385 - generateEvent emits required and optional NIP tags",
+  () => {
+    const builder = new Kind30385(TEST_PUBKEY);
+    const assertion = buildTrustedRelayAssertion(result(), history(), config);
+    const event = builder.generateEvent(assertion);
+
+    assertEquals(event.kind, 30385);
+    assertEquals(event.pubkey, TEST_PUBKEY);
+    assertEquals(event.content, "");
+    assertEquals(
+      event.tags.find((tag) => tag[0] === "d")?.[1],
+      "wss://relay.example.com",
+    );
+    assertEquals(
+      event.tags.find((tag) => tag[0] === "status")?.[1],
+      "evaluated",
+    );
+    assertEquals(
+      event.tags.find((tag) => tag[0] === "score")?.[1],
+      String(assertion.score),
+    );
+    assertEquals(
+      event.tags.find((tag) => tag[0] === "reliability")?.[1],
+      String(assertion.reliability),
+    );
+    assertEquals(
+      event.tags.find((tag) => tag[0] === "quality")?.[1],
+      String(assertion.quality),
+    );
+    assertEquals(
+      event.tags.find((tag) => tag[0] === "accessibility")?.[1],
+      String(assertion.accessibility),
+    );
+    assertEquals(event.tags.find((tag) => tag[0] === "confidence")?.[1], "low");
+    assertEquals(event.tags.find((tag) => tag[0] === "observations")?.[1], "3");
+    assertEquals(
+      event.tags.find((tag) => tag[0] === "operator")?.[1],
+      RELAY_PUBKEY,
+    );
+    assertEquals(
+      event.tags.find((tag) => tag[0] === "operator_verified")?.[1],
+      "nip11",
+    );
+    assertEquals(
+      event.tags.find((tag) => tag[0] === "network")?.[1],
+      "clearnet",
+    );
+    assertEquals(
+      event.tags.find((tag) => tag[0] === "client")?.[1],
+      "@nostrwatch/relaymon",
+    );
+  },
+);
+
+traTest(
+  "Kind30385 - generateAndSignEvent creates verifiable event",
+  async () => {
+    const builder = new Kind30385(TEST_PUBKEY);
+    const assertion = buildTrustedRelayAssertion(result(), history(), config);
+    const signed = await builder.generateAndSignEvent(assertion, TEST_PRIVKEY);
+
+    assertEquals(signed.kind, 30385);
+    assertEquals(signed.pubkey, TEST_PUBKEY);
+    assertExists(signed.id);
+    assertExists(signed.sig);
+    assert(verifyEvent(signed), "signed event should verify");
+  },
+);
+
+traTest("Kind30385 - material change detects first publish", () => {
+  const assertion = buildTrustedRelayAssertion(result(), history(), config);
+  const change = hasTrustedRelayMaterialChange(assertion, null);
+
+  assertEquals(change.changed, true);
+  assertEquals(change.reason, "first_publish");
+});
+
+traTest(
+  "Kind30385 - material change suppresses small score changes before refresh interval",
+  () => {
+    const assertion = buildTrustedRelayAssertion(result(), history(), config);
+    const change = hasTrustedRelayMaterialChange(
+      assertion,
+      {
+        status: assertion.status,
+        score: assertion.score === undefined ? undefined : assertion.score - 1,
+        reliability: assertion.reliability,
+        quality: assertion.quality,
+        accessibility: assertion.accessibility,
+        confidence: assertion.confidence,
+        publishedAt: 1_700_000_000,
+      },
+      3,
+      3600000,
+      1_700_000_100,
+    );
+
+    assertEquals(change.changed, false);
+  },
+);
+
+traTest(
+  "Kind30385 - material change detects status and threshold changes",
+  () => {
+    const assertion = buildTrustedRelayAssertion(result(), history(), config);
+
+    const statusChange = hasTrustedRelayMaterialChange(assertion, {
+      status: "unreachable",
+      score: assertion.score,
+      reliability: assertion.reliability,
+      quality: assertion.quality,
+      accessibility: assertion.accessibility,
+      confidence: assertion.confidence,
+      publishedAt: 1_700_000_000,
+    });
+    assertEquals(statusChange.changed, true);
+
+    const scoreChange = hasTrustedRelayMaterialChange(assertion, {
+      status: assertion.status,
+      score: assertion.score === undefined ? undefined : assertion.score - 5,
+      reliability: assertion.reliability,
+      quality: assertion.quality,
+      accessibility: assertion.accessibility,
+      confidence: assertion.confidence,
+      publishedAt: 1_700_000_000,
+    });
+    assertEquals(scoreChange.changed, true);
+  },
+);

--- a/apps/relaymon/tests/unit/kind30385.test.ts
+++ b/apps/relaymon/tests/unit/kind30385.test.ts
@@ -108,6 +108,31 @@ function result(overrides: Partial<RelayCheckResult> = {}): RelayCheckResult {
   } as RelayCheckResult;
 }
 
+function sample(
+  observedAt: number,
+  online: boolean,
+  latency = 120,
+) {
+  return {
+    url: "wss://relay.example.com",
+    observedAt,
+    online,
+    rttOpen: latency,
+    rttRead: latency + 20,
+    rttWrite: latency + 40,
+    network: "clearnet",
+    nip11Present: true,
+    operatorPubkey: RELAY_PUBKEY,
+    sslValid: true,
+    dnsAddress: "203.0.113.10",
+    dnsAs: "Example Network",
+    dnsAsn: "64500",
+    countryCode: "DE",
+    region: "Bavaria",
+    isHosting: true,
+  };
+}
+
 traTest(
   "Kind30385 - normalizeRelayUrl lowercases and removes trailing slash",
   () => {
@@ -140,6 +165,22 @@ traTest(
 );
 
 traTest(
+  "Kind30385 - defaults to RelayMon-local v2 algorithm metadata",
+  () => {
+    const assertion = buildTrustedRelayAssertion(
+      result(),
+      history(),
+      {
+        ...config,
+        algorithm: undefined,
+      },
+    );
+
+    assertEquals(assertion.algorithm, "relaymon-local-v2");
+  },
+);
+
+traTest(
   "Kind30385 - insufficient observations produce insufficient_data status",
   () => {
     const assertion = buildTrustedRelayAssertion(
@@ -163,6 +204,124 @@ traTest("Kind30385 - offline relay produces unreachable status", () => {
   assertEquals(assertion.status, "unreachable");
   assertExists(assertion.score);
 });
+
+traTest(
+  "Kind30385 - local outage and flapping history lowers reliability",
+  () => {
+    const stable = buildTrustedRelayAssertion(
+      result(),
+      history({
+        observations: 6,
+        reachableObservations: 6,
+        totalRttOpen: 600,
+        rttOpenSamples: 6,
+        totalRttRead: 720,
+        rttReadSamples: 6,
+        history: [
+          sample(1_700_000_000, true, 100),
+          sample(1_700_000_060, true, 105),
+          sample(1_700_000_120, true, 95),
+          sample(1_700_000_180, true, 100),
+          sample(1_700_000_240, true, 110),
+          sample(1_700_000_300, true, 100),
+        ],
+      }),
+      config,
+    );
+    const flapping = buildTrustedRelayAssertion(
+      result({ online: false, open: { data: false, duration: 1200 } }),
+      history({
+        observations: 6,
+        reachableObservations: 3,
+        totalRttOpen: 4400,
+        rttOpenSamples: 6,
+        totalRttRead: 5000,
+        rttReadSamples: 6,
+        history: [
+          sample(1_700_000_000, true, 100),
+          sample(1_700_000_060, false, 900),
+          sample(1_700_000_120, true, 120),
+          sample(1_700_000_180, false, 1000),
+          sample(1_700_000_240, true, 130),
+          sample(1_700_000_300, false, 1200),
+        ],
+      }),
+      config,
+    );
+
+    assertExists(stable.reliability);
+    assertExists(flapping.reliability);
+    assert(
+      stable.reliability > flapping.reliability,
+      "stable local history should score above flapping outage history",
+    );
+  },
+);
+
+traTest(
+  "Kind30385 - quality uses local DNS evidence",
+  () => {
+    const goodDns = buildTrustedRelayAssertion(
+      result({
+        dns: {
+          duration: 10,
+          data: {
+            address: "203.0.113.10",
+            as: "Example Network",
+            asn: 64500,
+          },
+        },
+      }),
+      history(),
+      config,
+    );
+    const failedDns = buildTrustedRelayAssertion(
+      result({
+        dns: {
+          duration: 10,
+          data: {},
+          error: new Error("dns failed"),
+        },
+      }),
+      history(),
+      config,
+    );
+
+    assertExists(goodDns.quality);
+    assertExists(failedDns.quality);
+    assert(
+      goodDns.quality > failedDns.quality,
+      "DNS evidence should affect quality scoring",
+    );
+  },
+);
+
+traTest(
+  "Kind30385 - anonymous networks use local network knowledge for jurisdiction",
+  () => {
+    const assertion = buildTrustedRelayAssertion(
+      result({
+        url: "ws://abcdef.onion",
+        hostname: "abcdef.onion",
+        protocol: "ws:",
+        network: "tor",
+        geo: {
+          duration: 25,
+          data: {
+            countryCode: "us",
+            region: "Virginia",
+          },
+        },
+      }),
+      history(),
+      config,
+    );
+
+    assertEquals(assertion.network, "tor");
+    assertEquals(assertion.countryCode, "XX");
+    assertEquals(assertion.region, undefined);
+  },
+);
 
 traTest(
   "Kind30385 - generateEvent emits required and optional NIP tags",
@@ -216,6 +375,19 @@ traTest(
       event.tags.find((tag) => tag[0] === "client")?.[1],
       "@nostrwatch/relaymon",
     );
+  },
+);
+
+traTest(
+  "Kind30385 - 30385 event pubkey is the RelayMon monitor pubkey",
+  () => {
+    const monitorPubkey = TEST_PUBKEY;
+    const builder = new Kind30385(monitorPubkey);
+    const assertion = buildTrustedRelayAssertion(result(), history(), config);
+    const event = builder.generateEvent(assertion);
+
+    assertEquals(event.kind, 30385);
+    assertEquals(event.pubkey, monitorPubkey);
   },
 );
 

--- a/apps/relaymon/tests/unit/worker-publishing.test.ts
+++ b/apps/relaymon/tests/unit/worker-publishing.test.ts
@@ -1,6 +1,11 @@
-import { assertEquals, assertExists, assert } from "https://deno.land/std@0.218.2/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.218.2/assert/mod.ts";
 import { Kind30166 } from "npm:@nostrwatch/publisher";
-import { getPublicKey, getEventHash, verifyEvent } from "npm:nostr-tools";
+import { getEventHash, getPublicKey, verifyEvent } from "npm:nostr-tools";
+import { hexToBytes } from "@noble/hashes/utils";
 import type { RelayCheckResult } from "../../src/types/relay.ts";
 
 /**
@@ -11,18 +16,21 @@ function publishTest(name: string, fn: () => void | Promise<void>) {
     name,
     sanitizeResources: false,
     sanitizeOps: false,
-    fn
+    fn,
   });
 }
 
 // Use a valid test private key
-const TEST_PRIVKEY = "0000000000000000000000000000000000000000000000000000000000000001";
-const TEST_PUBKEY = getPublicKey(TEST_PRIVKEY);
+const TEST_PRIVKEY =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+const TEST_PUBKEY = getPublicKey(hexToBytes(TEST_PRIVKEY));
 
 /**
  * Create a mock relay check result for testing
  */
-function createMockRelayCheckResult(overrides: Partial<RelayCheckResult> = {}): RelayCheckResult {
+function createMockRelayCheckResult(
+  overrides: Partial<RelayCheckResult> = {},
+): RelayCheckResult {
   return {
     url: "wss://relay.example.com",
     hostname: "relay.example.com",
@@ -34,15 +42,15 @@ function createMockRelayCheckResult(overrides: Partial<RelayCheckResult> = {}): 
     parent: "",
     open: {
       data: true,
-      duration: 150
+      duration: 150,
     },
     read: {
       data: true,
-      duration: 200
+      duration: 200,
     },
     write: {
       data: true,
-      duration: 180
+      duration: 180,
     },
     info: {
       data: {
@@ -51,11 +59,11 @@ function createMockRelayCheckResult(overrides: Partial<RelayCheckResult> = {}): 
         pubkey: TEST_PUBKEY,
         supported_nips: [1, 2, 9, 11],
         software: "nostr-relay",
-        version: "1.0.0"
+        version: "1.0.0",
       },
-      duration: 100
+      duration: 100,
     },
-    ...overrides
+    ...overrides,
   } as RelayCheckResult;
 }
 
@@ -88,7 +96,7 @@ publishTest("Kind30166 - event includes d-tag with relay URL", () => {
 
   const generated = event.generateEvent(checkResult);
 
-  const dTag = generated.tags.find(tag => tag[0] === "d");
+  const dTag = generated.tags.find((tag) => tag[0] === "d");
   assertExists(dTag, "d-tag should exist");
   assertEquals(dTag[1], relayUrl, "d-tag should contain relay URL");
 });
@@ -99,7 +107,7 @@ publishTest("Kind30166 - event includes network tag", () => {
 
   const generated = event.generateEvent(checkResult);
 
-  const nTag = generated.tags.find(tag => tag[0] === "n");
+  const nTag = generated.tags.find((tag) => tag[0] === "n");
   assertExists(nTag, "n-tag should exist");
   assertEquals(nTag[1], "clearnet", "n-tag should contain network type");
 });
@@ -109,14 +117,14 @@ publishTest("Kind30166 - event includes RTT tags for timing data", () => {
   const checkResult = createMockRelayCheckResult({
     open: { data: true, duration: 150 },
     read: { data: true, duration: 200 },
-    write: { data: true, duration: 180 }
+    write: { data: true, duration: 180 },
   });
 
   const generated = event.generateEvent(checkResult);
 
-  const rttOpenTag = generated.tags.find(tag => tag[0] === "rtt-open");
-  const rttReadTag = generated.tags.find(tag => tag[0] === "rtt-read");
-  const rttWriteTag = generated.tags.find(tag => tag[0] === "rtt-write");
+  const rttOpenTag = generated.tags.find((tag) => tag[0] === "rtt-open");
+  const rttReadTag = generated.tags.find((tag) => tag[0] === "rtt-read");
+  const rttWriteTag = generated.tags.find((tag) => tag[0] === "rtt-write");
 
   assertExists(rttOpenTag, "rtt-open tag should exist");
   assertExists(rttReadTag, "rtt-read tag should exist");
@@ -135,10 +143,10 @@ publishTest("Kind30166 - event includes NIP-11 info in content", () => {
         name: "Test Relay",
         description: "A test relay",
         pubkey: TEST_PUBKEY,
-        supported_nips: [1, 2, 9, 11]
+        supported_nips: [1, 2, 9, 11],
       },
-      duration: 100
-    }
+      duration: 100,
+    },
   });
 
   const generated = event.generateEvent(checkResult);
@@ -147,8 +155,16 @@ publishTest("Kind30166 - event includes NIP-11 info in content", () => {
   assert(generated.content.length > 2, "Content should not be empty JSON");
 
   const parsedContent = JSON.parse(generated.content);
-  assertEquals(parsedContent.name, "Test Relay", "Content should include relay name");
-  assertEquals(parsedContent.description, "A test relay", "Content should include description");
+  assertEquals(
+    parsedContent.name,
+    "Test Relay",
+    "Content should include relay name",
+  );
+  assertEquals(
+    parsedContent.description,
+    "A test relay",
+    "Content should include description",
+  );
 });
 
 publishTest("Kind30166 - event includes supported NIPs as N tags", () => {
@@ -156,18 +172,18 @@ publishTest("Kind30166 - event includes supported NIPs as N tags", () => {
   const checkResult = createMockRelayCheckResult({
     info: {
       data: {
-        supported_nips: [1, 2, 9, 11, 50]
+        supported_nips: [1, 2, 9, 11, 50],
       },
-      duration: 100
-    }
+      duration: 100,
+    },
   });
 
   const generated = event.generateEvent(checkResult);
 
-  const nTags = generated.tags.filter(tag => tag[0] === "N");
+  const nTags = generated.tags.filter((tag) => tag[0] === "N");
   assert(nTags.length >= 5, "Should have N tags for NIPs");
 
-  const nipNumbers = nTags.map(tag => parseInt(tag[1]));
+  const nipNumbers = nTags.map((tag) => parseInt(tag[1]));
   assert(nipNumbers.includes(1), "Should include NIP-1");
   assert(nipNumbers.includes(2), "Should include NIP-2");
   assert(nipNumbers.includes(9), "Should include NIP-9");
@@ -176,20 +192,21 @@ publishTest("Kind30166 - event includes supported NIPs as N tags", () => {
 });
 
 publishTest("Kind30166 - event includes relay pubkey as p-tag", () => {
-  const relayPubkey = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+  const relayPubkey =
+    "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
   const event = new Kind30166(TEST_PUBKEY);
   const checkResult = createMockRelayCheckResult({
     info: {
       data: {
-        pubkey: relayPubkey
+        pubkey: relayPubkey,
       },
-      duration: 100
-    }
+      duration: 100,
+    },
   });
 
   const generated = event.generateEvent(checkResult);
 
-  const pTag = generated.tags.find(tag => tag[0] === "p");
+  const pTag = generated.tags.find((tag) => tag[0] === "p");
   assertExists(pTag, "p-tag should exist");
   assertEquals(pTag[1], relayPubkey, "p-tag should contain relay pubkey");
 });
@@ -200,19 +217,21 @@ publishTest("Kind30166 - event includes software and version tags", () => {
     info: {
       data: {
         software: "nostr-rs-relay",
-        version: "0.8.9"
+        version: "0.8.9",
       },
-      duration: 100
-    }
+      duration: 100,
+    },
   });
 
   const generated = event.generateEvent(checkResult);
 
-  const sTag = generated.tags.find(tag => tag[0] === "s");
+  const sTag = generated.tags.find((tag) => tag[0] === "s");
   assertExists(sTag, "s-tag (software) should exist");
   assertEquals(sTag[1], "nostr-rs-relay", "Software should match");
 
-  const versionTags = generated.tags.filter(tag => tag[0] === "l" && tag[2] === "nip11.version");
+  const versionTags = generated.tags.filter((tag) =>
+    tag[0] === "l" && tag[2] === "nip11.version"
+  );
   assert(versionTags.length > 0, "Version label tag should exist");
   assertEquals(versionTags[0][1], "0.8.9", "Version should match");
 });
@@ -225,23 +244,26 @@ publishTest("Kind30166 - event includes limitation/restriction tags", () => {
         limitation: {
           auth_required: true,
           payment_required: false,
-          pow_required: false
-        }
+          pow_required: false,
+        },
       },
-      duration: 100
-    }
+      duration: 100,
+    },
   });
 
   const generated = event.generateEvent(checkResult);
 
-  const rTags = generated.tags.filter(tag => tag[0] === "R");
+  const rTags = generated.tags.filter((tag) => tag[0] === "R");
 
-  const authTag = rTags.find(tag => tag[1] === "auth");
-  const noPaymentTag = rTags.find(tag => tag[1] === "!payment");
-  const noPowTag = rTags.find(tag => tag[1] === "!pow");
+  const authTag = rTags.find((tag) => tag[1] === "auth");
+  const noPaymentTag = rTags.find((tag) => tag[1] === "!payment");
+  const noPowTag = rTags.find((tag) => tag[1] === "!pow");
 
   assertExists(authTag, "Should have 'auth' R tag when auth required");
-  assertExists(noPaymentTag, "Should have '!payment' R tag when payment not required");
+  assertExists(
+    noPaymentTag,
+    "Should have '!payment' R tag when payment not required",
+  );
   assertExists(noPowTag, "Should have '!pow' R tag when pow not required");
 });
 
@@ -251,7 +273,9 @@ publishTest("Kind30166 - event includes draft version tag", () => {
 
   const generated = event.generateEvent(checkResult);
 
-  const draftTag = generated.tags.find(tag => tag[0] === "l" && tag[2] === "nip66.draft");
+  const draftTag = generated.tags.find((tag) =>
+    tag[0] === "l" && tag[2] === "nip66.draft"
+  );
   assertExists(draftTag, "Draft version tag should exist");
   assertEquals(draftTag[1], "draft7", "Should be draft7");
 });
@@ -283,7 +307,11 @@ publishTest("Kind30166 - signed event has correct ID", async () => {
   // Compute expected ID manually
   const expectedId = getEventHash(generated);
 
-  assertEquals(signedEvent.id, expectedId, "Event ID should match computed hash");
+  assertEquals(
+    signedEvent.id,
+    expectedId,
+    "Event ID should match computed hash",
+  );
 });
 
 publishTest("Kind30166 - event with minimal check result", () => {
@@ -292,7 +320,7 @@ publishTest("Kind30166 - event with minimal check result", () => {
     open: undefined,
     read: undefined,
     write: undefined,
-    info: undefined
+    info: undefined,
   });
 
   const generated = event.generateEvent(minimalResult);
@@ -300,7 +328,7 @@ publishTest("Kind30166 - event with minimal check result", () => {
   assertExists(generated, "Should generate event with minimal data");
   assertEquals(generated.content, "{}", "Content should be empty JSON");
 
-  const dTag = generated.tags.find(tag => tag[0] === "d");
+  const dTag = generated.tags.find((tag) => tag[0] === "d");
   assertExists(dTag, "Should still have d-tag");
 });
 
@@ -308,12 +336,12 @@ publishTest("Kind30166 - event with tor network", () => {
   const event = new Kind30166(TEST_PUBKEY);
   const checkResult = createMockRelayCheckResult({
     url: "ws://somerelayabc123xyz.onion",
-    network: "tor"
+    network: "tor",
   });
 
   const generated = event.generateEvent(checkResult);
 
-  const nTag = generated.tags.find(tag => tag[0] === "n");
+  const nTag = generated.tags.find((tag) => tag[0] === "n");
   assertExists(nTag, "Network tag should exist");
   assertEquals(nTag[1], "tor", "Network should be tor");
 });
@@ -324,16 +352,18 @@ publishTest("Kind30166 - event with SSL certificate info", () => {
     protocol: "wss:",
     ssl: {
       data: {
-        valid_from: "2024-01-01T00:00:00Z",
-        valid_to: "2025-12-31T23:59:59Z"
+        valid_from: new Date(Date.now() - 86_400_000).toISOString(),
+        valid_to: new Date(Date.now() + 86_400_000).toISOString(),
       },
-      duration: 50
-    }
+      duration: 50,
+    },
   });
 
   const generated = event.generateEvent(checkResult);
 
-  const sslTag = generated.tags.find(tag => tag[0] === "R" && (tag[1] === "ssl" || tag[1] === "!ssl"));
+  const sslTag = generated.tags.find((tag) =>
+    tag[0] === "R" && (tag[1] === "ssl" || tag[1] === "!ssl")
+  );
   assertExists(sslTag, "SSL R tag should exist");
   // Should be 'ssl' since dates are valid
   assertEquals(sslTag[1], "ssl", "Should indicate valid SSL");
@@ -345,22 +375,30 @@ publishTest("Kind30166 - event with DNS info (IPv4 and IPv6)", () => {
     dns: {
       data: {
         ipv4: ["192.0.2.1", "192.0.2.2"],
-        ipv6: ["2001:db8::1", "2001:db8::2"]
+        ipv6: ["2001:db8::1", "2001:db8::2"],
       },
-      duration: 30
-    }
+      duration: 30,
+    },
   });
 
   const generated = event.generateEvent(checkResult);
 
-  const ipv4LabelTag = generated.tags.find(tag => tag[0] === "L" && tag[1] === "dns.ipv4");
-  const ipv6LabelTag = generated.tags.find(tag => tag[0] === "L" && tag[1] === "dns.ipv6");
+  const ipv4LabelTag = generated.tags.find((tag) =>
+    tag[0] === "L" && tag[1] === "dns.ipv4"
+  );
+  const ipv6LabelTag = generated.tags.find((tag) =>
+    tag[0] === "L" && tag[1] === "dns.ipv6"
+  );
 
   assertExists(ipv4LabelTag, "IPv4 label tag should exist");
   assertExists(ipv6LabelTag, "IPv6 label tag should exist");
 
-  const ipv4Tags = generated.tags.filter(tag => tag[0] === "l" && tag[2] === "dns.ipv4");
-  const ipv6Tags = generated.tags.filter(tag => tag[0] === "l" && tag[2] === "dns.ipv6");
+  const ipv4Tags = generated.tags.filter((tag) =>
+    tag[0] === "l" && tag[2] === "dns.ipv4"
+  );
+  const ipv6Tags = generated.tags.filter((tag) =>
+    tag[0] === "l" && tag[2] === "dns.ipv6"
+  );
 
   assertEquals(ipv4Tags.length, 2, "Should have 2 IPv4 addresses");
   assertEquals(ipv6Tags.length, 2, "Should have 2 IPv6 addresses");
@@ -371,21 +409,25 @@ publishTest("Kind30166 - event with language tags", () => {
   const checkResult = createMockRelayCheckResult({
     info: {
       data: {
-        language_tags: ["en", "es", "ja"]
+        language_tags: ["en", "es", "ja"],
       },
-      duration: 100
-    }
+      duration: 100,
+    },
   });
 
   const generated = event.generateEvent(checkResult);
 
-  const iso6391Label = generated.tags.find(tag => tag[0] === "L" && tag[1] === "ISO-639-1");
+  const iso6391Label = generated.tags.find((tag) =>
+    tag[0] === "L" && tag[1] === "ISO-639-1"
+  );
   assertExists(iso6391Label, "ISO-639-1 label should exist");
 
-  const langTags = generated.tags.filter(tag => tag[0] === "l" && tag[2] === "ISO-639-1");
+  const langTags = generated.tags.filter((tag) =>
+    tag[0] === "l" && tag[2] === "ISO-639-1"
+  );
   assert(langTags.length >= 3, "Should have language tags");
 
-  const langs = langTags.map(tag => tag[1]);
+  const langs = langTags.map((tag) => tag[1]);
   assert(langs.includes("en"), "Should include English");
   assert(langs.includes("es"), "Should include Spanish");
   assert(langs.includes("ja"), "Should include Japanese");
@@ -396,18 +438,18 @@ publishTest("Kind30166 - event with relay tags", () => {
   const checkResult = createMockRelayCheckResult({
     info: {
       data: {
-        tags: ["bitcoin", "lightning", "nsfw"]
+        tags: ["bitcoin", "lightning", "nsfw"],
       },
-      duration: 100
-    }
+      duration: 100,
+    },
   });
 
   const generated = event.generateEvent(checkResult);
 
-  const tTags = generated.tags.filter(tag => tag[0] === "t");
+  const tTags = generated.tags.filter((tag) => tag[0] === "t");
   assert(tTags.length >= 3, "Should have t-tags");
 
-  const tagValues = tTags.map(tag => tag[1]);
+  const tagValues = tTags.map((tag) => tag[1]);
   assert(tagValues.includes("bitcoin"), "Should include bitcoin tag");
   assert(tagValues.includes("lightning"), "Should include lightning tag");
   assert(tagValues.includes("nsfw"), "Should include nsfw tag");
@@ -417,8 +459,12 @@ publishTest("Kind30166 - multiple events have unique IDs", async () => {
   const event1 = new Kind30166(TEST_PUBKEY);
   const event2 = new Kind30166(TEST_PUBKEY);
 
-  const result1 = createMockRelayCheckResult({ url: "wss://relay1.example.com" });
-  const result2 = createMockRelayCheckResult({ url: "wss://relay2.example.com" });
+  const result1 = createMockRelayCheckResult({
+    url: "wss://relay1.example.com",
+  });
+  const result2 = createMockRelayCheckResult({
+    url: "wss://relay2.example.com",
+  });
 
   event1.generateEvent(result1);
   event2.generateEvent(result2);
@@ -426,28 +472,47 @@ publishTest("Kind30166 - multiple events have unique IDs", async () => {
   const signed1 = await event1.signEvent(TEST_PRIVKEY);
   const signed2 = await event2.signEvent(TEST_PRIVKEY);
 
-  assert(signed1.id !== signed2.id, "Different relays should have different event IDs");
+  assert(
+    signed1.id !== signed2.id,
+    "Different relays should have different event IDs",
+  );
 });
 
-publishTest("Kind30166 - event is replaceable (d-tag makes it unique per relay)", () => {
-  const event1 = new Kind30166(TEST_PUBKEY);
-  const event2 = new Kind30166(TEST_PUBKEY);
-  const relayUrl = "wss://relay.example.com";
+publishTest(
+  "Kind30166 - event is replaceable (d-tag makes it unique per relay)",
+  () => {
+    const event1 = new Kind30166(TEST_PUBKEY);
+    const event2 = new Kind30166(TEST_PUBKEY);
+    const relayUrl = "wss://relay.example.com";
 
-  const result1 = createMockRelayCheckResult({ url: relayUrl, checked_at: 1000 });
-  const result2 = createMockRelayCheckResult({ url: relayUrl, checked_at: 2000 });
+    const result1 = createMockRelayCheckResult({
+      url: relayUrl,
+      checked_at: 1000,
+    });
+    const result2 = createMockRelayCheckResult({
+      url: relayUrl,
+      checked_at: 2000,
+    });
 
-  const generated1 = event1.generateEvent(result1);
-  const generated2 = event2.generateEvent(result2);
+    const generated1 = event1.generateEvent(result1);
+    const generated2 = event2.generateEvent(result2);
 
-  // Both should have same d-tag (same relay URL)
-  const dTag1 = generated1.tags.find(tag => tag[0] === "d");
-  const dTag2 = generated2.tags.find(tag => tag[0] === "d");
+    // Both should have same d-tag (same relay URL)
+    const dTag1 = generated1.tags.find((tag) => tag[0] === "d");
+    const dTag2 = generated2.tags.find((tag) => tag[0] === "d");
 
-  assertEquals(dTag1?.[1], dTag2?.[1], "Both events should have same d-tag (same relay)");
-  assertEquals(dTag1?.[1], relayUrl, "d-tag should be relay URL");
+    assertEquals(
+      dTag1?.[1],
+      dTag2?.[1],
+      "Both events should have same d-tag (same relay)",
+    );
+    assertEquals(dTag1?.[1], relayUrl, "d-tag should be relay URL");
 
-  // d-tag makes it a parameterized replaceable event (NIP-33)
-  // Newer events with same d-tag replace older ones
-  assert(dTag1 !== undefined && dTag2 !== undefined, "Both should have d-tags for replaceability");
-});
+    // d-tag makes it a parameterized replaceable event (NIP-33)
+    // Newer events with same d-tag replace older ones
+    assert(
+      dTag1 !== undefined && dTag2 !== undefined,
+      "Both should have d-tags for replaceability",
+    );
+  },
+);

--- a/apps/relaymon/tests/unit/worker-retry.test.ts
+++ b/apps/relaymon/tests/unit/worker-retry.test.ts
@@ -1,4 +1,8 @@
-import { assertEquals, assertExists, assert } from "https://deno.land/std@0.218.2/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.218.2/assert/mod.ts";
 import { Worker } from "../../src/core/worker.ts";
 import { QueueManager } from "../../src/utils/queueManager.ts";
 import type { Config } from "../../src/types/config.ts";
@@ -6,7 +10,7 @@ import type { RelayCheckResult } from "../../src/types/relay.ts";
 import { db, initDB } from "../../src/db/db.ts";
 import { mockConfig } from "../helpers/fixtures.ts";
 import { getPublicKey, nip19 } from "npm:nostr-tools";
-import { hexToBytes } from "npm:@noble/hashes/utils";
+import { hexToBytes } from "@noble/hashes/utils";
 
 /**
  * Test helper to disable resource/ops sanitization
@@ -16,7 +20,7 @@ function retryTest(name: string, fn: () => void | Promise<void>) {
     name,
     sanitizeResources: false,
     sanitizeOps: false,
-    fn
+    fn,
   });
 }
 
@@ -25,8 +29,9 @@ const TEST_DB_PATH = `/tmp/test-worker-retry-${Date.now()}.db`;
 let dbInitialized = false;
 
 // Test constants
-const TEST_PRIVKEY = "0000000000000000000000000000000000000000000000000000000000000001";
-const TEST_PUBKEY = getPublicKey(TEST_PRIVKEY);
+const TEST_PRIVKEY =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+const TEST_PUBKEY = getPublicKey(hexToBytes(TEST_PRIVKEY));
 
 function ensureTestDB() {
   if (!dbInitialized) {
@@ -57,9 +62,9 @@ function createTestConfig(overrides: any = {}): Config {
       ...mockConfig.publisher,
       retry: {
         maxRetries: 3,
-        initialBackoffMs: 1000
-      }
-    }
+        initialBackoffMs: 1000,
+      },
+    },
   };
 
   // Deep merge overrides
@@ -79,7 +84,9 @@ function createTestConfig(overrides: any = {}): Config {
 /**
  * Create a mock relay check result
  */
-function createMockResult(overrides: Partial<RelayCheckResult> = {}): RelayCheckResult {
+function createMockResult(
+  overrides: Partial<RelayCheckResult> = {},
+): RelayCheckResult {
   return {
     url: "wss://relay.example.com",
     hostname: "relay.example.com",
@@ -91,9 +98,9 @@ function createMockResult(overrides: Partial<RelayCheckResult> = {}): RelayCheck
     parent: "",
     open: {
       data: true,
-      duration: 150
+      duration: 150,
     },
-    ...overrides
+    ...overrides,
   } as RelayCheckResult;
 }
 
@@ -106,9 +113,9 @@ retryTest("Worker - constructor accepts retry configuration", () => {
       relays: ["wss://relay.example.com"],
       retry: {
         maxRetries: 5,
-        initialBackoffMs: 2000
-      }
-    }
+        initialBackoffMs: 2000,
+      },
+    },
   });
 
   const worker = createTestWorker(config);
@@ -130,39 +137,46 @@ retryTest("Worker - handleRetryForRelay increments retry count", () => {
   assert(true, "handleRetryForRelay should execute without error");
 });
 
-retryTest("Worker - handleRetryForRelay tracks multiple retries for same relay", () => {
-  ensureTestDB();
+retryTest(
+  "Worker - handleRetryForRelay tracks multiple retries for same relay",
+  () => {
+    ensureTestDB();
 
-  const config = createTestConfig();
-  const worker = createTestWorker(config);
-  const relayUrl = "wss://test-relay.example.com";
+    const config = createTestConfig();
+    const worker = createTestWorker(config);
+    const relayUrl = "wss://test-relay.example.com";
 
-  // Multiple retries
-  worker.handleRetryForRelay(relayUrl);
-  worker.handleRetryForRelay(relayUrl);
-  worker.handleRetryForRelay(relayUrl);
+    // Multiple retries
+    worker.handleRetryForRelay(relayUrl);
+    worker.handleRetryForRelay(relayUrl);
+    worker.handleRetryForRelay(relayUrl);
 
-  assert(true, "Should handle multiple retries for same relay");
-});
+    assert(true, "Should handle multiple retries for same relay");
+  },
+);
 
-retryTest("Worker - handleRetryForRelay tracks retries for different relays independently", () => {
-  ensureTestDB();
+retryTest(
+  "Worker - handleRetryForRelay tracks retries for different relays independently",
+  () => {
+    ensureTestDB();
 
-  const config = createTestConfig();
-  const worker = createTestWorker(config);
+    const config = createTestConfig();
+    const worker = createTestWorker(config);
 
-  worker.handleRetryForRelay("wss://relay1.example.com");
-  worker.handleRetryForRelay("wss://relay2.example.com");
-  worker.handleRetryForRelay("wss://relay1.example.com");
+    worker.handleRetryForRelay("wss://relay1.example.com");
+    worker.handleRetryForRelay("wss://relay2.example.com");
+    worker.handleRetryForRelay("wss://relay1.example.com");
 
-  assert(true, "Should track retries for different relays independently");
-});
+    assert(true, "Should track retries for different relays independently");
+  },
+);
 
 retryTest("Worker - publishResult with retry configuration", async () => {
   ensureTestDB();
 
   // Set up environment for signing
-  const testPrivkey = "0000000000000000000000000000000000000000000000000000000000000001";
+  const testPrivkey =
+    "0000000000000000000000000000000000000000000000000000000000000001";
   const originalEnv = Deno.env.get("RELAYMON_NSEC");
   Deno.env.set("RELAYMON_NSEC", nip19.nsecEncode(hexToBytes(testPrivkey)));
 
@@ -172,9 +186,9 @@ retryTest("Worker - publishResult with retry configuration", async () => {
         relays: ["wss://relay.example.com"],
         retry: {
           maxRetries: 3,
-          initialBackoffMs: 100 // Short backoff for testing
-        }
-      }
+          initialBackoffMs: 100, // Short backoff for testing
+        },
+      },
     });
 
     const worker = createTestWorker(config);
@@ -225,9 +239,9 @@ retryTest("Worker - retry configuration uses custom maxRetries", () => {
       relays: ["wss://relay.example.com"],
       retry: {
         maxRetries: customMaxRetries,
-        initialBackoffMs: 1000
-      }
-    }
+        initialBackoffMs: 1000,
+      },
+    },
   });
 
   const worker = createTestWorker(config);
@@ -243,9 +257,9 @@ retryTest("Worker - retry configuration uses custom initialBackoffMs", () => {
       relays: ["wss://relay.example.com"],
       retry: {
         maxRetries: 3,
-        initialBackoffMs: customBackoff
-      }
-    }
+        initialBackoffMs: customBackoff,
+      },
+    },
   });
 
   const worker = createTestWorker(config);
@@ -257,13 +271,16 @@ retryTest("Worker - default retry configuration when not specified", () => {
 
   const config = createTestConfig({
     publisher: {
-      relays: ["wss://relay.example.com"]
+      relays: ["wss://relay.example.com"],
       // No retry config - should use defaults
-    }
+    },
   });
 
   const worker = createTestWorker(config);
-  assertExists(worker, "Worker should use default retry config when not specified");
+  assertExists(
+    worker,
+    "Worker should use default retry config when not specified",
+  );
 });
 
 retryTest("Worker - formatDuration converts milliseconds correctly", () => {
@@ -308,78 +325,82 @@ retryTest("Worker - relay check retry uses RetryManager", () => {
       networks: ["clearnet"],
       seed: {
         enabled: false,
-        interval: 3600000
+        interval: 3600000,
       },
       checks: {
         enabled: true,
         options: {
           expires: 86400000,
-          interval: 3600000
-        }
+          interval: 3600000,
+        },
       },
       retry: {
         enabled: true,
         expiry: [
           { delay: 60000, retries: 3 },
           { delay: 300000, retries: 5 },
-          { delay: 900000, retries: 10 }
-        ]
+          { delay: 900000, retries: 10 },
+        ],
       },
       deduplication: {
-        enabled: false
+        enabled: false,
       },
       ignorelist: {
         enabled: false,
         interval: "6h",
         deletion_interval: "24h",
         relays: [],
-        pubkeys: []
-      }
-    }
+        pubkeys: [],
+      },
+    },
   });
 
   const worker = createTestWorker(config);
   assertExists(worker, "Worker should initialize with RetryManager config");
 });
 
-retryTest("Worker - multiple publish attempts for different relays", async () => {
-  ensureTestDB();
+retryTest(
+  "Worker - multiple publish attempts for different relays",
+  async () => {
+    ensureTestDB();
 
-  const testPrivkey = "0000000000000000000000000000000000000000000000000000000000000001";
-  const originalEnv = Deno.env.get("RELAYMON_NSEC");
-  Deno.env.set("RELAYMON_NSEC", nip19.nsecEncode(hexToBytes(testPrivkey)));
+    const testPrivkey =
+      "0000000000000000000000000000000000000000000000000000000000000001";
+    const originalEnv = Deno.env.get("RELAYMON_NSEC");
+    Deno.env.set("RELAYMON_NSEC", nip19.nsecEncode(hexToBytes(testPrivkey)));
 
-  try {
-    const config = createTestConfig({
-      publisher: {
-        relays: ["wss://relay.example.com"],
-        retry: {
-          maxRetries: 2,
-          initialBackoffMs: 50
-        }
+    try {
+      const config = createTestConfig({
+        publisher: {
+          relays: ["wss://relay.example.com"],
+          retry: {
+            maxRetries: 2,
+            initialBackoffMs: 50,
+          },
+        },
+      });
+
+      const worker = createTestWorker(config);
+
+      const result1 = createMockResult({ url: "wss://relay1.example.com" });
+      const result2 = createMockResult({ url: "wss://relay2.example.com" });
+      const result3 = createMockResult({ url: "wss://relay3.example.com" });
+
+      // Queue multiple publish jobs
+      await worker.publishResult(result1);
+      await worker.publishResult(result2);
+      await worker.publishResult(result3);
+
+      assert(true, "Should handle multiple publish attempts");
+    } finally {
+      if (originalEnv) {
+        Deno.env.set("RELAYMON_NSEC", originalEnv);
+      } else {
+        Deno.env.delete("RELAYMON_NSEC");
       }
-    });
-
-    const worker = createTestWorker(config);
-
-    const result1 = createMockResult({ url: "wss://relay1.example.com" });
-    const result2 = createMockResult({ url: "wss://relay2.example.com" });
-    const result3 = createMockResult({ url: "wss://relay3.example.com" });
-
-    // Queue multiple publish jobs
-    await worker.publishResult(result1);
-    await worker.publishResult(result2);
-    await worker.publishResult(result3);
-
-    assert(true, "Should handle multiple publish attempts");
-  } finally {
-    if (originalEnv) {
-      Deno.env.set("RELAYMON_NSEC", originalEnv);
-    } else {
-      Deno.env.delete("RELAYMON_NSEC");
     }
-  }
-});
+  },
+);
 
 retryTest("Worker - exponential backoff calculation", () => {
   ensureTestDB();
@@ -389,9 +410,9 @@ retryTest("Worker - exponential backoff calculation", () => {
       relays: ["wss://relay.example.com"],
       retry: {
         maxRetries: 5,
-        initialBackoffMs: 1000
-      }
-    }
+        initialBackoffMs: 1000,
+      },
+    },
   });
 
   const worker = createTestWorker(config);
@@ -404,7 +425,10 @@ retryTest("Worker - exponential backoff calculation", () => {
   // retry 3: 8000ms (4000 * 2)
   // etc.
 
-  assertExists(worker, "Worker should be created with exponential backoff config");
+  assertExists(
+    worker,
+    "Worker should be created with exponential backoff config",
+  );
 });
 
 retryTest("Worker - retry tracking persists across worker instance", () => {


### PR DESCRIPTION
## Summary
- Adds opt-in RelayMon kind 30385 Trusted Relay Assertion publishing based on the trustedrelays draft NIP shape.
- Records per-relay observation history, derives reliability/quality/accessibility/score/confidence tags, and republishes only on material change or refresh interval.
- Adds trustedRelayAssertions config defaults plus relaymon/docker-stack docs and examples.
- Refreshes related validation drift: current nostr-tools key-byte handling, kind1066 O status tags, and a date-stable SSL fixture.

## Validation
- deno task test:kind30385: 9 passed, 0 failed
- deno task test:unit: 359 passed, 0 failed
- deno task test:proxy-connectivity: 3 passed, 0 failed, 5 ignored after one transient remote relay failure in the prior full-suite attempt
- deno task test: 398 passed, 0 failed, 8 ignored
- deno task compile: passed
- docker build -f apps/relaymon/.docker/Dockerfile -t nostrwatch/relaymon:tra-test .: passed; Dockerfile cache step kept its existing nonfatal --no-remote fallback before image export