### PR TITLE
Keep cached monitors visible during resync

### DIFF
--- a/apps/gui/src/lib/stores/app-cache-state.test.ts
+++ b/apps/gui/src/lib/stores/app-cache-state.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { StateManager } from '@nostrwatch/route66';
+
+import { hasUsableCachedData, shouldForceFullBootstrap, shouldRequireSeedBootstrap } from './app';
+
+const CACHE_KEYS = [
+	'aggregate:complete',
+	'count:events:checks',
+	'cache:monitors',
+	'aggregate:relays',
+	'relays:minisearch',
+	'aggregate:operators'
+];
+
+const clearCacheKeys = () => {
+	for (const key of CACHE_KEYS) {
+		try {
+			StateManager.remove(key);
+		} catch {}
+	}
+};
+
+describe('cached boot state', () => {
+	afterEach(() => {
+		clearCacheKeys();
+	});
+
+	it('does not require the boot screen when static aggregate cache exists', () => {
+		clearCacheKeys();
+		StateManager.set('aggregate:complete', 'cached-aggregate-payload');
+
+		expect(hasUsableCachedData()).toBe(true);
+		expect(
+			shouldRequireSeedBootstrap({
+				bootstrapped: false,
+				seeded: false,
+				seedBootStatus: 'idle',
+				hasUsableCache: hasUsableCachedData()
+			})
+		).toBe(false);
+	});
+
+	it('requires seed bootstrap only for a real first visit with no markers or cache', () => {
+		clearCacheKeys();
+
+		expect(hasUsableCachedData()).toBe(false);
+		expect(
+			shouldRequireSeedBootstrap({
+				bootstrapped: false,
+				seeded: false,
+				seedBootStatus: 'idle',
+				hasUsableCache: false
+			})
+		).toBe(true);
+	});
+
+	it('keeps temporary suspension idempotent for in-progress resync with cache', () => {
+		clearCacheKeys();
+		StateManager.set('count:events:checks', 100);
+
+		const state = {
+			bootstrapped: false,
+			seeded: false,
+			seedBootStatus: 'in_progress' as const,
+			hasUsableCache: hasUsableCachedData()
+		};
+
+		expect(shouldRequireSeedBootstrap(state)).toBe(false);
+		expect(shouldRequireSeedBootstrap(state)).toBe(false);
+	});
+
+	it('does not force full sync when bootstrap markers are missing but cache exists', () => {
+		expect(
+			shouldForceFullBootstrap({
+				bootstrapped: false,
+				hasUsableCache: true,
+				opfsStatus: 'online'
+			})
+		).toBe(false);
+	});
+
+	it('still forces full sync for real first visit or cache fallback states', () => {
+		expect(
+			shouldForceFullBootstrap({
+				bootstrapped: false,
+				hasUsableCache: false,
+				opfsStatus: 'online'
+			})
+		).toBe(true);
+		expect(
+			shouldForceFullBootstrap({
+				bootstrapped: true,
+				hasUsableCache: true,
+				opfsStatus: 'fallback'
+			})
+		).toBe(true);
+		expect(
+			shouldForceFullBootstrap({
+				bootstrapped: true,
+				hasUsableCache: true,
+				opfsStatus: 'error'
+			})
+		).toBe(true);
+	});
+});

--- a/apps/gui/src/lib/stores/app.ts
+++ b/apps/gui/src/lib/stores/app.ts
@@ -131,6 +131,60 @@ export const shouldSync = () => {
     return false; 
 }
 
+function hasNonEmptyArrayCache(key: string): boolean {
+    try {
+        const value = StateManager.get(key);
+        return Array.isArray(value) && value.length > 0;
+    } catch {
+        return false;
+    }
+}
+
+function hasPositiveNumberCache(key: string): boolean {
+    try {
+        const value = Number(StateManager.get(key));
+        return Number.isFinite(value) && value > 0;
+    } catch {
+        return false;
+    }
+}
+
+export const hasUsableCachedData = (): boolean => {
+    try {
+        if (StateManager.get('aggregate:complete')) return true;
+    } catch {}
+
+    return (
+        hasPositiveNumberCache('count:events:checks') ||
+        hasNonEmptyArrayCache('cache:monitors') ||
+        hasNonEmptyArrayCache('aggregate:relays') ||
+        hasNonEmptyArrayCache('relays:minisearch') ||
+        hasNonEmptyArrayCache('aggregate:operators')
+    );
+}
+
+export type BootstrapGateState = {
+    bootstrapped: boolean;
+    seeded: boolean;
+    seedBootStatus: 'idle' | 'in_progress' | 'complete' | 'error';
+    hasUsableCache: boolean;
+}
+
+export const shouldRequireSeedBootstrap = (state: BootstrapGateState): boolean => {
+    const seedReady = state.seeded || state.seedBootStatus === 'complete';
+    const freshState = !state.bootstrapped && !state.seeded && !state.hasUsableCache;
+    return freshState && !seedReady;
+}
+
+export const shouldForceFullBootstrap = (state: {
+    bootstrapped: boolean;
+    hasUsableCache: boolean;
+    opfsStatus: OpfsStatusType;
+}): boolean => {
+    if (state.opfsStatus === 'fallback' || state.opfsStatus === 'error') return true;
+    return !state.bootstrapped && !state.hasUsableCache;
+}
+
 export const hasBeenBootstrapped = (): boolean => {
     // Check for both 'sync:all' (re-sync) and 'sync:all-force' (fresh bootstrap)
     return StateManager.get('register:sync:all') || StateManager.get('register:sync:all-force') ? true : false

--- a/apps/gui/src/lib/stores/data-register.ts
+++ b/apps/gui/src/lib/stores/data-register.ts
@@ -1,7 +1,7 @@
 import { DataRegister } from "$lib/managers/DataRegister";
 import { get, writable, type Writable } from "svelte/store";
 import { doBootstrap } from "$stores/routines";
-import { doAggregateCache, doLiveSync, isBootstrapped, isBootstrapping, isSeeded, lastCompleteSync, setStatsAsOf, tabState } from "$stores/app";
+import { doAggregateCache, doLiveSync, hasUsableCachedData, isBootstrapped, isBootstrapping, isSeeded, lastCompleteSync, setStatsAsOf, tabState } from "$stores/app";
 import { backfillMonitorChecks, fetchDisabledMonitorsChecks, fetchMonitors, fetchMonitorsChecks, fetchNip11s, fetchOperators } from "$lib/fetchers/bootstrap";
 import { instance, removeStaleChecksFromStore, seedFromCache } from "$utils/lifecycle";
 import { liveSync } from "$utils/live-sync";
@@ -85,8 +85,16 @@ export const dataRegisterInit = async () => {
             // Only the leader tab should download + ingest the (potentially large) build-seed payload.
             if (get(tabState) !== 'leader') return false;
 
-            // Normal first-run: no bootstrap markers and no prior seed import.
-            if (!get(isBootstrapped) && !get(isSeeded)) return true;
+            const hasRenderableCache = hasUsableCachedData();
+
+            // Normal first-run: no bootstrap markers, no prior seed import, and no
+            // UI-renderable cache. A missing marker alone is not enough to hide
+            // cached monitors behind a long reseed/resync boot screen.
+            if (!get(isBootstrapped) && !get(isSeeded)) return !hasRenderableCache;
+
+            // Static cache is enough to render while the normal sync path repairs
+            // stale/missing backend cache state. Do not start a seed bootstrap over it.
+            if (hasRenderableCache) return false;
 
             // Recovery path: localStorage can say "seeded/bootstrapped" while the actual cache
             // is empty (e.g. OPFS/SQLite fallback, corruption reset, or user wiped SQLite only).
@@ -106,7 +114,7 @@ export const dataRegisterInit = async () => {
                 if (typeof cache?.ready === 'function') {
                     await withTimeout(cache.ready(), 5_000);
                 }
-                const checkCount = await withTimeout(cache.COUNT([{ kinds: [30166] }]), 5_000);
+                const checkCount = Number(await withTimeout(cache.COUNT([{ kinds: [30166] }]), 5_000));
                 return !Number.isFinite(checkCount) || checkCount < 100;
             } catch {
                 // If we cannot verify cache health, attempt build-seed so the UI can recover.
@@ -305,7 +313,7 @@ export const dataRegisterInit = async () => {
             // when this origin hasn't been "bootstrapped" yet.
             if (get(tabState) !== 'leader') return true;
             const bootstrapped = get(isBootstrapped);
-            if (!bootstrapped) {
+            if (!bootstrapped && !hasUsableCachedData()) {
                 console.log('[DataRegister] skipping sync:cache: fresh state');
                 return false;
             }

--- a/apps/gui/src/lib/utils/bootstrap-render-state.test.ts
+++ b/apps/gui/src/lib/utils/bootstrap-render-state.test.ts
@@ -7,6 +7,7 @@ describe('getBootstrapRenderState', () => {
 		const state = getBootstrapRenderState({
 			isReady: true,
 			hasActualData: false,
+			hasUsableCache: false,
 			isBootstrapped: false,
 			isSeeded: false,
 			seedBootStatus: 'complete',
@@ -25,6 +26,7 @@ describe('getBootstrapRenderState', () => {
 		const state = getBootstrapRenderState({
 			isReady: false,
 			hasActualData: false,
+			hasUsableCache: false,
 			isBootstrapped: false,
 			isSeeded: false,
 			seedBootStatus: 'in_progress',
@@ -40,6 +42,7 @@ describe('getBootstrapRenderState', () => {
 		const state = getBootstrapRenderState({
 			isReady: true,
 			hasActualData: true,
+			hasUsableCache: false,
 			isBootstrapped: false,
 			isSeeded: false,
 			seedBootStatus: 'complete',
@@ -56,6 +59,7 @@ describe('getBootstrapRenderState', () => {
 		const state = getBootstrapRenderState({
 			isReady: false,
 			hasActualData: true,
+			hasUsableCache: false,
 			isBootstrapped: true,
 			isSeeded: true,
 			seedBootStatus: 'complete',
@@ -71,6 +75,7 @@ describe('getBootstrapRenderState', () => {
 		const state = getBootstrapRenderState({
 			isReady: true,
 			hasActualData: false,
+			hasUsableCache: false,
 			isBootstrapped: false,
 			isSeeded: false,
 			seedBootStatus: 'complete',
@@ -80,5 +85,23 @@ describe('getBootstrapRenderState', () => {
 		expect(state.showContent).toBe(false);
 		expect(state.showFollowerWaiting).toBe(true);
 		expect(state.showBootstrapLoading).toBe(false);
+	});
+
+	it('shows cached content during an in-progress cached resync', () => {
+		const state = getBootstrapRenderState({
+			isReady: true,
+			hasActualData: false,
+			hasUsableCache: true,
+			isBootstrapped: false,
+			isSeeded: false,
+			seedBootStatus: 'in_progress',
+			tabState: 'leader'
+		});
+
+		expect(state.needsSeedBootstrap).toBe(false);
+		expect(state.loadedEnough).toBe(true);
+		expect(state.showBootstrapLoading).toBe(false);
+		expect(state.showContent).toBe(true);
+		expect(state.navDisabled).toBe(false);
 	});
 });

--- a/apps/gui/src/lib/utils/bootstrap-render-state.ts
+++ b/apps/gui/src/lib/utils/bootstrap-render-state.ts
@@ -4,6 +4,7 @@ import type { SeedBootStatus } from '$lib/stores/boot-state';
 export interface BootstrapRenderStateInput {
 	isReady: boolean;
 	hasActualData: boolean;
+	hasUsableCache: boolean;
 	isBootstrapped: boolean;
 	isSeeded: boolean;
 	seedBootStatus: SeedBootStatus;
@@ -19,17 +20,20 @@ export interface BootstrapRenderState {
 	showBootstrapLoading: boolean;
 	showFollowerWaiting: boolean;
 	showContent: boolean;
+	showInitialBootFallback: boolean;
 	navDisabled: boolean;
 }
 
 export function getBootstrapRenderState(input: BootstrapRenderStateInput): BootstrapRenderState {
 	const seedInProgress = input.seedBootStatus === 'in_progress';
 	const seedReady = input.isSeeded || input.seedBootStatus === 'complete';
-	const isFreshState = !input.isBootstrapped && !input.isSeeded;
-	const loadedEnough = input.hasActualData && (!isFreshState || seedReady);
+	const hasRenderableData = input.hasActualData || input.hasUsableCache;
+	const isFreshState = !input.isBootstrapped && !input.isSeeded && !input.hasUsableCache;
+	const loadedEnough = hasRenderableData && (!isFreshState || seedReady);
 	const needsSeedBootstrap = isFreshState && !seedReady;
-	const showContent = input.isReady && loadedEnough && !seedInProgress;
+	const showContent = input.isReady && loadedEnough;
 	const showFollowerWaiting = !showContent && input.tabState === 'follower';
+	const showBootstrapLoading = needsSeedBootstrap && input.tabState === 'leader';
 
 	return {
 		seedInProgress,
@@ -37,9 +41,11 @@ export function getBootstrapRenderState(input: BootstrapRenderStateInput): Boots
 		isFreshState,
 		loadedEnough,
 		needsSeedBootstrap,
-		showBootstrapLoading: needsSeedBootstrap && input.tabState === 'leader',
+		showBootstrapLoading,
 		showFollowerWaiting,
 		showContent,
-		navDisabled: !loadedEnough || needsSeedBootstrap || seedInProgress
+		showInitialBootFallback:
+			!showBootstrapLoading && !showFollowerWaiting && !showContent && !input.hasUsableCache,
+		navDisabled: !loadedEnough || needsSeedBootstrap
 	};
 }

--- a/apps/gui/src/routes/+layout.svelte
+++ b/apps/gui/src/routes/+layout.svelte
@@ -21,8 +21,10 @@
 	    tabState,
 	    hasBeenBootstrapped,
 	    isBootstrapped,
+	    hasUsableCachedData,
 	    isSeeded,
 	    opfsStatus,
+	    shouldForceFullBootstrap,
 	  } from '$lib/stores/app';
 	  import { relayCheckAggregates } from '$lib/stores';
 	  import { showDebugButton } from '$lib/stores/preferences';
@@ -124,9 +126,14 @@
 	    dataRegisterInit();
 	    const datas: string[] = ['sync:cache'];
 	    if (get(tabState) === 'leader') {
-	      const opfs = get(opfsStatus);
-	      const forceFullSync = opfs === 'fallback' || opfs === 'error';
-	      datas.push(forceFullSync ? 'sync:all-force' : hasBeenBootstrapped() ? 'sync:all' : 'sync:all-force');
+	      const bootstrapped = hasBeenBootstrapped();
+	      const hasCache = hasUsableCachedData();
+	      const forceFullSync = shouldForceFullBootstrap({
+	        bootstrapped,
+	        hasUsableCache: hasCache,
+	        opfsStatus: get(opfsStatus),
+	      });
+	      datas.push(forceFullSync ? 'sync:all-force' : 'sync:all');
 	    }
 	    void get(dataRegister)
 	      .require(datas)
@@ -262,9 +269,11 @@
   // Render gating
   // --------------------------------------------------------------------------------
   $: hasActualData = $relayCheckAggregates?.length > 0;
+  $: hasCachedData = hasUsableCachedData();
   $: bootstrapRenderState = getBootstrapRenderState({
     isReady,
     hasActualData,
+    hasUsableCache: hasCachedData,
     isBootstrapped: $isBootstrapped,
     isSeeded: $isSeeded,
     seedBootStatus: $seedBootStatus,
@@ -283,12 +292,12 @@
   {:else if bootstrapRenderState.showFollowerWaiting}
     <FollowerLoading />
   {:else if bootstrapRenderState.showContent}
-    <HeaderComponent navDisabled={false} />
+    <HeaderComponent navDisabled={bootstrapRenderState.navDisabled} />
     <MonitorsBanner />
     <div id="content-wrapper" class="block flow-root">
       <slot />
     </div>
-  {:else}
+  {:else if bootstrapRenderState.showInitialBootFallback}
     <div class="flex flex-col items-center justify-center h-screen px-4">
       <div class="text-7xl mb-3">booting.</div>
     </div>

--- a/apps/gui/tests/bootstrap-cache-gate.spec.ts
+++ b/apps/gui/tests/bootstrap-cache-gate.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+
+test('cached monitor data bypasses first-visit boot screen during resync', async ({ page }) => {
+	let seedManifestRequests = 0;
+	page.on('request', (request) => {
+		if (new URL(request.url()).pathname === '/seed/manifest.json') seedManifestRequests += 1;
+	});
+
+	await page.addInitScript(() => {
+		localStorage.clear();
+		localStorage.setItem('state:count:events:checks', '100');
+		localStorage.setItem('state:_types', JSON.stringify({ 'state:count:events:checks': 'number' }));
+	});
+
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await expect(page.locator('#content-wrapper')).toBeVisible({ timeout: 15_000 });
+
+	await expect(page.getByText('booting.', { exact: true })).toHaveCount(0);
+	expect(seedManifestRequests).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Treat existing static monitor/check caches as renderable state, even when bootstrap markers are missing.
- Skip build-seed and forced `sync:all-force` for cached resync cases; use cache hydration plus normal sync unless OPFS fallback/error or a true first visit requires full bootstrap.
- Update the current `getBootstrapRenderState` helper so cached data can render while seed/resync is in progress and the generic `booting.` fallback does not cover cached installs.
- Add unit coverage for the cache/bootstrap policy and a Chromium browser regression proving cached state does not show `booting.` or request `/seed/manifest.json`.

## Verification
- `pnpm --dir apps/gui test -- src/lib/stores/app-cache-state.test.ts src/lib/stores/boot-state.test.ts` (main worktree; Vitest ran 21 files / 300 tests)
- `pnpm --dir apps/gui lint` (main worktree)
- `pnpm --dir apps/gui exec playwright test tests/bootstrap-cache-gate.spec.ts --project=chromium --reporter=line` (main worktree)
- `pnpm --dir /tmp/nostr-watch-monitor-cache-pr/apps/gui lint` (clean PR worktree)
- `pnpm --dir /tmp/nostr-watch-monitor-cache-pr/apps/gui exec vitest run src/lib/utils/bootstrap-render-state.test.ts` (clean PR worktree)

## Known gaps
- Clean-worktree broad GUI test run is blocked before this patch's tests by missing local workspace package dist for `@nostrwatch/route66` and related dependencies.
- `pnpm --dir apps/gui check` still has unrelated baseline diagnostics; touched-file filtering now only shows the pre-existing `process/browser` declaration issue in `+layout.svelte`.
