### PR TITLE
Harden client-side NIP-11 fetch redirects

### DIFF
--- a/apps/gui/playwright.config.ts
+++ b/apps/gui/playwright.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   },
   projects: [
     { name: 'chromium', use: { browserName: 'chromium' } },
+    { name: 'firefox', use: { browserName: 'firefox' } },
   ],
   webServer: {
     command: 'pnpm dev',

--- a/apps/gui/src/lib/services/Nip11Service/fetch-relay-information.test.ts
+++ b/apps/gui/src/lib/services/Nip11Service/fetch-relay-information.test.ts
@@ -1,0 +1,210 @@
+import http from 'node:http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	createNip11FetchInit,
+	fetchRelayInformation,
+	relayUrlToNip11HttpUrl
+} from './fetch-relay-information';
+
+type TestServer = {
+	url: string;
+	close: () => Promise<void>;
+	getHits: () => Record<string, number>;
+};
+
+const listen = async (handler: http.RequestListener): Promise<TestServer> => {
+	const hits: Record<string, number> = {};
+	const server = http.createServer((req, res) => {
+		const path = req.url ?? '/';
+		hits[path] = (hits[path] ?? 0) + 1;
+		handler(req, res);
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+	const address = server.address();
+	if (!address || typeof address === 'string') throw new Error('Failed to bind test server.');
+
+	return {
+		url: `http://127.0.0.1:${address.port}`,
+		close: () =>
+			new Promise<void>((resolve, reject) =>
+				server.close((error) => (error ? reject(error) : resolve()))
+			),
+		getHits: () => ({ ...hits })
+	};
+};
+
+const relayFor = (serverUrl: string, path = ''): string =>
+	serverUrl.replace('http://', 'ws://') + path;
+
+const responseWithoutContentType = (body: string): Response => {
+	const response = new Response(body);
+	response.headers.delete('content-type');
+	return response;
+};
+
+describe('hardened NIP-11 fetch', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('converts only ws and wss relay URLs to HTTP NIP-11 URLs', () => {
+		expect(relayUrlToNip11HttpUrl('ws://relay.example/path?x=1#ignored')).toBe(
+			'http://relay.example/path?x=1'
+		);
+		expect(relayUrlToNip11HttpUrl('wss://relay.example/')).toBe('https://relay.example/');
+		expect(() => relayUrlToNip11HttpUrl('https://relay.example/')).toThrow(/ws: or wss:/);
+		expect(() => relayUrlToNip11HttpUrl('wss://user:pass@relay.example/')).toThrow(/credentials/);
+	});
+
+	it('sets defensive fetch options for every NIP-11 request', async () => {
+		const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+			new Response(JSON.stringify({ name: 'valid relay' }), {
+				headers: { 'content-type': 'application/nostr+json' }
+			})
+		);
+
+		await expect(fetchRelayInformation('wss://relay.example/', { fetchImpl })).resolves.toEqual({
+			name: 'valid relay'
+		});
+
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchImpl.mock.calls[0]!;
+		expect(url).toBe('https://relay.example/');
+		expect(init).toMatchObject({
+			redirect: 'error',
+			credentials: 'omit',
+			referrerPolicy: 'no-referrer',
+			cache: 'no-store',
+			headers: { Accept: 'application/nostr+json' }
+		});
+		expect(init?.signal).toBeInstanceOf(AbortSignal);
+		expect(createNip11FetchInit(new AbortController().signal).redirect).toBe('error');
+	});
+
+	it('aborts hung fetches at the configured timeout', async () => {
+		const fetchImpl = vi.fn<typeof fetch>((_url, init) => {
+			return new Promise<Response>((_resolve, reject) => {
+				(init?.signal as AbortSignal).addEventListener('abort', () => {
+					reject(new DOMException('Aborted', 'AbortError'));
+				});
+			});
+		});
+
+		await expect(
+			fetchRelayInformation('wss://relay.example/', { fetchImpl, timeoutMs: 10 })
+		).rejects.toMatchObject({
+			code: 'timeout'
+		});
+		expect((fetchImpl.mock.calls[0]?.[1]?.signal as AbortSignal).aborted).toBe(true);
+	});
+
+	it('enforces content-type compatibility and bounded JSON body parsing', async () => {
+		await expect(
+			fetchRelayInformation('wss://relay.example/', {
+				fetchImpl: vi
+					.fn<typeof fetch>()
+					.mockResolvedValue(responseWithoutContentType(JSON.stringify({ name: 'legacy relay' })))
+			})
+		).resolves.toEqual({ name: 'legacy relay' });
+
+		await expect(
+			fetchRelayInformation('wss://relay.example/', {
+				fetchImpl: vi
+					.fn<typeof fetch>()
+					.mockResolvedValue(
+						new Response('{"name":"wrong type"}', { headers: { 'content-type': 'text/html' } })
+					)
+			})
+		).rejects.toMatchObject({ code: 'invalid-content-type' });
+
+		await expect(
+			fetchRelayInformation('wss://relay.example/', {
+				fetchImpl: vi
+					.fn<typeof fetch>()
+					.mockResolvedValue(responseWithoutContentType('<html></html>'))
+			})
+		).rejects.toMatchObject({ code: 'invalid-content-type' });
+
+		await expect(
+			fetchRelayInformation('wss://relay.example/', {
+				maxBodyBytes: 8,
+				fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(
+					new Response(JSON.stringify({ name: 'too large' }), {
+						headers: { 'content-type': 'application/json' }
+					})
+				)
+			})
+		).rejects.toMatchObject({ code: 'oversize' });
+
+		await expect(
+			fetchRelayInformation('wss://relay.example/', {
+				fetchImpl: vi
+					.fn<typeof fetch>()
+					.mockResolvedValue(
+						new Response('{not json}', { headers: { 'content-type': 'application/json' } })
+					)
+			})
+		).rejects.toMatchObject({ code: 'invalid-json' });
+
+		await expect(
+			fetchRelayInformation('wss://relay.example/', {
+				fetchImpl: vi
+					.fn<typeof fetch>()
+					.mockResolvedValue(
+						new Response('[]', { headers: { 'content-type': 'application/json' } })
+					)
+			})
+		).rejects.toMatchObject({ code: 'invalid-response' });
+	});
+
+	it('rejects hostile 302 NIP-11 responses without following the sentinel URL', async () => {
+		const server = await listen((req, res) => {
+			if (req.url === '/sentinel') {
+				res.writeHead(200, { 'content-type': 'application/nostr+json' });
+				res.end(JSON.stringify({ name: 'sentinel' }));
+				return;
+			}
+
+			res.writeHead(302, {
+				location: `${server.url}/sentinel`,
+				'access-control-allow-origin': '*'
+			});
+			res.end();
+		});
+
+		try {
+			await expect(fetchRelayInformation(relayFor(server.url))).rejects.toMatchObject({
+				code: 'fetch-failed'
+			});
+			expect(server.getHits()['/']).toBe(1);
+			expect(server.getHits()['/sentinel'] ?? 0).toBe(0);
+		} finally {
+			await server.close();
+		}
+	});
+
+	it('loads valid NIP-11 JSON from arbitrary untrusted local origins', async () => {
+		const relayInfo = {
+			name: 'untrusted local relay',
+			description: 'Valid NIP-11 from an arbitrary origin',
+			pubkey: '0'.repeat(64),
+			supported_nips: [1, 11]
+		};
+		const server = await listen((_req, res) => {
+			res.writeHead(200, {
+				'content-type': 'application/nostr+json',
+				'access-control-allow-origin': '*'
+			});
+			res.end(JSON.stringify(relayInfo));
+		});
+
+		try {
+			await expect(fetchRelayInformation(relayFor(server.url))).resolves.toEqual(relayInfo);
+			expect(server.getHits()['/']).toBe(1);
+		} finally {
+			await server.close();
+		}
+	});
+});

--- a/apps/gui/src/lib/services/Nip11Service/fetch-relay-information.ts
+++ b/apps/gui/src/lib/services/Nip11Service/fetch-relay-information.ts
@@ -1,0 +1,223 @@
+import type { RelayInformation } from '@nostrwatch/route66/models';
+
+export const NIP11_ACCEPT = 'application/nostr+json';
+export const NIP11_MAX_BODY_BYTES = 128 * 1024;
+export const NIP11_TIMEOUT_MS = 5_000;
+
+export type Nip11FetchErrorCode =
+	| 'invalid-relay-url'
+	| 'timeout'
+	| 'fetch-failed'
+	| 'http-error'
+	| 'invalid-content-type'
+	| 'oversize'
+	| 'invalid-json'
+	| 'invalid-response';
+
+export type SerializedNip11FetchError = {
+	code: Nip11FetchErrorCode;
+	message: string;
+	status?: number;
+};
+
+export class Nip11FetchError extends Error {
+	code: Nip11FetchErrorCode;
+	status?: number;
+
+	constructor(code: Nip11FetchErrorCode, message: string, status?: number) {
+		super(message);
+		this.name = 'Nip11FetchError';
+		this.code = code;
+		this.status = status;
+	}
+}
+
+export type FetchRelayInformationOptions = {
+	timeoutMs?: number;
+	maxBodyBytes?: number;
+	fetchImpl?: typeof fetch;
+};
+
+export const relayUrlToNip11HttpUrl = (relay: string): string => {
+	let url: URL;
+	try {
+		url = new URL(relay);
+	} catch {
+		throw new Nip11FetchError('invalid-relay-url', `Invalid relay URL: ${relay}`);
+	}
+
+	if (url.username || url.password) {
+		throw new Nip11FetchError('invalid-relay-url', 'Relay URL must not contain credentials.');
+	}
+
+	if (url.protocol === 'ws:') {
+		url.protocol = 'http:';
+	} else if (url.protocol === 'wss:') {
+		url.protocol = 'https:';
+	} else {
+		throw new Nip11FetchError(
+			'invalid-relay-url',
+			`Relay URL must use ws: or wss:, got ${url.protocol}`
+		);
+	}
+
+	url.hash = '';
+	return url.toString();
+};
+
+export const createNip11FetchInit = (signal: AbortSignal): RequestInit => ({
+	redirect: 'error',
+	credentials: 'omit',
+	referrerPolicy: 'no-referrer',
+	cache: 'no-store',
+	headers: {
+		Accept: NIP11_ACCEPT
+	},
+	signal
+});
+
+const isJsonContentType = (contentType: string): boolean => {
+	const mime = contentType.split(';', 1)[0]?.trim().toLowerCase() ?? '';
+	return (
+		mime === NIP11_ACCEPT ||
+		mime === 'application/json' ||
+		mime === 'text/json' ||
+		mime.endsWith('+json')
+	);
+};
+
+const startsLikeJsonObject = (body: string): boolean => body.trimStart().startsWith('{');
+
+const bytesFor = (text: string): number => new TextEncoder().encode(text).byteLength;
+
+const readBodyWithLimit = async (response: Response, maxBodyBytes: number): Promise<string> => {
+	const contentLength = response.headers.get('content-length');
+	if (contentLength) {
+		const parsedLength = Number(contentLength);
+		if (Number.isFinite(parsedLength) && parsedLength > maxBodyBytes) {
+			throw new Nip11FetchError('oversize', `NIP-11 response exceeds ${maxBodyBytes} bytes.`);
+		}
+	}
+
+	if (!response.body) {
+		const text = await response.text();
+		if (bytesFor(text) > maxBodyBytes) {
+			throw new Nip11FetchError('oversize', `NIP-11 response exceeds ${maxBodyBytes} bytes.`);
+		}
+		return text;
+	}
+
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let received = 0;
+
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		if (!value) continue;
+
+		const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
+		received += chunk.byteLength;
+		if (received > maxBodyBytes) {
+			await reader.cancel();
+			throw new Nip11FetchError('oversize', `NIP-11 response exceeds ${maxBodyBytes} bytes.`);
+		}
+		chunks.push(chunk);
+	}
+
+	const body = new Uint8Array(received);
+	let offset = 0;
+	for (const chunk of chunks) {
+		body.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+
+	return new TextDecoder().decode(body);
+};
+
+const parseRelayInformation = (body: string): RelayInformation => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(body);
+	} catch {
+		throw new Nip11FetchError('invalid-json', 'NIP-11 response body is not valid JSON.');
+	}
+
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+		throw new Nip11FetchError('invalid-response', 'NIP-11 response must be a JSON object.');
+	}
+
+	return parsed as RelayInformation;
+};
+
+export const fetchRelayInformation = async (
+	relay: string,
+	options: FetchRelayInformationOptions = {}
+): Promise<RelayInformation> => {
+	const url = relayUrlToNip11HttpUrl(relay);
+	const timeoutMs = options.timeoutMs ?? NIP11_TIMEOUT_MS;
+	const maxBodyBytes = options.maxBodyBytes ?? NIP11_MAX_BODY_BYTES;
+	const fetchImpl = options.fetchImpl ?? fetch;
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+	try {
+		const response = await fetchImpl(url, createNip11FetchInit(controller.signal));
+		if (!response.ok) {
+			throw new Nip11FetchError(
+				'http-error',
+				`NIP-11 request failed with HTTP ${response.status}.`,
+				response.status
+			);
+		}
+
+		const contentType = response.headers.get('content-type')?.trim() ?? '';
+		if (contentType && !isJsonContentType(contentType)) {
+			throw new Nip11FetchError(
+				'invalid-content-type',
+				`Unsupported NIP-11 content-type: ${contentType}`
+			);
+		}
+
+		const body = await readBodyWithLimit(response, maxBodyBytes);
+		if (!contentType && !startsLikeJsonObject(body)) {
+			throw new Nip11FetchError(
+				'invalid-content-type',
+				'NIP-11 response without content-type must start with a JSON object.'
+			);
+		}
+
+		return parseRelayInformation(body);
+	} catch (error) {
+		if (error instanceof Nip11FetchError) throw error;
+		if (
+			controller.signal.aborted ||
+			(error instanceof DOMException && error.name === 'AbortError')
+		) {
+			throw new Nip11FetchError('timeout', `NIP-11 request timed out after ${timeoutMs}ms.`);
+		}
+		throw new Nip11FetchError(
+			'fetch-failed',
+			error instanceof Error
+				? error.message
+				: 'NIP-11 request failed before a response was available.'
+		);
+	} finally {
+		clearTimeout(timeout);
+	}
+};
+
+export const serializeNip11FetchError = (error: unknown): SerializedNip11FetchError => {
+	if (error instanceof Nip11FetchError) {
+		return {
+			code: error.code,
+			message: error.message,
+			...(error.status === undefined ? {} : { status: error.status })
+		};
+	}
+
+	return {
+		code: 'fetch-failed',
+		message: error instanceof Error ? error.message : String(error)
+	};
+};

--- a/apps/gui/src/lib/services/Nip11Service/index.test.ts
+++ b/apps/gui/src/lib/services/Nip11Service/index.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { nip11sLocal } from '$lib/stores/nip11s-local';
+
+import { Nip11Service } from './index';
+
+describe('Nip11Service', () => {
+	afterEach(() => {
+		nip11sLocal.set(new Map());
+		vi.unstubAllGlobals();
+	});
+
+	it('creates worker for arbitrary automatic relay probes', async () => {
+		const instances: Array<{ postMessage: ReturnType<typeof vi.fn> }> = [];
+
+		class WorkerStub {
+			onmessage: ((message: MessageEvent) => void) | null = null;
+			onerror: ((event: Event) => void) | null = null;
+			postMessage = vi.fn();
+
+			constructor() {
+				instances.push({ postMessage: this.postMessage });
+			}
+		}
+
+		vi.stubGlobal('Worker', WorkerStub);
+
+		const service = new Nip11Service();
+		const pending = service.check('wss://attacker.example/', { timeoutMs: 20 });
+
+		await vi.waitFor(() => {
+			expect(instances[0]?.postMessage).toHaveBeenCalledWith({
+				relay: 'wss://attacker.example/',
+				timeoutMs: 20
+			});
+		});
+		await expect(pending).resolves.toBeUndefined();
+	});
+});

--- a/apps/gui/src/lib/services/Nip11Service/index.ts
+++ b/apps/gui/src/lib/services/Nip11Service/index.ts
@@ -1,5 +1,3 @@
-import type { nip11 } from 'nostr-tools';
-
 import { get, type Writable } from 'svelte/store';
 
 import type { Route66 } from '@nostrwatch/route66';
@@ -7,8 +5,8 @@ import { type Nip11 as Nip11Type, type RelayInformation } from '@nostrwatch/rout
 
 import { nip11sLocal } from '$lib/stores/nip11s-local.js';
 import { setRelayError } from '$lib/stores/relay-errors.js';
+import type { SerializedNip11FetchError } from './fetch-relay-information.js';
 
-import { instance } from '$lib/utils/lifecycle';
 // import { relaysErrors } from '$lib/stores/relay-errors';
 
 import PQueue from 'p-queue';
@@ -16,8 +14,8 @@ const queue = new PQueue({concurrency: 10});
 
 export type Nip11ServiceMessage = {
     relay: string,
-    nip11?: nip11.RelayInformation
-    error?: any
+    nip11?: RelayInformation
+    error?: SerializedNip11FetchError | string
 }
 
 type Nip11Constructor = new (info: RelayInformation) => Nip11Type;
@@ -26,6 +24,10 @@ type PendingRequest = {
     promise: Promise<Nip11Type | undefined>;
     resolve: (value: Nip11Type | undefined) => void;
     timeoutId: ReturnType<typeof setTimeout>;
+};
+
+type Nip11CheckOptions = {
+    timeoutMs?: number;
 };
 
 export class Nip11Service {
@@ -43,7 +45,7 @@ export class Nip11Service {
         return $nip11sLocal.get(relay)
     }
 
-    async check(relay: string, options: { timeoutMs?: number } = {}): Promise<Nip11Type | undefined> {
+    async check(relay: string, options: Nip11CheckOptions = {}): Promise<Nip11Type | undefined> {
         const timeoutMs = options.timeoutMs ?? 5_000;
 
         const existing = this.find(relay);
@@ -52,7 +54,7 @@ export class Nip11Service {
         const inFlight = this.pending.get(relay);
         if (inFlight) return inFlight.promise;
 
-        return queue.add(() => this.request(relay, timeoutMs));
+        return (await queue.add(() => this.request(relay, timeoutMs))) ?? undefined;
     }
 
     private async request(relay: string, timeoutMs: number): Promise<Nip11Type | undefined> {
@@ -72,11 +74,11 @@ export class Nip11Service {
         const timeoutId = setTimeout(() => {
             this.pending.delete(relay);
             resolveFn(undefined);
-        }, timeoutMs);
+        }, timeoutMs + 250);
 
         this.pending.set(relay, { promise, resolve: resolveFn, timeoutId });
 
-        worker.postMessage({ relay });
+        worker.postMessage({ relay, timeoutMs });
 
         return promise;
     }
@@ -123,7 +125,7 @@ export class Nip11Service {
         }
 
         if (error) {
-            setRelayError(relay, 'schema', 'nip11', error?.message ?? String(error));
+            setRelayError(relay, 'schema', 'nip11', typeof error === 'string' ? error : error.message);
             pending?.resolve(undefined);
             return;
         }
@@ -140,7 +142,8 @@ export class Nip11Service {
             return map;
         });
 
-        instance()
+        import('$lib/utils/lifecycle')
+            .then(({ instance }) => instance())
             .then(($route66: Route66) => {
                 void $route66?.adapters?.cacheAdapter?.upsertNip11?.(relay, nip11.json);
             })

--- a/apps/gui/src/lib/services/Nip11Service/nip11.worker.ts
+++ b/apps/gui/src/lib/services/Nip11Service/nip11.worker.ts
@@ -1,38 +1,25 @@
-import { nip11 } from "nostr-tools";
 import type { Nip11ServiceMessage } from "./index.js";
+import { fetchRelayInformation, serializeNip11FetchError } from "./fetch-relay-information";
 
-const check = async (relay: string): Promise<nip11.RelayInformation> => {
-    return nip11.fetchRelayInformation(relay)
-}
+type Nip11WorkerRequest = {
+    relay: string;
+    timeoutMs?: number;
+};
 
-const timeoutMessage = (relay: string) => {
-    const error = `Request for NIP-11 from ${relay} timed out.`
-    self.postMessage({ relay, error } as Nip11ServiceMessage)
-}
-
-self.onmessage = ({ data }) => {
-    const { relay } = data;
-    let timedOut:boolean = false
-    const timeoutRequest = () => { 
-        console.error('TIMED OUT')
-        timedOut = true;
-        timeoutMessage(relay) 
-    }
-    const timeout = setTimeout(timeoutRequest, 5000)
+self.onmessage = ({ data }: MessageEvent<Nip11WorkerRequest>) => {
+    const { relay, timeoutMs } = data;
     // console.log('N11S worker received message', data)
-    check(relay)
-        .then((nip11: nip11.RelayInformation) => {
-            if(timedOut) return;
-            clearTimeout(timeout)
+    fetchRelayInformation(relay, { timeoutMs })
+        .then((nip11) => {
             self.postMessage({ relay, nip11 } as Nip11ServiceMessage)
         })
-        .catch((error: any) => { 
-            if(timedOut) return;
-            clearTimeout(timeout)
-            self.postMessage({ relay, error } as Nip11ServiceMessage)
+        .catch((error: unknown) => {
+            self.postMessage({ relay, error: serializeNip11FetchError(error) } as Nip11ServiceMessage)
         })
 }
 
-self.onerror = (err: any) => {
-    self.postMessage({ error: 'timed out.' } as Nip11ServiceMessage)
+self.onerror = () => {
+    self.postMessage({
+        error: { code: 'fetch-failed', message: 'NIP-11 worker failed.' }
+    } as Nip11ServiceMessage)
 }

--- a/apps/gui/tests/nip11-redirect-firefox.spec.ts
+++ b/apps/gui/tests/nip11-redirect-firefox.spec.ts
@@ -1,0 +1,97 @@
+import { createHash } from 'node:crypto';
+import http from 'node:http';
+import { test } from '@playwright/test';
+
+test.skip(({ browserName }) => browserName !== 'firefox', 'Firefox-only NIP-11 redirect repro');
+test.setTimeout(60_000);
+
+test('hostile NIP-11 302 does not follow sentinel or navigate parent frame', async ({ page }) => {
+	const hits: Record<string, number> = {};
+	let nip11Hits = 0;
+	const server = http.createServer((req, res) => {
+		const path = req.url ?? '/';
+		hits[path] = (hits[path] ?? 0) + 1;
+
+		if (path === '/sentinel') {
+			res.writeHead(200, {
+				'content-type': 'application/nostr+json',
+				'access-control-allow-origin': '*'
+			});
+			res.end(JSON.stringify({ name: 'sentinel should not load' }));
+			return;
+		}
+
+		const accept = Array.isArray(req.headers.accept)
+			? req.headers.accept.join(',')
+			: (req.headers.accept ?? '');
+		if (!accept.includes('application/nostr+json')) {
+			res.writeHead(200, { 'content-type': 'text/plain', 'access-control-allow-origin': '*' });
+			res.end('ok');
+			return;
+		}
+
+		nip11Hits += 1;
+		const address = server.address();
+		if (!address || typeof address === 'string')
+			throw new Error('Hostile server address unavailable.');
+		res.writeHead(302, {
+			location: `http://127.0.0.1:${address.port}/sentinel`,
+			'access-control-allow-origin': '*'
+		});
+		res.end();
+	});
+	server.on('upgrade', (req, socket) => {
+		const key = req.headers['sec-websocket-key'];
+		if (typeof key !== 'string') {
+			socket.destroy();
+			return;
+		}
+
+		const accept = createHash('sha1')
+			.update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+			.digest('base64');
+		socket.write(
+			[
+				'HTTP/1.1 101 Switching Protocols',
+				'Upgrade: websocket',
+				'Connection: Upgrade',
+				`Sec-WebSocket-Accept: ${accept}`,
+				'\r\n'
+			].join('\r\n')
+		);
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+	const address = server.address();
+	if (!address || typeof address === 'string') throw new Error('Hostile server failed to bind.');
+
+	try {
+		const route = `/relays/ws/127.0.0.1:${address.port}/nip-11`;
+		await page.goto(route);
+		const initialFrameUrl = page.url();
+		const startedAt = Date.now();
+		while (nip11Hits === 0 && Date.now() - startedAt < 15_000) {
+			await page.waitForTimeout(100);
+		}
+		if (nip11Hits === 0) {
+			throw new Error(
+				`NIP-11 endpoint was not requested; hits=${JSON.stringify(hits)}; page=${page.url()}`
+			);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		const sentinelHits = hits['/sentinel'] ?? 0;
+		if (sentinelHits !== 0) {
+			throw new Error(
+				`Sentinel was requested ${sentinelHits} time(s); hits=${JSON.stringify(hits)}`
+			);
+		}
+		if (page.url() !== initialFrameUrl) {
+			throw new Error(`Parent frame URL changed from ${initialFrameUrl} to ${page.url()}`);
+		}
+	} finally {
+		await new Promise<void>((resolve, reject) =>
+			server.close((error) => (error ? reject(error) : resolve()))
+		);
+	}
+});


### PR DESCRIPTION
## Summary
- Replace the worker's `nostr-tools` NIP-11 fetch path with app-owned client-side fetching.
- Reject HTTP redirects with `redirect: 'error'`, omit credentials/referrers, disable cache reuse, enforce `Accept: application/nostr+json`, bound response bodies, and return structured worker errors.
- Preserve arbitrary untrusted relay metadata fetches without allowlists, denylists, or trusted-relay gates.
- Add unit coverage and a Firefox runtime repro that proves a hostile 302 is not followed and the relay page does not navigate.

## Redirect proof
- Old dependency path: `apps/gui/node_modules/nostr-tools/lib/esm/nip11.js:11` called `fetch(...)` with only an `Accept` header, so browser default redirect-follow applied.
- New hardened path: `apps/gui/src/lib/services/Nip11Service/fetch-relay-information.ts` sets `redirect: 'error'`; `nip11.worker.ts` calls this helper instead of `nip11.fetchRelayInformation`.

## Verification
- `pnpm --dir apps/gui test`
- `pnpm --dir apps/gui lint`
- `pnpm --dir apps/gui exec playwright test --reporter=line`
- `pnpm --dir apps/gui check` still reports unrelated baseline diagnostics; touched NIP-11/Playwright files were absent from the raw check errors.
