### PR TITLE
Restore first-run bootstrap content gate

### DIFF
--- a/apps/gui/src/lib/utils/bootstrap-render-state.test.ts
+++ b/apps/gui/src/lib/utils/bootstrap-render-state.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBootstrapRenderState } from './bootstrap-render-state';
+
+describe('getBootstrapRenderState', () => {
+	it('keeps first-run users in the bootstrap UI when seed finishes without data', () => {
+		const state = getBootstrapRenderState({
+			isReady: true,
+			hasActualData: false,
+			isBootstrapped: false,
+			isSeeded: false,
+			seedBootStatus: 'complete',
+			tabState: 'leader'
+		});
+
+		expect(state.needsSeedBootstrap).toBe(false);
+		expect(state.loadedEnough).toBe(false);
+		expect(state.showContent).toBe(false);
+		expect(state.showBootstrapLoading).toBe(true);
+		expect(state.navDisabled).toBe(true);
+	});
+
+	it('shows content after first-run bootstrap has actual relay-check data', () => {
+		const state = getBootstrapRenderState({
+			isReady: true,
+			hasActualData: true,
+			isBootstrapped: false,
+			isSeeded: false,
+			seedBootStatus: 'complete',
+			tabState: 'leader'
+		});
+
+		expect(state.loadedEnough).toBe(true);
+		expect(state.showBootstrapLoading).toBe(false);
+		expect(state.showContent).toBe(true);
+		expect(state.navDisabled).toBe(false);
+	});
+
+	it('does not show content before the app boot function is ready', () => {
+		const state = getBootstrapRenderState({
+			isReady: false,
+			hasActualData: true,
+			isBootstrapped: true,
+			isSeeded: true,
+			seedBootStatus: 'complete',
+			tabState: 'leader'
+		});
+
+		expect(state.loadedEnough).toBe(true);
+		expect(state.showContent).toBe(false);
+		expect(state.showBootstrapLoading).toBe(true);
+	});
+
+	it('keeps follower tabs on the follower wait screen while seed import is active', () => {
+		const state = getBootstrapRenderState({
+			isReady: true,
+			hasActualData: false,
+			isBootstrapped: false,
+			isSeeded: false,
+			seedBootStatus: 'in_progress',
+			tabState: 'follower'
+		});
+
+		expect(state.showContent).toBe(false);
+		expect(state.showFollowerWaiting).toBe(true);
+		expect(state.showBootstrapLoading).toBe(false);
+	});
+});

--- a/apps/gui/src/lib/utils/bootstrap-render-state.ts
+++ b/apps/gui/src/lib/utils/bootstrap-render-state.ts
@@ -1,0 +1,45 @@
+import type { TabStateType } from '$lib/stores/app';
+import type { SeedBootStatus } from '$lib/stores/boot-state';
+
+export interface BootstrapRenderStateInput {
+	isReady: boolean;
+	hasActualData: boolean;
+	isBootstrapped: boolean;
+	isSeeded: boolean;
+	seedBootStatus: SeedBootStatus;
+	tabState: TabStateType;
+}
+
+export interface BootstrapRenderState {
+	seedInProgress: boolean;
+	seedReady: boolean;
+	isFreshState: boolean;
+	loadedEnough: boolean;
+	needsSeedBootstrap: boolean;
+	showBootstrapLoading: boolean;
+	showFollowerWaiting: boolean;
+	showContent: boolean;
+	navDisabled: boolean;
+}
+
+export function getBootstrapRenderState(input: BootstrapRenderStateInput): BootstrapRenderState {
+	const seedInProgress = input.seedBootStatus === 'in_progress';
+	const seedReady = input.isSeeded || input.seedBootStatus === 'complete';
+	const isFreshState = !input.isBootstrapped && !input.isSeeded;
+	const loadedEnough = input.hasActualData && (!isFreshState || seedReady);
+	const needsSeedBootstrap = isFreshState && !seedReady;
+	const showContent = input.isReady && loadedEnough && !seedInProgress;
+	const showFollowerWaiting = !showContent && input.tabState === 'follower' && seedInProgress;
+
+	return {
+		seedInProgress,
+		seedReady,
+		isFreshState,
+		loadedEnough,
+		needsSeedBootstrap,
+		showBootstrapLoading: !showContent && !showFollowerWaiting,
+		showFollowerWaiting,
+		showContent,
+		navDisabled: !loadedEnough || needsSeedBootstrap || seedInProgress
+	};
+}

--- a/apps/gui/src/routes/+layout.svelte
+++ b/apps/gui/src/routes/+layout.svelte
@@ -20,6 +20,7 @@
 	    appState,
 	    tabState,
 	    hasBeenBootstrapped,
+	    isBootstrapped,
 	    isSeeded,
 	    opfsStatus,
 	  } from '$lib/stores/app';
@@ -33,6 +34,7 @@
 	    resetBootActivities,
 	  } from '$lib/stores/boot-activity';
 	  import { seedBootStatus } from '$lib/stores/boot-state';
+	  import { getBootstrapRenderState } from '$lib/utils/bootstrap-render-state';
 
 
   let modules: Record<ModuleKey, any> | null = null;
@@ -258,25 +260,17 @@
   });
 
   // --------------------------------------------------------------------------------
-	  // Render gating
-	  // --------------------------------------------------------------------------------
-	  $: hasActualData = $relayCheckAggregates?.length > 0;
-	  $: seedInProgress = $seedBootStatus === 'in_progress';
-	  // "bootloaded" === seed import completed (or no seed payload available).
-	  $: seedReady = $isSeeded || $seedBootStatus === 'complete';
-
-	  // Fresh state: no prior bootstrap markers AND no seed marker.
-	  // This supports old installs (bootstrapped pre-seed) without forcing seed boot UI.
-	  $: isFreshState = !hasBeenBootstrapped() && !$isSeeded;
-
-	  // Bootloader = build-seed import (first run / after reset).
-	  $: needsSeedBootstrap = isFreshState && !seedReady;
-
-	  // Only show full-screen boot UI when a seed import is required.
-	  // After seed is loaded, show the app immediately; network sync continues in background.
-	  $: showBootstrapLoading = needsSeedBootstrap && ($tabState === 'leader' || !seedInProgress);
-	  $: showFollowerWaiting = needsSeedBootstrap && seedInProgress && $tabState === 'follower';
-	  $: showContent = !needsSeedBootstrap;
+  // Render gating
+  // --------------------------------------------------------------------------------
+  $: hasActualData = $relayCheckAggregates?.length > 0;
+  $: bootstrapRenderState = getBootstrapRenderState({
+    isReady,
+    hasActualData,
+    isBootstrapped: $isBootstrapped,
+    isSeeded: $isSeeded,
+    seedBootStatus: $seedBootStatus,
+    tabState: $tabState,
+  });
 </script>
 
 {#if $unsupported}
@@ -285,17 +279,17 @@
   <div class="text-xs opacity-30">This version of nostr.watch does not support mobile devices.</div>
 </div>
 {:else}
-	  <HeaderComponent navDisabled={!hasActualData || needsSeedBootstrap || seedInProgress} />
-	  {#if showBootstrapLoading}
-	    <BootstrapLoading {isReady} />
-	  {:else if showFollowerWaiting}
-	    <FollowerLoading />
-	  {:else if showContent}
-	    <MonitorsBanner />
-	    <div id="content-wrapper" class="block flow-root">
-	      <slot />
-	    </div>
-	  {/if}
+  <HeaderComponent navDisabled={bootstrapRenderState.navDisabled} />
+  {#if bootstrapRenderState.showBootstrapLoading}
+    <BootstrapLoading {isReady} />
+  {:else if bootstrapRenderState.showFollowerWaiting}
+    <FollowerLoading />
+  {:else if bootstrapRenderState.showContent}
+    <MonitorsBanner />
+    <div id="content-wrapper" class="block flow-root">
+      <slot />
+    </div>
+  {/if}
 {/if}
 
 {#if $showDebugButton}


### PR DESCRIPTION
## Summary

Restores the controlled first-visit bootstrap gate so seed completion is not treated as enough to render the app shell.

Clean/reset users now stay on the bootstrap surface until the GUI is ready, seed import is not active, and actual relay-check aggregates exist. This fixes the regression where an empty/missing seed could mark boot as complete and land first-time users on an empty relays table.

## Changes

- Adds a small `getBootstrapRenderState` helper for the layout boot/content decision.
- Wires `+layout.svelte` to require actual relay-check aggregate data before showing content.
- Uses the reactive `isBootstrapped` store for render state while preserving `hasBeenBootstrapped()` for selecting the sync composite.
- Adds regression tests for the empty-seed first-run case, app readiness, successful data readiness, and follower seed-import waiting.

## Verification

- [x] `pnpm --filter @nostrwatch/gui exec vitest run src/lib/utils/bootstrap-render-state.test.ts`
- [x] `pnpm --filter @nostrwatch/gui test`
- [x] `pnpm --filter @nostrwatch/gui build`
- [x] `pnpm -r build`
- [x] `pnpm --filter @nostrwatch/gui exec prettier --check src/lib/utils/bootstrap-render-state.ts src/lib/utils/bootstrap-render-state.test.ts`

## Known Existing Issue

`pnpm --filter @nostrwatch/gui check` still fails with 72 unrelated baseline deltas after the layout import issue from this branch was fixed. The remaining diagnostics are in existing files such as `src/routes/+page.svelte`, route66 adapter typings, `nostr-tools/nip19` type names, and existing Svelte/a11y warnings; no `+layout.svelte` diagnostic remains from this patch.
