### PR TITLE
Add actionlint workflow validation

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,28 @@
+name: Actionlint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - "scripts/run-actionlint.sh"
+      - "package.json"
+  push:
+    branches: [next]
+    paths:
+      - ".github/workflows/**"
+      - "scripts/run-actionlint.sh"
+      - "package.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check GitHub Actions workflows
+        run: bash scripts/run-actionlint.sh -color

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "nip66:dev": "vitepress dev nip66-docs",
     "nip66:build": "vitepress build nip66-docs",
     "nip66:preview": "vitepress preview nip66-docs",
+    "lint:actions": "bash scripts/run-actionlint.sh",
     "lint:docs": "markdownlint-cli2 'libraries/*/README.md' 'apps/*/README.md' 'internal/*/README.md'",
     "preinstall": "npx only-allow pnpm",
     "changeset": "changeset",

--- a/scripts/run-actionlint.sh
+++ b/scripts/run-actionlint.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTIONLINT_VERSION="${ACTIONLINT_VERSION:-1.7.12}"
+
+if [[ -n "${ACTIONLINT_BIN:-}" ]]; then
+  exec "${ACTIONLINT_BIN}" "$@"
+fi
+
+case "$(uname -s)" in
+  Linux) actionlint_os="linux" ;;
+  Darwin) actionlint_os="darwin" ;;
+  *)
+    echo "Unsupported OS for actionlint bootstrap: $(uname -s)" >&2
+    exit 2
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64 | amd64) actionlint_arch="amd64" ;;
+  arm64 | aarch64) actionlint_arch="arm64" ;;
+  *)
+    echo "Unsupported architecture for actionlint bootstrap: $(uname -m)" >&2
+    exit 2
+    ;;
+esac
+
+cache_root="${XDG_CACHE_HOME:-${HOME:-${PWD}/.cache}}/nostr-watch/actionlint/${ACTIONLINT_VERSION}/${actionlint_os}_${actionlint_arch}"
+actionlint_bin="${cache_root}/actionlint"
+
+verify_checksum() {
+  local checksums_file="$1"
+  local archive="$2"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    grep "  ${archive}\$" "${checksums_file}" | sha256sum -c -
+    return
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    local expected actual
+    expected="$(awk -v archive="${archive}" '$2 == archive { print $1 }' "${checksums_file}")"
+    actual="$(shasum -a 256 "${archive}" | awk '{ print $1 }')"
+    if [[ -z "${expected}" || "${expected}" != "${actual}" ]]; then
+      echo "Checksum verification failed for ${archive}" >&2
+      exit 3
+    fi
+    return
+  fi
+
+  echo "Need sha256sum or shasum to verify actionlint download" >&2
+  exit 3
+}
+
+if [[ ! -x "${actionlint_bin}" ]]; then
+  mkdir -p "${cache_root}"
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "${tmp_dir}"' EXIT
+
+  archive="actionlint_${ACTIONLINT_VERSION}_${actionlint_os}_${actionlint_arch}.tar.gz"
+  checksums="actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+  release_url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
+
+  curl -fsSL "${release_url}/${archive}" -o "${tmp_dir}/${archive}"
+  curl -fsSL "${release_url}/${checksums}" -o "${tmp_dir}/${checksums}"
+
+  (
+    cd "${tmp_dir}"
+    verify_checksum "${checksums}" "${archive}"
+    tar -xzf "${archive}"
+    install -m 0755 actionlint "${actionlint_bin}"
+  )
+fi
+
+exec "${actionlint_bin}" "$@"


### PR DESCRIPTION
## Summary
- add `pnpm lint:actions` as a local repo command for GitHub Actions workflow linting
- add `scripts/run-actionlint.sh`, which downloads pinned upstream `rhysd/actionlint` v1.7.12, verifies the release checksum, caches the binary, and runs it
- add a dedicated `Actionlint` workflow for workflow/script/package changes

## Rationale
`pnpm dlx actionlint` is not usable here because the npm package named `actionlint` exposes no CLI binary. This PR uses the upstream `rhysd/actionlint` release artifact directly, matching the project actionlint documentation's recommended binary usage while keeping the repo command reproducible.

## Verification
- `pnpm lint:actions`
- `bash scripts/run-actionlint.sh -color`
- `bash scripts/run-actionlint.sh -version` -> `1.7.12`
- `bash -n scripts/run-actionlint.sh`
- `ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f); puts \"#{f} ok\" }" .github/workflows/actionlint.yml .github/workflows/daily-seeded-gui-deploy.yml .github/workflows/docker-images.yml .github/workflows/docs-deploy.yml .github/workflows/docs-lint.yml .github/workflows/publish-package.yml`
- `git diff --check`

## Notes
- The new workflow may not run on this PR until GitHub sees the workflow on the base branch; local `pnpm lint:actions` is the current proof.
