### PR TITLE
Keep release GUI deploys from publishing empty seeds

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -81,8 +81,6 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @nostrwatch/gui... build
       - run: pnpm --filter @nostrwatch/gui build:seeded
-        env:
-          SEED_ALLOW_EMPTY: "true"
 
       - name: Deploy to nsite
         uses: sandwichfarm/nsite-action@v0.1.3


### PR DESCRIPTION
## Summary
- Removes the release deploy's SEED_ALLOW_EMPTY fallback from the seeded GUI build.
- Restores the same strict seed-generation behavior used by the daily seeded deploy, so a transient seed fetch failure cannot publish an empty first-run dataset.

## Verification
- git diff --check
- pnpm run lint:actions
- Ruby YAML parse for .github/workflows/*.yml

## Notes
- This intentionally does not change runtime bootstrap code. Working backward from the current regression window, the recent commits did not modify +layout.svelte, data-register.ts, or seed.ts; the deploy fallback was the current change that could turn seed fetch failure into an empty deployed bootstrap artifact.