### PR TITLE
Fix next workflow follow-up failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ See the [Architecture Overview](docs/architecture.md) for details on the adapter
 | [`@nostrwatch/nip66`](libraries/nip66/) | NIP-66 protocol reference documentation | `docs` | — |
 | ~~[`@nostrwatch/schemata`](libraries/schemata/)~~ | ~~JSON schemas for Nostr protocol~~ — moved to `@nostrability/schemata` | `deprecated` | — |
 | ~~[`@nostrwatch/sanitize`](libraries/sanitize/)~~ | ~~Relay URL sanitization~~ — replaced by [`nostrings`](libraries/nostrings/) | `deprecated` | — |
-| ~~[`@nostrwatch/idb`](libraries/idb/)~~ | ~~IndexedDB wrapper~~ — never implemented | `deprecated` | — |
-| ~~[`@nostrwatch/kit`](libraries/kit/)~~ | ~~Adapter toolkit~~ — never completed | `deprecated` | — |
+| ~~`@nostrwatch/idb`~~ | ~~IndexedDB wrapper~~ — never implemented | `deprecated` | — |
+| ~~`@nostrwatch/kit`~~ | ~~Adapter toolkit~~ — never completed | `deprecated` | — |
 | ~~[`@nostrwatch/transform`](libraries/transform/)~~ | ~~Data transformation library~~ — never implemented | `deprecated` | — |
 
 ### Internal

--- a/apps/docker-stacks/README.md
+++ b/apps/docker-stacks/README.md
@@ -32,11 +32,11 @@ Each stack composes these services (and optional network proxies) into a ready-t
 
 | Stack | Services | Description |
 |-------|----------|-------------|
-| [`relaymon-clearnet/`](relaymon-clearnet/) | RelayMon | Standard clearnet relay monitoring |
-| [`relaymon-vpn/`](relaymon-vpn/) | RelayMon, Gluetun | Relay monitoring routed through a VPN |
-| [`relaymon-multinet/`](relaymon-multinet/) | RelayMon, Tor, I2P | Multi-network monitoring (clearnet + Tor + I2P) |
-| [`trawler-relaymon-clearnet/`](trawler-relaymon-clearnet/) | Trawler, RelayMon | Relay crawler and monitor on clearnet |
-| [`trawler-relaymon-multinet/`](trawler-relaymon-multinet/) | Trawler, RelayMon, Tor, I2P | Relay crawler and monitor with multi-network routing |
+| [`relaymon-clearnet/`](relaymon-clearnet/README.md) | RelayMon | Standard clearnet relay monitoring |
+| [`relaymon-vpn/`](relaymon-vpn/README.md) | RelayMon, Gluetun | Relay monitoring routed through a VPN |
+| [`relaymon-multinet/`](relaymon-multinet/README.md) | RelayMon, Tor, I2P | Multi-network monitoring (clearnet + Tor + I2P) |
+| [`trawler-relaymon-clearnet/`](trawler-relaymon-clearnet/README.md) | Trawler, RelayMon | Relay crawler and monitor on clearnet |
+| [`trawler-relaymon-multinet/`](trawler-relaymon-multinet/README.md) | Trawler, RelayMon, Tor, I2P | Relay crawler and monitor with multi-network routing |
 
 Each stack directory contains its own README with detailed setup instructions.
 

--- a/apps/rstate/Dockerfile
+++ b/apps/rstate/Dockerfile
@@ -1,49 +1,30 @@
-# Multi-stage build for RelayVM
+FROM node:22.15.0-alpine AS builder
 
-# Build stage
-FROM node:20-alpine AS builder
+WORKDIR /repo
 
-WORKDIR /app
+RUN apk add --no-cache python3 make g++
+RUN corepack enable && corepack prepare pnpm@11.11.0 --activate
 
-# Copy package files
-COPY package*.json ./
-COPY tsconfig.json ./
-COPY tsup.config.ts ./
+COPY . .
 
-# Install dependencies
-RUN npm ci
+RUN pnpm install --frozen-lockfile --filter @nostr-watch/rstate...
+RUN pnpm --filter @nostr-watch/rstate... build
+RUN pnpm --filter @nostr-watch/rstate deploy --legacy --prod /prod/rstate
 
-# Copy source
-COPY src ./src
-
-# Build
-RUN npm run build
-
-# Production stage
-FROM node:20-alpine AS production
+FROM node:22.15.0-alpine AS production
 
 WORKDIR /app
 
-# Install production dependencies only
-COPY package*.json ./
-RUN npm ci --omit=dev
+ENV NODE_ENV=production
 
-# Copy built artifacts from builder
-COPY --from=builder /app/dist ./dist
+COPY --from=builder /prod/rstate ./
 
-# Create non-root user
 RUN addgroup -g 1001 -S cvm && \
     adduser -S cvm -u 1001
 
-# Switch to non-root user
 USER cvm
 
-# Expose port (if using HTTP transport, future)
-# EXPOSE 3000
-
-# Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD node -e "console.log('CVM running')" || exit 1
 
-# Run
 CMD ["node", "dist/index.js"]

--- a/apps/rstate/Dockerfile.dockerignore
+++ b/apps/rstate/Dockerfile.dockerignore
@@ -1,0 +1,29 @@
+# Exclude everything by default.
+*
+
+# Include root workspace controls needed by pnpm.
+!package.json
+!pnpm-lock.yaml
+!pnpm-workspace.yaml
+
+# Include rstate and workspace packages it can build against.
+!apps/
+!apps/rstate/
+!apps/rstate/**
+!internal/
+!internal/**
+!libraries/
+!libraries/**
+
+# Re-exclude heavy or local-only content in included directories.
+**/node_modules/
+**/dist/
+**/tests/
+**/test/
+**/.claude/
+**/.hive-mind/
+**/.swarm/
+**/*.db
+**/*.db-*
+**/*.env*
+**/*.log

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -76,8 +76,6 @@ export default defineConfig({
           items: [
             { text: 'auditor', link: '/libraries/auditor/' },
             { text: 'db', link: '/libraries/db/' },
-            { text: 'idb', link: '/libraries/idb/' },
-            { text: 'kit', link: '/libraries/kit/' },
             { text: 'memory-relay', link: '/libraries/memory-relay/' },
             { text: 'negentropy', link: '/libraries/negentropy/' },
             { text: 'nip66', link: '/libraries/nip66/' },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,7 @@ overrides:
   follow-redirects: '>=1.15.12'
   immutable: '>=5.1.5'
   js-yaml: '>=4.1.2'
+  read-yaml-file: 2.1.0
   '@babel/core': '>=7.29.1'
   protocol-buffers-schema: '>=3.6.1'
   yaml: '>=2.8.3'
@@ -10891,10 +10892,6 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
-  pify@4.0.1:
-    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
-    engines: {node: '>=6'}
-
   pino-abstract-transport@2.0.0:
     resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
 
@@ -11357,9 +11354,9 @@ packages:
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
-  read-yaml-file@1.1.0:
-    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
-    engines: {node: '>=6'}
+  read-yaml-file@2.1.0:
+    resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
+    engines: {node: '>=10.13'}
 
   readable-stream@1.0.34:
     resolution: {integrity: sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==}
@@ -12194,10 +12191,6 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
-
-  strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
 
   strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
@@ -16114,7 +16107,7 @@ snapshots:
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
       globby: 11.1.0
-      read-yaml-file: 1.1.0
+      read-yaml-file: 2.1.0
 
   '@mapbox/geojson-rewind@0.5.2':
     dependencies:
@@ -23860,8 +23853,6 @@ snapshots:
 
   pify@2.3.0: {}
 
-  pify@4.0.1: {}
-
   pino-abstract-transport@2.0.0:
     dependencies:
       split2: 4.2.0
@@ -24374,12 +24365,10 @@ snapshots:
     dependencies:
       pify: 2.3.0
 
-  read-yaml-file@1.1.0:
+  read-yaml-file@2.1.0:
     dependencies:
-      graceful-fs: 4.2.11
       js-yaml: 4.3.0
-      pify: 4.0.1
-      strip-bom: 3.0.0
+      strip-bom: 4.0.0
 
   readable-stream@1.0.34:
     dependencies:
@@ -25489,8 +25478,6 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
-
-  strip-bom@3.0.0: {}
 
   strip-bom@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,7 @@ overrides:
   follow-redirects: '>=1.15.12'
   immutable: '>=5.1.5'
   js-yaml: '>=4.1.2'
+  read-yaml-file: 2.1.0
   '@babel/core': '>=7.29.1'
   protocol-buffers-schema: '>=3.6.1'
   yaml: '>=2.8.3'

--- a/scripts/ci/plan-docker-images.mjs
+++ b/scripts/ci/plan-docker-images.mjs
@@ -33,7 +33,7 @@ import { readFileSync, appendFileSync, existsSync } from "node:fs";
 // nocapd is intentionally excluded (deprecated).
 const CATALOG = {
   rstate: {
-    context: "apps/rstate",
+    context: ".",
     dockerfile: "apps/rstate/Dockerfile",
     versionFile: "apps/rstate/package.json",
   },


### PR DESCRIPTION
## Summary
- fix VitePress dead links that caused Docs Deploy to fail
- rebuild the rstate Docker image from the pnpm workspace instead of standalone npm ci
- keep rstate Docker builds on the repo root context with a Dockerfile-specific ignore file
- override read-yaml-file to the js-yaml 4-compatible CJS release so changeset publish works with the security override

## Why
After #942 fixed the Node 20/pnpm 11 runtime mismatch, the next push exposed separate workflow failures:
- Docs Deploy failed on 7 VitePress dead links
- Docker Images failed in rstate because npm ci had no tracked package-lock.json
- Release failed because read-yaml-file@1.1.0 called the removed js-yaml.safeLoad API

## Verification
- pnpm install --frozen-lockfile with pnpm 11.3.0
- pnpm docs:build
- pnpm --filter @nostr-watch/rstate... build
- docker build -t nostrwatch-rstate:workflow-fix -f apps/rstate/Dockerfile .
- pnpm run lint:actions
- GH_EVENT_NAME=push GH_REF_TYPE=branch GH_REF_NAME=next GH_SHA=bf7f6ad node scripts/ci/plan-docker-images.mjs
- pnpm changeset publish completed with no unpublished projects after the read-yaml-file override