### PR TITLE
Fix pnpm 11 workflow Node runtime

### DIFF
--- a/.github/workflows/daily-seeded-gui-deploy.yml
+++ b/.github/workflows/daily-seeded-gui-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.15.0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.15.0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.15.0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.15.0
       - uses: pnpm/action-setup@v4
         with:
           version: 11


### PR DESCRIPTION
## Summary
- run pnpm 11 workflows on Node 22.15.0, matching the repo Volta pin
- update release, GUI seeded deploy, and docs deploy jobs that run pnpm install
- leave Node-only docker image planning workflow unchanged

## Why
The failed Release workflow was installing pnpm 11 under Node 20.20.2. pnpm 11 requires Node >=22.13 and fails before install with missing node:sqlite.

## Verification
- ruby YAML parse for edited workflows
- git diff --check
- pnpm install --frozen-lockfile on Node v22.23.1 with pnpm v11.3.0
- pnpm run lint:actions