### PR TITLE
Fix monitors hydration control flow

### DIFF
--- a/apps/gui/src/lib/components/partials/MonitorActions.svelte
+++ b/apps/gui/src/lib/components/partials/MonitorActions.svelte
@@ -3,7 +3,7 @@
     import { Checkbox } from "$lib/components/ui/checkbox/index.js";
     import * as Table from '$lib/components/ui/table/index.js'
 
-    import { monitorsMap } from "$lib/stores/monitors.js";
+    import { monitorSelectionLocked, monitorsMap } from "$lib/stores/monitors.js";
     import type { IEvent, Monitor } from '@nostrwatch/route66/models';
     import { events, eventsArray } from '$lib/stores/events.js';
 
@@ -12,7 +12,7 @@
 	import { onMount } from 'svelte';
 	import { eventKey } from '$lib/utils/event-keys';
 	import { activeMonitorChecksCount } from '$lib/stores';
-    import { pauseLiveSync } from '$lib/utils/live-sync';
+    import { pauseLiveSync, type LiveSyncResumer } from '$lib/utils/live-sync';
 	import { delay } from '@nostrwatch/utils';
 	import type { Nip05 } from 'nostr-tools/nip05';
 	import { nip05Service } from '$stores/nip05s';
@@ -75,61 +75,69 @@
 
     onMount(() => {
         toggleEnableMonitor = async () => {
+            if($monitorSelectionLocked) return;
             if(busy) return;
             busy = true;
             disabled.set(true);
-            const { publishEventsToMemoryRelay } = await import('$lib/stores/events-helpers.js');
-            const resumer = await pauseLiveSync();
-            // console.log('monitors: toggleEnableMonitor', $monitor.enabled)
-            if(!$monitor) return console.warn('Monitor not found');
-            if($monitor?.enabled) {
-                // console.log('monitors:  disabling monitor')
-                $monitor.disable();
-                events.update($events => {
-                    $events.entries().forEach( ([key, event]) => {
-                        if(event.pubkey === $monitor.pubkey){
-                            $events.delete(key);
-                        }
-                    })
-                    return $events;
-                })
-                await updateState($monitor, false);
-                await resumer();
-                disabled.set(false);
-            } 
-            else {
-                // console.log('monitors: enabling monitor')
-                $monitor?.enable()
-                const options = {
-                    filters: [ $monitor.checkFilter ],
-                    options: {
-                        stream: true,
-                        returnResults: true,
-                        cache: true,
-                        sync: true,
-                        batch: 25
-                    },
-                    relays: [ ...($route66?.services?.monitors?.nip66Relays || []), ...$monitor.relays ],
-                    priority: 20
+            let resumer: LiveSyncResumer | undefined;
+            try {
+                const { publishEventsToMemoryRelay } = await import('$lib/stores/events-helpers.js');
+                resumer = await pauseLiveSync();
+                // console.log('monitors: toggleEnableMonitor', $monitor.enabled)
+                const currentMonitor = $monitor;
+                if(!currentMonitor) {
+                    console.warn('Monitor not found');
+                    return;
                 }
-                const onevents = publishEventsToMemoryRelay
-                await $route66?.services?.monitors?.subscribe(options, { onevents })
-                await updateState($monitor, true);
-                await resumer();
+                if(currentMonitor.enabled) {
+                    // console.log('monitors:  disabling monitor')
+                    currentMonitor.disable();
+                    events.update($events => {
+                        $events.entries().forEach( ([key, event]) => {
+                            if(event.pubkey === currentMonitor.pubkey){
+                                $events.delete(key);
+                            }
+                        })
+                        return $events;
+                    })
+                    await updateState(currentMonitor, false);
+                }
+                else {
+                    // console.log('monitors: enabling monitor')
+                    currentMonitor.enable()
+                    const options = {
+                        filters: [ currentMonitor.checkFilter ],
+                        options: {
+                            stream: true,
+                            returnResults: true,
+                            cache: true,
+                            keepAlive: false,
+                            sync: true,
+                            batch: 25
+                        },
+                        relays: [ ...($route66?.services?.monitors?.nip66Relays || []), ...currentMonitor.relays ],
+                        priority: 20
+                    }
+                    const onevents = publishEventsToMemoryRelay
+                    await ($route66?.services?.monitors as any)?.subscribe(options, { onevents })
+                    await updateState(currentMonitor, true);
+                }
+            } finally {
+                await resumer?.();
                 disabled.set(false);
-
+                busy = false;
             }
-            busy = false;
         }
     })
 
     $: checked = $monitor?.enabled
+    $: selectionDisabled = $disabled || $monitorSelectionLocked;
 </script>
 
 {#if view === 'cell'}
     <Table.Cell>
         {#if $monitor?.pubkey}
-        <Checkbox disabled={$disabled} id="toggle-${$monitor.pubkey.slice(0,21)}" bind:checked aria-labelledby="terms-label" onCheckedChange={toggleEnableMonitor} />
+        <Checkbox disabled={selectionDisabled} id="toggle-${$monitor.pubkey.slice(0,21)}" bind:checked aria-labelledby="terms-label" onCheckedChange={toggleEnableMonitor} />
         {/if}
     </Table.Cell>
 {:else}

--- a/apps/gui/src/lib/fetchers/seed.ts
+++ b/apps/gui/src/lib/fetchers/seed.ts
@@ -32,6 +32,7 @@ type SeedManifestV1 = {
 
 const SEED_MANIFEST_URL = '/seed/manifest.json';
 const STATE_KEY_GENERATED_AT = 'seed:build:generatedAt';
+const DEFAULT_SEEDED_ENABLED_MONITORS = 3;
 
 function resolveSeedAssetUrl(pathOrUrl: string): string {
   if (/^[a-z]+:\/\//i.test(pathOrUrl)) return pathOrUrl;
@@ -140,6 +141,10 @@ async function yieldToBrowser(): Promise<void> {
 function formatProgress(loaded: number, total?: number): string {
   if (typeof total === 'number' && Number.isFinite(total) && total > 0) return `${loaded}/${total}`;
   return `${loaded}`;
+}
+
+function registrationCheckCount(event?: IEvent): number {
+  return event?.tags?.filter((tag: string[]) => tag[0] === 'c')?.length ?? 0;
 }
 
 function withSeedVersion(url: string, seedKey: string): string {
@@ -327,21 +332,18 @@ export const seedBuildData = async (): Promise<void> => {
       const sortedMonitorEntries = Array.from(monitorEventsByPubkey.entries())
         .filter(([_, data]) => data.registration)
         .sort((a, b) => {
-          const aChecks = (a[1].registration as any)?.tags?.filter((t: any) => t[0] === 'c')?.length ?? 0;
-          const bChecks = (b[1].registration as any)?.tags?.filter((t: any) => t[0] === 'c')?.length ?? 0;
+          const aChecks = registrationCheckCount(a[1].registration);
+          const bChecks = registrationCheckCount(b[1].registration);
           return bChecks - aChecks; // Descending by check count
         });
 
-      // Don't pre-enable monitors in seed — seed data lacks check events to
-      // determine real activity.  Let bootstrap's maybeEnableMonitors() handle
-      // enabling after ensureMonitorsActive() sets real lastActive values.
-      const monitorsCache = sortedMonitorEntries.map(([pubkey, data]) => ({
+      const monitorsCache = sortedMonitorEntries.map(([pubkey, data], index) => ({
         pubkey,
         registration: data.registration,
         profile: data.profile,
         relays: data.relays,
-        priority: 0,
-        enabled: false,
+        priority: index,
+        enabled: index < DEFAULT_SEEDED_ENABLED_MONITORS,
         lastActive: -1,
       }));
 

--- a/apps/gui/src/lib/stores/monitors.ts
+++ b/apps/gui/src/lib/stores/monitors.ts
@@ -183,7 +183,7 @@ export const monitorNip05s = derived(
   monitors,
   monitors => 
     monitors
-      .filter( m => m?.profile?.nip05 )
+      .filter((m): m is Monitor & { profile: NonNullable<Monitor["profile"]> & { nip05: string } } => Boolean(m?.profile?.nip05))
       .map( m => ({ pubkey: m.pubkey, nip05: m.profile.nip05 }) )
 )
 
@@ -471,6 +471,7 @@ if (typeof window !== "undefined") {
 }
 
 export const monitorsChecked: Writable<boolean> = writable(false);
+export const monitorSelectionLocked: Writable<boolean> = writable(true);
 
 export const monitorRows = derived(
   [monitors, monitorRelayLivenessCounts, nip05s, statsAsOf, livenessReady, monitorFreshness, monitorsLivenessLeniency],

--- a/apps/gui/src/routes/monitors/+page.svelte
+++ b/apps/gui/src/routes/monitors/+page.svelte
@@ -1,20 +1,17 @@
 <script lang="ts">
     import { onMount, onDestroy } from 'svelte';
-    import Stats from '$lib/components/layout/Stats.svelte';
-    import DataTable from '$lib/components/lists/table/DataTable.svelte';
     import MonitorsActions from '$lib/components/partials/MonitorActions.svelte';
     import * as Alert from "$lib/components/ui/alert/index.js";
     
-    import { monitorRows, monitors } from '$lib/stores/monitors.js';
+    import { livenessReady, monitorRows, monitorSelectionLocked, monitors } from '$lib/stores/monitors.js';
 
     import { StateManager } from '@nostrwatch/route66';
     import { doBootstrap } from '$lib/stores/routines';
     import { doAggregateCache, tabState } from '$lib/stores/app';
     import { get, writable, type Writable } from 'svelte/store';
 	import type { DataViewViews } from '$lib/components/data-view/DataTableTypes';
-	import { type DataTableConfig, defaultDataTableConfig } from '$lib/components/lists/table/DataTableTypes';
+	import { type DataTableConfig, defaultDataTableConfig } from '$lib/components/data-view/DataTableTypes';
     import builtInTableConfig from '$lib/config/dataTable/monitors.js'
-	import { bootstrapMonitorData } from '$utils/lifecycle';
 	import { dataRegister } from '$stores/data-register';
 	import DataViewRoot from '$lib/components/data-view/DataViewRoot.svelte';
 	import { HeaderConfigStore } from '$stores/header-config';
@@ -22,6 +19,8 @@
     const dataKey: string = 'monitors'
     const config: Writable<DataTableConfig | null> = writable(null);
     const ready: Writable<boolean> = writable(false);
+    const pageDataReady: Writable<boolean> = writable(false);
+    const pageDataError: Writable<Error | null> = writable(null);
 
 	const enabledViews: DataViewViews[] = ['table'];
 	const activeView: Writable<DataViewViews> = writable(enabledViews.length === 1 ? enabledViews[0] : 'table');
@@ -71,6 +70,9 @@
 
     onMount(() => {
         if (typeof window === 'undefined' || typeof navigator === 'undefined') return;
+        pageDataReady.set(false);
+        pageDataError.set(null);
+        monitorSelectionLocked.set(true);
 		setHeaderSelectors();
         doBootstrap.set(true)
         doAggregateCache.set(true)
@@ -81,11 +83,16 @@
         }
         void $dataRegister
             .require(keys)
-            .catch((err) => console.error('[DataRegister] require failed', err));
+            .then(() => pageDataReady.set(true))
+            .catch((err) => {
+                pageDataError.set(err instanceof Error ? err : new Error(String(err)));
+                console.error('[DataRegister] require failed', err);
+            });
     });
 
 	onDestroy(() => {
 		clearHeaderSelectors();
+        monitorSelectionLocked.set(true);
 	});
 
     $: countInactiveMonitorsEnabled = $monitorRows.filter((monitor: any) => { return !monitor.active && monitor.enabled }).length;
@@ -94,19 +101,31 @@
     $: criticalInactiveMonitorsEnabled = countInactiveMonitorsEnabled > 0;
     $: warnHasLessThanRecommendedMonitors = countEnabledMonitors < 3;
     $: warnHasMoreThanRecommendedMonitors = countEnabledMonitors > 8;
+    $: hasRealLivenessData = $monitorRows.some((monitor: any) =>
+        [monitor.reportingOnline, monitor.reportingOffline, monitor.likelyDead].some((value) => typeof value === 'number' && value > 0)
+    );
+    $: monitorPageHydrated =
+        $ready &&
+        $pageDataReady &&
+        !$pageDataError &&
+        $livenessReady &&
+        $monitorRows.length > 0 &&
+        hasRealLivenessData;
+    $: monitorSelectionLocked.set(!monitorPageHydrated);
+    $: showMonitorWarnings = monitorPageHydrated;
 </script>
 <main class="mt-10">
 {#if $ready}
     {#if $monitorRows.length}
         <div class="px-10">
-            {#if criticalHasNoMonitorsEnabled}
+            {#if showMonitorWarnings && criticalHasNoMonitorsEnabled}
                 <Alert.Root class="mb-2">
                     <Alert.Title class="text-red-500 font-bold">Critical</Alert.Title>
                     <Alert.Description class="opacity-80">
                         You have no monitors enabled, which will prevent the application from functioning correctly.
                     </Alert.Description>
                 </Alert.Root>
-            {:else if warnHasLessThanRecommendedMonitors}
+            {:else if showMonitorWarnings && warnHasLessThanRecommendedMonitors}
                 <Alert.Root class="mb-2">
                     <Alert.Title class="text-orange-500 font-bold">Warning</Alert.Title>
                     <Alert.Description class="opacity-80">
@@ -144,7 +163,7 @@
 			showViewSelector={false}
             actionsComponent={MonitorsActions}
         />
-    {:else if !$monitors.length}
+    {:else if $pageDataReady && $livenessReady && !$monitors.length}
         <div class="px-10 mt-20 text-center">
             <p class="text-gray-500 text-lg">No monitors found</p>
         </div>


### PR DESCRIPTION
## Summary
- lock `/monitors` selection controls until the page has completed its own monitor data request and has real liveness aggregate data
- suppress false monitor warnings until the page-local hydration gate is satisfied
- seed the top 3 monitors by registration check count so seeded first-runs do not show relay checks with zero enabled monitors
- harden monitor toggle cleanup so busy/disabled state always releases after toggle attempts

## Verification
- `git diff --check`
- `pnpm --filter @nostrwatch/gui exec vitest run src/lib/stores/monitors.test.ts src/lib/utils/bootstrap-render-state.test.ts`
- `pnpm --filter @nostrwatch/gui build`
- `pnpm --filter @nostrwatch/gui exec svelte-check --tsconfig ./tsconfig.json --output machine` still exits 1 from existing baseline diagnostics, but the filtered touched-file output is clean for `MonitorActions`, `routes/monitors/+page`, `fetchers/seed`, and `stores/monitors`.

## Browser Proof
Dev server from this worktree: `http://127.0.0.1:5180/`.

Empty-origin Playwright run explicitly cleared all origin storage before loading `/monitors`.

Result:
- `ok: true`
- seed manifest was absent locally (`seed404: true`), so this exercised no-seed fallback
- websocket errors were observed and ignored as expected Nostr network noise (`websocketErrors: 2`)
- during boot: `hasHeader: false`, `hasCritical: false`, `controlEnabled: 0`
- final `/monitors` state: `rows: 24`, `controlCount: 24`, `controlChecked: 3`, `controlDisabled: 0`, `monitorCacheCount: 24`, `monitorCacheEnabled: 3`, `livenessCacheCount: 24`, `livenessNonZeroCount: 1`

Screenshots written locally during proof:
- `/tmp/nostrwatch-monitors-final-empty-origin-initial.png`
- `/tmp/nostrwatch-monitors-final-empty-origin-hydrating.png`
- `/tmp/nostrwatch-monitors-final-empty-origin-hydrated.png`
