### PR TITLE
fix(relaymon): publish each relay deletion once, not on every boot

### DIFF
--- a/apps/relaymon/src/db/db.ts
+++ b/apps/relaymon/src/db/db.ts
@@ -1310,13 +1310,62 @@ export function markRelayIgnored(url: string, reason?: string): void {
  */
 export function markRelayUnignored(url: string): void {
   try {
+    // Clear the deletion marker too: if this relay is ignored again later, its
+    // deletion must be re-published once (the prior deletion only covered the
+    // earlier 30166).
     db.query(
-      `UPDATE relay_status SET ignore = 0, ignore_reason = '' WHERE url = ?`,
+      `UPDATE relay_status SET ignore = 0, ignore_reason = '', deletion_published_at = 0 WHERE url = ?`,
       [url],
     );
     logger.info(`Unmarked relay ${url} as ignored`);
   } catch (e) {
     logger.error(`Failed to unignore relay ${url}: ${e}`);
+  }
+}
+
+/**
+ * Whether a NIP-09 deletion has already been published for this relay's current
+ * ignore episode. The marker is cleared whenever the relay becomes unignored
+ * (markRelayUnignored / persistResult), so this only stays true while the relay
+ * remains ignored — letting deletion publishing send each deletion once.
+ */
+export function isDeletionPublished(url: string): boolean {
+  try {
+    const rows = db.query(
+      `SELECT deletion_published_at FROM relay_status WHERE url = ?`,
+      [url],
+    );
+    if (!rows || rows.length === 0) return false;
+    return ((rows[0][0] as number) || 0) > 0;
+  } catch (e) {
+    logger.error(`Failed to read deletion_published_at for ${url}: ${e}`);
+    return false;
+  }
+}
+
+/** Record that a NIP-09 deletion has been published for this relay. */
+export function markDeletionPublished(url: string, at: number = Date.now()): void {
+  try {
+    db.query(
+      `UPDATE relay_status SET deletion_published_at = ? WHERE url = ?`,
+      [at, url],
+    );
+  } catch (e) {
+    logger.error(`Failed to mark deletion published for ${url}: ${e}`);
+  }
+}
+
+/** URLs of ignored relays that have not yet had a deletion published. */
+export function getIgnoredRelaysPendingDeletion(): Array<{ url: string; reason: string }> {
+  try {
+    const rows = db.query(
+      `SELECT url, ignore_reason FROM relay_status
+       WHERE ignore = 1 AND COALESCE(deletion_published_at, 0) = 0`,
+    );
+    return rows.map((r) => ({ url: r[0] as string, reason: (r[1] as string) || "" }));
+  } catch (e) {
+    logger.error(`Failed to query ignored relays pending deletion: ${e}`);
+    return [];
   }
 }
 

--- a/apps/relaymon/src/utils/IgnoreListSync.ts
+++ b/apps/relaymon/src/utils/IgnoreListSync.ts
@@ -3,7 +3,7 @@ import { SimplePool, nip19, getPublicKey } from "npm:nostr-tools";
 import { hexToBytes } from "@noble/hashes/utils";
 import type { Event } from "npm:nostr-tools";
 import { normalizeURL } from "npm:nostr-tools/utils";
-import { db } from "../db/db.ts";
+import { db, getIgnoredRelaysPendingDeletion } from "../db/db.ts";
 import type { Config, IgnoreListConfig } from "../types/config.ts";
 import { getErrorMessage } from "../types/errors.ts";
 
@@ -387,13 +387,20 @@ export class IgnoreListSync {
       return;
     }
 
-    this.logger.info(`Publishing NIP-09 deletions for ${this.localIgnoredRelays.size} ignored relays...`);
+    // Only publish for ignored relays whose deletion has NOT already been sent
+    // (deletion_published_at = 0). This is what prevents re-sending a deletion
+    // for every ignored relay on each boot; deleteRelayCheckEvent marks each on
+    // success and the marker survives restarts.
+    const pending = getIgnoredRelaysPendingDeletion();
+    this.logger.info(
+      `Publishing NIP-09 deletions for ${pending.length} ignored relays pending deletion (of ${this.localIgnoredRelays.size} total)...`,
+    );
 
     // Import deletion utility
     const { deleteRelayCheckEvent } = await import("./deletion.ts");
 
     let deletionCount = 0;
-    for (const [relayUrl, reason] of this.localIgnoredRelays) {
+    for (const { url: relayUrl, reason } of pending) {
       try {
         const ok = await deleteRelayCheckEvent(
           relayUrl,

--- a/apps/relaymon/src/utils/deletion.ts
+++ b/apps/relaymon/src/utils/deletion.ts
@@ -4,7 +4,12 @@ import { getEventHash, getPublicKey } from "npm:nostr-tools";
 import { hexToBytes } from "@noble/hashes/utils";
 import type { Config } from "../config/config.ts";
 import type { QueueManager } from "./queueManager.ts";
-import { clearDeltaState, clearPeriodSnapshots } from "../db/db.ts";
+import {
+  clearDeltaState,
+  clearPeriodSnapshots,
+  isDeletionPublished,
+  markDeletionPublished,
+} from "../db/db.ts";
 import { getPrivateKey } from "../core/daemon.ts";
 
 const logger = getLogger("Deletion");
@@ -60,7 +65,9 @@ export class Kind5Event extends Event {
 }
 
 /**
- * Track deleted relays to prevent publishing duplicate deletion events
+ * In-memory fast path for the current run. The durable guarantee lives in the
+ * relay_status.deletion_published_at column (isDeletionPublished) so the
+ * "publish each deletion once" rule survives reboots.
  */
 const deletedRelays = new Set<string>();
 
@@ -100,8 +107,11 @@ export async function deleteRelayCheckEvent(
       return false;
     }
     
-    // Check if we've already deleted this relay
-    if (deletedRelays.has(relayUrl)) {
+    // Check if we've already deleted this relay — in this run (fast path) or in
+    // a previous one (durable, survives reboot). This is what stops re-sending a
+    // deletion for every ignored relay on every boot.
+    if (deletedRelays.has(relayUrl) || isDeletionPublished(relayUrl)) {
+      deletedRelays.add(relayUrl);
       logger.debug(`Relay ${relayUrl} already has deletion event, skipping.`);
       return false;
     }
@@ -125,8 +135,10 @@ export async function deleteRelayCheckEvent(
           await publisher.publishEvent(signedEvent);
           logger.info(`Queued deletion event for relay ${relayUrl} using a-tag`);
 
-          // Add to the set of deleted relays on successful publish
+          // Record on successful publish (in-memory + durable) so we never
+          // re-send this deletion.
           deletedRelays.add(relayUrl);
+          markDeletionPublished(relayUrl);
 
           // Clear delta state and period snapshots for this relay
           clearDeltaState(relayUrl);
@@ -143,8 +155,9 @@ export async function deleteRelayCheckEvent(
       const publisher = new Publisher(pubkey, config.publisher.relays);
       await publisher.publishEvent(signedEvent);
 
-      // Add to the set of deleted relays
+      // Record on successful publish (in-memory + durable).
       deletedRelays.add(relayUrl);
+      markDeletionPublished(relayUrl);
 
       // Clear delta state and period snapshots for this relay
       clearDeltaState(relayUrl);

--- a/apps/relaymon/src/utils/hostnames.ts
+++ b/apps/relaymon/src/utils/hostnames.ts
@@ -805,8 +805,10 @@ export const reevaluateAllDeduplication = async (
             logger.info(`${relayUrl}: ignore status changed from ${wasIgnored} to ${updatedResult.ignore}`);
 
             db.query(
-              "UPDATE relay_status SET ignore = ?, parent = ? WHERE url = ?",
-              [updatedResult.ignore ? 1 : 0, updatedResult.parent || null, relayUrl]
+              // Clear the deletion marker when unignoring so a later re-ignore
+              // re-publishes its deletion exactly once.
+              "UPDATE relay_status SET ignore = ?, parent = ?, deletion_published_at = CASE WHEN ? = 1 THEN deletion_published_at ELSE 0 END WHERE url = ?",
+              [updatedResult.ignore ? 1 : 0, updatedResult.parent || null, updatedResult.ignore ? 1 : 0, relayUrl]
             );
 
             changedRelays.push({

--- a/apps/relaymon/tests/unit/deletion-publish-once.test.ts
+++ b/apps/relaymon/tests/unit/deletion-publish-once.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Deletions must be published once per ignore episode, not on every boot.
+ *
+ * The durable marker is relay_status.deletion_published_at: ignored relays with
+ * 0 are pending; once a deletion is published the marker is set and survives
+ * restarts; it is cleared when the relay becomes unignored so a later re-ignore
+ * republishes exactly once.
+ */
+
+import { assert, assertEquals } from "https://deno.land/std@0.218.2/assert/mod.ts";
+import {
+  db,
+  getIgnoredRelaysPendingDeletion,
+  initializeDB,
+  isDeletionPublished,
+  markDeletionPublished,
+  markRelayUnignored,
+  persistResult,
+} from "../../src/db/db.ts";
+
+initializeDB(":memory:", false);
+
+function seed(rows: Array<{ url: string; ignore: boolean; published?: number }>) {
+  db.query("DELETE FROM relay_status");
+  for (const r of rows) {
+    db.query(
+      `INSERT OR REPLACE INTO relay_status (url, online, ignore, ignore_reason, parent, checked_at, network, deletion_published_at)
+       VALUES (?, 0, ?, '', '', ?, 'clearnet', ?)`,
+      [r.url, r.ignore ? 1 : 0, Date.now(), r.published ?? 0],
+    );
+  }
+}
+
+function publishedAt(url: string): number {
+  const rows = db.query("SELECT deletion_published_at FROM relay_status WHERE url = ?", [url]);
+  return rows.length ? (rows[0][0] as number) || 0 : -1;
+}
+
+function t(name: string, fn: () => void) {
+  Deno.test({ name, sanitizeResources: false, sanitizeOps: false, fn });
+}
+
+t("pending = ignored relays whose deletion has not been published", () => {
+  seed([
+    { url: "wss://a.example/", ignore: true, published: 0 },
+    { url: "wss://b.example/", ignore: true, published: 0 },
+    { url: "wss://c.example/", ignore: true, published: 1781000000000 }, // already published
+    { url: "wss://d.example/", ignore: false, published: 0 }, // not ignored
+  ]);
+  const pending = getIgnoredRelaysPendingDeletion().map((p) => p.url).sort();
+  assertEquals(pending, ["wss://a.example/", "wss://b.example/"]);
+});
+
+t("markDeletionPublished / isDeletionPublished round-trip and removes from pending", () => {
+  seed([{ url: "wss://a.example/", ignore: true, published: 0 }]);
+  assertEquals(isDeletionPublished("wss://a.example/"), false);
+  markDeletionPublished("wss://a.example/");
+  assertEquals(isDeletionPublished("wss://a.example/"), true);
+  assertEquals(getIgnoredRelaysPendingDeletion().length, 0);
+});
+
+t("boot idempotency: each deletion is pending only once across boots", () => {
+  seed([
+    { url: "wss://a.example/", ignore: true, published: 0 },
+    { url: "wss://b.example/", ignore: true, published: 0 },
+    { url: "wss://c.example/", ignore: true, published: 0 },
+  ]);
+  // First boot: all pending; simulate successful publishes.
+  const firstBoot = getIgnoredRelaysPendingDeletion();
+  assertEquals(firstBoot.length, 3);
+  for (const { url } of firstBoot) markDeletionPublished(url);
+  // Second boot (no state lost): nothing left to publish.
+  assertEquals(getIgnoredRelaysPendingDeletion().length, 0);
+});
+
+t("unignore clears the marker so a later re-ignore republishes once", () => {
+  seed([{ url: "wss://a.example/", ignore: true, published: 0 }]);
+  markDeletionPublished("wss://a.example/");
+  assert(publishedAt("wss://a.example/") > 0);
+  markRelayUnignored("wss://a.example/");
+  assertEquals(publishedAt("wss://a.example/"), 0, "marker cleared on unignore");
+});
+
+t("persistResult clears the marker when not ignored, preserves it when ignored", () => {
+  seed([{ url: "wss://a.example/", ignore: true, published: 0 }]);
+  markDeletionPublished("wss://a.example/");
+  const stamped = publishedAt("wss://a.example/");
+  assert(stamped > 0);
+
+  // Persist as still-ignored: marker preserved.
+  persistResult({
+    url: "wss://a.example/",
+    online: false,
+    ignore: true,
+    ignore_reason: "dup",
+    parent: "wss://a.example/",
+    network: "clearnet",
+  });
+  assertEquals(publishedAt("wss://a.example/"), stamped, "marker preserved while ignored");
+
+  // Persist as recovered (not ignored): marker cleared.
+  persistResult({
+    url: "wss://a.example/",
+    online: true,
+    ignore: false,
+    ignore_reason: "",
+    parent: "",
+    network: "clearnet",
+    open: { data: true, duration: 5 },
+  });
+  assertEquals(publishedAt("wss://a.example/"), 0, "marker cleared when no longer ignored");
+});

--- a/libraries/db/src/index.ts
+++ b/libraries/db/src/index.ts
@@ -38,7 +38,8 @@ export function initDB(dbPath: string = DEFAULT_DB_PATH, enableWAL: boolean = tr
       checked_at INTEGER,
       rtt INTEGER,
       network TEXT,
-      retries INTEGER DEFAULT 0
+      retries INTEGER DEFAULT 0,
+      deletion_published_at INTEGER DEFAULT 0
     )
   `);
 
@@ -69,6 +70,22 @@ export function initDB(dbPath: string = DEFAULT_DB_PATH, enableWAL: boolean = tr
   if (!hasIgnoreReasonColumn) {
     logger.info("Adding ignore_reason column to relay_status table");
     db.query(`ALTER TABLE relay_status ADD COLUMN ignore_reason TEXT DEFAULT ''`);
+  }
+
+  // Timestamp of the last NIP-09 deletion we published for this relay (0 = not
+  // yet published). Lets deletion publishing be idempotent across reboots so an
+  // ignored relay's deletion is sent once rather than on every boot.
+  let hasDeletionPublishedColumn = false;
+  for (const row of tableInfo) {
+    if (row[1] === "deletion_published_at") {
+      hasDeletionPublishedColumn = true;
+      break;
+    }
+  }
+
+  if (!hasDeletionPublishedColumn) {
+    logger.info("Adding deletion_published_at column to relay_status table");
+    db.query(`ALTER TABLE relay_status ADD COLUMN deletion_published_at INTEGER DEFAULT 0`);
   }
 
   // Create timestamp table to track seeder methods' last run times
@@ -201,6 +218,9 @@ export function persistResult(result: any): void {
       checked_at = excluded.checked_at,
       rtt = excluded.rtt,
       network = excluded.network,
+      -- Clear the deletion marker whenever the relay is no longer ignored, so a
+      -- future re-ignore publishes a fresh deletion exactly once.
+      deletion_published_at = CASE WHEN excluded.ignore = 1 THEN deletion_published_at ELSE 0 END,
       ${retryUpdate}
     `,
     [result.url, online, ignore, ignore_reason, parent, checked_at, rtt, network]


### PR DESCRIPTION
## Problem

On every boot relaymon re-publishes a NIP-09 (kind:5) deletion for **every** ignored relay — currently ~17k. The "already deleted" guard (`deletedRelays` Set in `deletion.ts`) is **in-memory only**, so it resets each process and `IgnoreListSync.publishDeletions()` walks the whole ignore list again. A deletion only needs to be sent **once** per ignore episode.

## Fix — persist the guard

- **`relay_status.deletion_published_at`** column (idempotent migration in `libraries/db`): timestamp of the last deletion published for a relay, `0` = none.
- **`deleteRelayCheckEvent`** (the central sender) now skips when the durable marker is set (or the in-memory fast-path is) and **stamps it on successful publish** — so "send once" survives restarts and applies to *all* call sites (boot bulk, per-check, remediation drain).
- **`publishDeletions`** iterates only relays actually **pending** (`ignore = 1 AND deletion_published_at = 0`) instead of the full list — so a steady-state boot sends **0** deletions.
- The marker is **cleared when a relay becomes unignored** (`markRelayUnignored`, `persistResult` on `ignore = 0`, dedup re-evaluation), so a later re-ignore republishes exactly once — a prior deletion only covered the earlier `30166`.

## Behaviour

| | before | after |
|---|---|---|
| boot with 17k ignored, deletions already sent | 17k kind:5 re-sent | **0** |
| relay newly ignored | 1 | 1 |
| ignored → recovered → re-ignored | 1 each boot | 1 per episode |

## Tests

`apps/relaymon/tests/unit/deletion-publish-once.test.ts` — pending selection, mark/round-trip, **cross-boot idempotency**, and unignore/persist marker reset. Full relaymon unit suite: **374 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)