### PR TITLE
Allow RelayMon TRA publication during warmup

### DIFF
--- a/apps/relaymon/src/core/daemon.ts
+++ b/apps/relaymon/src/core/daemon.ts
@@ -303,12 +303,77 @@ export async function runDaemon(config: Config): Promise<void> {
       logger.info("No seeder found, skipping initial seeding.");
     }
 
+    // Start health reporting before warmup. Warmup can run for a long time, and
+    // external push monitors should still see that RelayMon is alive.
+    let healthServer: HealthServer | null = null;
+    if (config.health?.enabled && config.health.server.enabled) {
+      try {
+        logger.info("Starting health server...");
+
+        // Load auth token if auth is enabled
+        let authToken: string | undefined;
+        if (config.health.server.authEnabled) {
+          authToken = await loadHealthAuthToken();
+          if (!authToken) {
+            logger.warn("Health server auth enabled but no token configured (RELAYMON_HEALTH_AUTH_TOKEN)");
+          }
+        }
+
+        healthServer = await startHealthServer(
+          config.health.server,
+          {
+            queueManager,
+            privkey,
+            heartbeat: heartbeatTracker,
+            errorTracker,
+            authToken,
+            thresholds: config.health.thresholds,
+          },
+        );
+      } catch (error) {
+        logger.error(`Failed to start health server: ${error.message}`);
+        errorTracker.track(`Failed to start health server: ${error.message}`, "daemon");
+      }
+    }
+
+    let kumaPusher: KumaPusher | null = null;
+    if (config.health?.enabled && config.health.kuma.enabled) {
+      try {
+        logger.info("Starting Kuma pusher...");
+
+        // Load Kuma push URL
+        const kumaPushUrl = await loadKumaPushUrl();
+        if (!kumaPushUrl) {
+          logger.error("Kuma pusher enabled but no push URL configured");
+          logger.error("Set RELAYMON_KUMA_PUSH_URL or RELAYMON_KUMA_BASE_URL + RELAYMON_KUMA_TOKEN");
+        } else {
+          logger.info(`Kuma push URL configured: ${redactUrl(kumaPushUrl)}`);
+
+          kumaPusher = await startKumaPusher(
+            config.health.kuma,
+            {
+              queueManager,
+              privkey,
+              heartbeat: heartbeatTracker,
+              errorTracker,
+              thresholds: config.health.thresholds,
+            },
+            kumaPushUrl,
+          );
+        }
+      } catch (error) {
+        logger.error(`Failed to start Kuma pusher: ${error.message}`);
+        errorTracker.track(`Failed to start Kuma pusher: ${error.message}`, "daemon");
+      }
+    }
+
     // Warmup runner - checks all unchecked relays (checked_at = -1) for configured networks
     async function runWarmup(): Promise<void> {
       try {
         // Turn on warmup mode in the worker to suppress publishing and bypass DB-ignore for first checks
         worker.setWarmupMode(true);
         queueManager.setWarmupActive(true);
+        heartbeatTracker.checkLoop = Date.now();
         while (true) {
           // Build network filter from config
           const networks: string[] = Array.isArray(config.relaymon.networks) ? config.relaymon.networks : ["clearnet"];
@@ -323,6 +388,7 @@ export async function runDaemon(config: Config): Promise<void> {
           }
 
           logger.info(`Warmup: processing ${urls.length} unchecked relays`);
+          heartbeatTracker.checkLoop = Date.now();
           // Enqueue all unchecked relays
           for (const url of urls) {
             // Skip any malformed items defensively
@@ -545,70 +611,6 @@ export async function runDaemon(config: Config): Promise<void> {
           logger.error(`Error in runIgnoredRelayReevaluation: ${error.message}`);
           await delay(60000);
         }
-      }
-    }
-
-    // Initialize health server if enabled
-    let healthServer: HealthServer | null = null;
-    if (config.health?.enabled && config.health.server.enabled) {
-      try {
-        logger.info("Starting health server...");
-
-        // Load auth token if auth is enabled
-        let authToken: string | undefined;
-        if (config.health.server.authEnabled) {
-          authToken = await loadHealthAuthToken();
-          if (!authToken) {
-            logger.warn("Health server auth enabled but no token configured (RELAYMON_HEALTH_AUTH_TOKEN)");
-          }
-        }
-
-        healthServer = await startHealthServer(
-          config.health.server,
-          {
-            queueManager,
-            privkey,
-            heartbeat: heartbeatTracker,
-            errorTracker,
-            authToken,
-            thresholds: config.health.thresholds,
-          },
-        );
-      } catch (error) {
-        logger.error(`Failed to start health server: ${error.message}`);
-        errorTracker.track(`Failed to start health server: ${error.message}`, "daemon");
-      }
-    }
-
-    // Initialize Kuma pusher if enabled
-    let kumaPusher: KumaPusher | null = null;
-    if (config.health?.enabled && config.health.kuma.enabled) {
-      try {
-        logger.info("Starting Kuma pusher...");
-
-        // Load Kuma push URL
-        const kumaPushUrl = await loadKumaPushUrl();
-        if (!kumaPushUrl) {
-          logger.error("Kuma pusher enabled but no push URL configured");
-          logger.error("Set RELAYMON_KUMA_PUSH_URL or RELAYMON_KUMA_BASE_URL + RELAYMON_KUMA_TOKEN");
-        } else {
-          logger.info(`Kuma push URL configured: ${redactUrl(kumaPushUrl)}`);
-
-          kumaPusher = await startKumaPusher(
-            config.health.kuma,
-            {
-              queueManager,
-              privkey,
-              heartbeat: heartbeatTracker,
-              errorTracker,
-              thresholds: config.health.thresholds,
-            },
-            kumaPushUrl,
-          );
-        }
-      } catch (error) {
-        logger.error(`Failed to start Kuma pusher: ${error.message}`);
-        errorTracker.track(`Failed to start Kuma pusher: ${error.message}`, "daemon");
       }
     }
 

--- a/apps/relaymon/src/core/worker.ts
+++ b/apps/relaymon/src/core/worker.ts
@@ -766,13 +766,6 @@ export class Worker {
       return;
     }
 
-    if (this.warmupMode) {
-      this.logger.debug(
-        `Warmup mode active; suppressing trusted relay assertion for ${result.url}`,
-      );
-      return;
-    }
-
     if (result.ignore && !traConfig.publish_blocked) {
       this.logger.debug(
         `Skipping trusted relay assertion for ignored relay ${result.url}`,

--- a/apps/relaymon/tests/unit/worker-tra.test.ts
+++ b/apps/relaymon/tests/unit/worker-tra.test.ts
@@ -1,0 +1,155 @@
+import {
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.218.2/assert/mod.ts";
+import { getPublicKey } from "npm:nostr-tools";
+import { hexToBytes } from "@noble/hashes/utils";
+import { Worker } from "../../src/core/worker.ts";
+import { QueueManager } from "../../src/utils/queueManager.ts";
+import { db, initializeDB } from "../../src/db/db.ts";
+import type { Config } from "../../src/types/config.ts";
+import type { RelayCheckResult } from "../../src/types/relay.ts";
+import { mockConfig } from "../helpers/fixtures.ts";
+
+function traWorkerTest(name: string, fn: () => void | Promise<void>) {
+  Deno.test({
+    name,
+    sanitizeResources: false,
+    sanitizeOps: false,
+    fn,
+  });
+}
+
+const TEST_PRIVKEY =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+const TEST_PUBKEY = getPublicKey(hexToBytes(TEST_PRIVKEY));
+const TEST_DB_PATH = `/tmp/test-worker-tra-${Date.now()}.db`;
+let dbInitialized = false;
+
+async function ensureTestDB() {
+  if (!dbInitialized) {
+    await initializeDB(TEST_DB_PATH, false);
+    dbInitialized = true;
+  }
+}
+
+function createTestConfig(): Config {
+  return {
+    ...mockConfig,
+    publisher: {
+      relays: [],
+      retry: {
+        maxRetries: 0,
+        initialBackoffMs: 1,
+      },
+    },
+    relaymon: {
+      ...mockConfig.relaymon,
+      trustedRelayAssertions: {
+        enabled: true,
+        relays: ["wss://relaypag.es", "wss://relay.nostr.watch"],
+        min_observations: 1,
+        material_change_threshold: 3,
+        refresh_interval: 60 * 60 * 1000,
+        history_retention: 30 * 24 * 60 * 60 * 1000,
+        max_observations_per_relay: 1000,
+        publish_unreachable: true,
+        publish_blocked: false,
+        algorithm: {
+          version: "relaymon-local-v2",
+          url:
+            "https://github.com/Letdown2491/trustedrelays/blob/main/ALGORITHM.md",
+        },
+      },
+    },
+    logLevel: "error",
+  } as Config;
+}
+
+function createResult(
+  overrides: Partial<RelayCheckResult> = {},
+): RelayCheckResult {
+  return {
+    url: "wss://relay.example.com",
+    hostname: "relay.example.com",
+    protocol: "wss:",
+    network: "clearnet",
+    checked_at: Math.floor(Date.now() / 1000),
+    online: true,
+    ignore: false,
+    parent: "",
+    open: {
+      data: true,
+      duration: 150,
+    },
+    read: {
+      data: true,
+      duration: 200,
+    },
+    info: {
+      data: {
+        name: "Test Relay",
+        pubkey: TEST_PUBKEY,
+        supported_nips: [1, 11],
+        software: "test-relay",
+        version: "1.0.0",
+      },
+      duration: 100,
+    },
+    ...overrides,
+  } as RelayCheckResult;
+}
+
+traWorkerTest(
+  "Worker TRA publishing is not suppressed during warmup",
+  async () => {
+    await ensureTestDB();
+
+    const originalNsec = Deno.env.get("RELAYMON_NSEC");
+    Deno.env.set("RELAYMON_NSEC", TEST_PRIVKEY);
+
+    try {
+      const config = createTestConfig();
+      const queueManager = new QueueManager(
+        config.queue?.workerConcurrency || 1,
+      );
+      const worker = new Worker(TEST_PUBKEY, queueManager, config);
+      const published: Array<{ kind: number; tags: string[][] }> = [];
+
+      (worker as unknown as {
+        trustedRelayPublisher: {
+          publishEvent: (
+            event: { kind: number; tags: string[][] },
+          ) => Promise<void>;
+        };
+      }).trustedRelayPublisher = {
+        publishEvent: async (event) => {
+          published.push(event);
+        },
+      };
+
+      worker.setWarmupMode(true);
+      await worker.publishTrustedRelayAssertion(createResult());
+      await queueManager.waitEmpty([queueManager.publishQueue]);
+
+      assertEquals(published.length, 1);
+      assertEquals(published[0].kind, 30385);
+      assertExists(published[0].tags.find((tag) => tag[0] === "d"));
+
+      const rows = db.query(
+        "SELECT observations, last_event_id, last_published_at FROM relay_trust_assertion_state WHERE url = ?",
+        ["wss://relay.example.com"],
+      );
+      assertEquals(rows.length, 1);
+      assertEquals(rows[0][0], 1);
+      assertExists(rows[0][1]);
+      assertExists(rows[0][2]);
+    } finally {
+      if (originalNsec) {
+        Deno.env.set("RELAYMON_NSEC", originalNsec);
+      } else {
+        Deno.env.delete("RELAYMON_NSEC");
+      }
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- let enabled RelayMon trusted relay assertions publish during warmup instead of suppressing the entire TRA path
- keep regular NIP-66 check and delta publish suppression during warmup
- start health server and Kuma pusher before warmup so long Fisherman warmups report process liveness
- add a worker regression proving warmup mode publishes kind 30385 and stores TRA publication state

## Root cause
Fisherman is still in RelayMon warmup while draining unchecked relays. `publishTrustedRelayAssertion()` returned immediately when `warmupMode` was active, so warmup checks neither recorded TRA observation history nor enqueued kind 30385 publish jobs. That makes the current absence of 30385 events expected until warmup finishes.

## Verification
- `deno test --no-check --unstable-sloppy-imports --allow-net --allow-env --allow-read --allow-write --allow-run tests/unit/worker-tra.test.ts tests/unit/kind30385.test.ts tests/unit/config-types.test.ts`
- `deno fmt --check tests/unit/worker-tra.test.ts src/core/worker.ts`
- `git diff --check -- apps/relaymon/src/core/daemon.ts apps/relaymon/src/core/worker.ts apps/relaymon/tests/unit/worker-tra.test.ts`

## Not verified
- live Fisherman image rollout
- post-rollout live kind 30385 events on `wss://relaypag.es` or `wss://relay.nostr.watch`
