### PR TITLE
chore(trawler): remove committed merge-conflict markers from CHANGELOG

### DIFF
--- a/apps/trawler/CHANGELOG.md
+++ b/apps/trawler/CHANGELOG.md
@@ -1,7 +1,5 @@
 # @nostrwatch/trawler
 
-<<<<<<< HEAD
-=======
 ## 0.6.1
 
 ### Patch Changes
@@ -20,7 +18,6 @@
   - @nostrwatch/nostrings@0.3.0
   - @nostrwatch/nwcache@0.5.0
 
->>>>>>> next
 ## 0.5.2
 
 ### Patch Changes


### PR DESCRIPTION
`apps/trawler/CHANGELOG.md` on `next` contains committed Git merge-conflict markers (`<<<<<<< HEAD` / `=======` / `>>>>>>> next`) from a prior botched merge — they render as literal garbage in the changelog.

The `HEAD` side was empty and the other side held the `0.6.0` / `0.6.1` entries, so this just drops the three marker lines and keeps the entries. Content-only; no version or release change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)