### PR TITLE
Fix deploy workflow pnpm version mismatch

### DIFF
--- a/.github/workflows/daily-seeded-gui-deploy.yml
+++ b/.github/workflows/daily-seeded-gui-deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11
 
       - name: Install
         run: pnpm install --frozen-lockfile
@@ -61,4 +61,3 @@ jobs:
           replication-timeout: "15000"
           request-timeout: "30000"
           retry-limit: "5"
-

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11
 
       - name: Install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -77,10 +77,12 @@ jobs:
           node-version: 20
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @nostrwatch/gui... build
       - run: pnpm --filter @nostrwatch/gui build:seeded
+        env:
+          SEED_ALLOW_EMPTY: "true"
 
       - name: Deploy to nsite
         uses: sandwichfarm/nsite-action@v0.1.3


### PR DESCRIPTION
## Summary
- update root release/deploy workflows from pnpm 9 to pnpm 11 so frozen install matches the regenerated lockfile override metadata
- keep the scheduled seeded deploy strict, but allow empty seed output in the release deploy GUI job so transient relay seed failures do not block code deployment

## Failure addressed
GitHub Actions run https://github.com/sandwichfarm/nostr-watch/actions/runs/29059709180 failed in both `Release` and `Deploy GUI` at `pnpm install --frozen-lockfile` with:

`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH Cannot proceed with the frozen installation. The current "overrides" configuration doesn't match the value found in the lockfile`

The run installed pnpm 9, while the merged dependency-hardening PR had regenerated the lockfile with pnpm 11 workspace overrides.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm -r --filter '!@nostrwatch/gui' build`
- `pnpm --filter @nostrwatch/gui... build`
- `SEED_ALLOW_EMPTY=true pnpm --filter @nostrwatch/gui build:seeded`
- `ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f); puts \"#{f} ok\" }" .github/workflows/publish-package.yml .github/workflows/daily-seeded-gui-deploy.yml .github/workflows/docs-deploy.yml`
- `git diff --check`

## Notes
- `pnpm dlx actionlint ...` could not be used locally because the npm package exposes no binary via pnpm dlx.
- External nsite/Bunny deploy steps were not run locally because they require repository secrets.
