### PR TITLE
Harden GUI iframe and external-link handling

### DIFF
--- a/apps/gui/src/lib/components/data-view/map/MapBasic.svelte
+++ b/apps/gui/src/lib/components/data-view/map/MapBasic.svelte
@@ -50,7 +50,7 @@
     {pointColor}
     clusterExpandOnClick={false}
     attribution={[
-      '<a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>',
+      '<a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">OpenStreetMap contributors</a>',
     ]}
     fitViewOnInit={true}
     fitViewOnUpdate={true}

--- a/apps/gui/src/lib/components/feeds/FeedNote.svelte
+++ b/apps/gui/src/lib/components/feeds/FeedNote.svelte
@@ -100,7 +100,7 @@
             <span class="">{timeAgo(note.created_at*1000)}</span>
         {/if} 
         | 
-        <a href="https://njump.me/{note.reference}" target="_blank">link</a>
+        <a href="https://njump.me/{note.reference}" target="_blank" rel="noopener noreferrer">link</a>
     </div>
     
     <div class="content text-black/55 dark:text-white/55 text-xl my-6 overflow-hidden overflow-ellipsis {noteClamp? `line-clamp-${noteClamp}` : ''}]">

--- a/apps/gui/src/lib/config/dataTable/operators.ts
+++ b/apps/gui/src/lib/config/dataTable/operators.ts
@@ -117,7 +117,7 @@ export const tableFormatters: Formatters = {
         // Nostr identifier guard — must be a bech32-style nostr id before
         // we interpolate into href. Anything else is rejected.
         if (!/^(npub|nprofile|nevent|note|naddr)1[a-z0-9]+$/i.test(reference)) return '-';
-        const referenceHtml = `<a href="https://njump.me/${escapeHtml(String(reference))}" target="_blank" class="text-sm underline">jump</a>`;
+        const referenceHtml = `<a href="https://njump.me/${escapeHtml(String(reference))}" target="_blank" rel="noopener noreferrer" class="text-sm underline">jump</a>`;
         return referenceHtml;
     },
     relaysCount: (relaysCount: number) => {

--- a/apps/gui/src/lib/utils/notes.test.ts
+++ b/apps/gui/src/lib/utils/notes.test.ts
@@ -104,6 +104,13 @@ describe('parseNote — XSS hardening — bare attack payloads (FEED-01)', () =>
         expect(out).not.toMatch(/<script\b/i);
         expect(out).not.toMatch(/onerror=/i);
     });
+
+    it('strips raw iframe navigation payloads from user-authored HTML', async () => {
+        const payload = '<iframe src="https://attacker.example/"></iframe>';
+        const out = await drain(parseNote(payload, CALLER_CONFIG));
+        expect(out).not.toMatch(/<iframe\b/i);
+        expect(out).not.toContain('attacker.example');
+    });
 });
 
 describe('parseNote — parseImages breakout (FEED-02)', () => {
@@ -224,10 +231,9 @@ describe('parseNote — preserves valid content', () => {
         // production embed could silently break and tests would still pass. We
         // lock the contract by asserting the iframe shape with src=.
         //
-        // GREEN constraint: applySanitize's ADD_ATTR list MUST include 'src'
-        // so DOMPurify preserves the iframe src attribute (default config
-        // strips <iframe> entirely; ADD_TAGS:['iframe'] re-allows the tag,
-        // but src is then stripped unless explicitly added to ADD_ATTR).
+        // GREEN constraint: raw <iframe> stays disallowed. YouTube survives only
+        // because replaceYoutubeLink stores a validated videoId behind a token
+        // before sanitize and restores an app-generated iframe after sanitize.
         // The iframe src is locked by replaceYoutubeLink's regex
         // (videoId = [a-zA-Z0-9_-]+) so no attacker input can reach it.
         expect(out).toMatch(/<iframe\b[^>]*\bsrc=["']https:\/\/www\.youtube\.com\/embed\/dQw4w9WgXcQ/);

--- a/apps/gui/src/lib/utils/notes.ts
+++ b/apps/gui/src/lib/utils/notes.ts
@@ -36,11 +36,12 @@ import { escapeHtml, safeImageUrl, sanitizeHtml } from '$lib/utils/sanitize';
  *
  * # YouTube iframe survival
  *
- * DOMPurify's default config strips <iframe>. replaceYoutubeLink emits an
- * <iframe> shape; we extend ALLOWED_TAGS at the applySanitize step to
- * preserve YouTube embeds. The src attribute is locked by the
- * replaceYoutubeLink regex (videoId = `[a-zA-Z0-9_-]+`) so no attacker
- * input can reach the iframe.
+ * DOMPurify's default config strips <iframe>. replaceYoutubeLink stores
+ * validated YouTube IDs behind per-parse tokens before markdown/sanitize;
+ * applySanitize restores only those app-generated tokens after DOMPurify
+ * removes raw user-authored iframes. The src attribute is locked by the
+ * replaceYoutubeLink regex (videoId = `[a-zA-Z0-9_-]+`) so no attacker input
+ * can reach the iframe.
  *
  * # Pipeline order (CONTEXT.md locked decision)
  *
@@ -191,15 +192,43 @@ function replaceAmpersand(text: string): string {
   return text.replace(/&;/g, `'`);
 }
 
-function replaceYoutubeLink(text: string): string {
-  const youtubeRegex = /(https?:\/\/(?:www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]+))/g;
-  if (!youtubeRegex.test(text)) return text;
-  // videoId is restricted to [a-zA-Z0-9_-]+ at the regex level — safe by
-  // construction. Still passes through DOMPurify at the final step (which
-  // is configured to allow <iframe> with a tight attribute allowlist).
-  return text.replace(youtubeRegex, (_match, _url, _domain, videoId) => {
-    return `<iframe width="100%" height="auto" src="https://www.youtube.com/embed/${videoId}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`;
-  });
+type YoutubeEmbed = {
+  token: string;
+  videoId: string;
+};
+
+const youtubeEmbedSrc = (videoId: string) => `https://www.youtube.com/embed/${videoId}`;
+
+function renderYoutubeEmbed(videoId: string): string {
+  return `<iframe width="100%" height="auto" src="${youtubeEmbedSrc(videoId)}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen referrerpolicy="strict-origin-when-cross-origin" sandbox="allow-scripts allow-same-origin allow-presentation"></iframe>`;
+}
+
+function createYoutubeEmbedTransforms() {
+  const embeds: YoutubeEmbed[] = [];
+  const nonce = Math.random().toString(36).slice(2);
+
+  const replaceYoutubeLink = (text: string): string => {
+    const youtubeRegex =
+      /(https?:\/\/(?:www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]+))/g;
+    if (!youtubeRegex.test(text)) return text;
+    // videoId is restricted to [a-zA-Z0-9_-]+ at the regex level. Store it
+    // behind a per-parse token so raw user-authored iframes are still stripped.
+    return text.replace(youtubeRegex, (_match, _url, _domain, videoId) => {
+      const token = `NWYTOKEN${nonce}${embeds.length}END`;
+      embeds.push({ token, videoId });
+      return token;
+    });
+  };
+
+  const restoreYoutubeEmbeds = (text: string): string => {
+    let out = text;
+    for (const { token, videoId } of embeds) {
+      out = out.split(token).join(renderYoutubeEmbed(videoId));
+    }
+    return out;
+  };
+
+  return { replaceYoutubeLink, restoreYoutubeEmbeds };
 }
 
 /**
@@ -281,25 +310,20 @@ async function applyMarkdown(text: string, options: MarkedOptions): Promise<stri
  * event handlers (onerror, onclick, ...), and javascript: / data:text/html
  * URLs from href / src.
  *
- * <iframe> survival: ADD_TAGS includes 'iframe' so replaceYoutubeLink's
- * embed survives. ADD_ATTR includes 'src' (in addition to 'allow',
- * 'allowfullscreen', 'frameborder', 'scrolling') so DOMPurify preserves
- * the src attribute on the iframe — without it, DOMPurify allows the
- * <iframe> tag but strips src, breaking the embed. The iframe src is
- * locked by replaceYoutubeLink's regex (videoId = [a-zA-Z0-9_-]+) so no
- * attacker input can reach the iframe. ALLOW_TAGS is NOT used (would
- * replace the default allowlist); ADD_TAGS / ADD_ATTR extend it.
+ * YouTube embed survival is intentionally not implemented by globally allowing
+ * <iframe>. replaceYoutubeLink converts validated YouTube URLs to per-parse
+ * tokens before markdown/DOMPurify, then applySanitize restores only those
+ * app-generated tokens after DOMPurify strips raw user-authored iframes.
  */
-function applySanitize(text: string): string {
-  return sanitizeHtml(text, {
-    ADD_TAGS: ['iframe'],
-    ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder', 'scrolling', 'src'],
-  });
+function applySanitize(text: string, restoreYoutubeEmbeds?: (text: string) => string): string {
+  const sanitized = sanitizeHtml(text);
+  return restoreYoutubeEmbeds ? restoreYoutubeEmbeds(sanitized) : sanitized;
 }
 
 export function parseNote(input: string, config: ParseConfig = defaultConfig): Writable<string> {
   const store = writable<string>(input);
   const parser = new Parser();
+  const youtubeEmbeds = createYoutubeEmbedTransforms();
 
   // ---- Sync stage (in CONTEXT.md-locked order) ----
   if (config.images) parser.addSync(parseImages);
@@ -307,7 +331,7 @@ export function parseNote(input: string, config: ParseConfig = defaultConfig): W
   if (config.removeHashtags) parser.addSync(removeHashtags);
   if (config.truncate) parser.addSync((s: string) => truncateText(s, config.truncateLength!));
   if (config.replaceAmpersand) parser.addSync(replaceAmpersand);
-  parser.addSync(replaceYoutubeLink);
+  parser.addSync(youtubeEmbeds.replaceYoutubeLink);
 
   const syncOut = parser.applySync(input);
   store.set(syncOut);
@@ -324,7 +348,7 @@ export function parseNote(input: string, config: ParseConfig = defaultConfig): W
   // config.sanitize field is preserved for back-compat (the 4 callers
   // literally pass `sanitize: false`) but it is now a no-op — the
   // pipeline always appends applySanitize.
-  parser.addAsync(async (text: string) => applySanitize(text));
+  parser.addAsync(async (text: string) => applySanitize(text, youtubeEmbeds.restoreYoutubeEmbeds));
 
   // Drain the sequential pipeline; emit on the writable store.
   parser

--- a/apps/gui/src/lib/utils/v2.5-xss-smoke.test.ts
+++ b/apps/gui/src/lib/utils/v2.5-xss-smoke.test.ts
@@ -16,7 +16,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { tick } from 'svelte';
-import { readFileSync } from 'fs';
+import { readFileSync, readdirSync, statSync } from 'fs';
 import { resolve } from 'path';
 import { get, writable, type Readable } from 'svelte/store';
 import { safeHttpUrl, safeImageUrl } from './sanitize';
@@ -63,6 +63,20 @@ const BANNER_SINK_FILES = [
  */
 function stripHtmlComments(source: string): string {
     return source.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+function sourceFiles(dir: string): string[] {
+    const files: string[] = [];
+    for (const entry of readdirSync(dir)) {
+        const path = resolve(dir, entry);
+        const stat = statSync(path);
+        if (stat.isDirectory()) {
+            files.push(...sourceFiles(path));
+        } else if (/\.(svelte|ts)$/.test(path) && !/\.test\.ts$/.test(path)) {
+            files.push(path);
+        }
+    }
+    return files;
 }
 
 /**
@@ -132,6 +146,22 @@ describe('v2.5 XSS milestone canary', () => {
         // Positive anchor: the safe wrapper `safePaymentsUrl` MUST appear in href context.
         // Real binding shape at CardFees.svelte:61 is `href="{safePaymentsUrl}"`.
         expect(live).toMatch(/href\s*=\s*["']?\{safePaymentsUrl\}/);
+    });
+
+    it('all target="_blank" links isolate the opener tab', () => {
+        const offenders: string[] = [];
+
+        for (const file of sourceFiles(APPS_GUI_SRC)) {
+            const live = stripHtmlComments(readFileSync(file, 'utf8'));
+            for (const match of live.matchAll(/<[^>]*target=["']_blank["'][^>]*>/gi)) {
+                const tag = match[0];
+                if (!/\brel=["'][^"']*\bnoopener\b/.test(tag)) {
+                    offenders.push(`${file.replace(`${APPS_GUI_SRC}/`, '')}: ${tag}`);
+                }
+            }
+        }
+
+        expect(offenders).toEqual([]);
     });
 
     // -------------------------------------------------------------------------

--- a/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardFees.svelte
+++ b/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardFees.svelte
@@ -59,7 +59,8 @@
                     size="lg"
                     class="text-lg py-1.5 font-mono inline-block gradient-orange" 
                     href="{safePaymentsUrl}"
-                    target="_blank">
+                    target="_blank"
+                    rel="noopener noreferrer">
                     purchase access
                 </Button>
                 {/if}
@@ -81,59 +82,3 @@
         </Card.Footer>            
     </Card.Root>
 {/if}
-
-<!-- 
-{#if keysLength > 0}
-<Card.Root class="relay-card">
-    <Card.Header>
-        <Card.Title>Fee Schedule</Card.Title>  
-        <Card.Description></Card.Description>
-    </Card.Header>  
-    <Card.Content>
-        {#if fees && type === 'object'}
-        {#each Object.entries(fees as FeesObject) as [key, keyfees]}
-        <h2>{capitalize(key)}</h2>
-        <Table.Root>
-            <Table.Header>
-                <Table.Row>
-                    <Table.Head>
-                        Amount
-                    </Table.Head>
-                    <Table.Head>
-                        Unit
-                    </Table.Head>
-                    <Table.Head>
-                        Period
-                    </Table.Head>
-                </Table.Row>
-            </Table.Header>
-            <Table.Body>
-                {#if keyfees}
-                {#each (keyfees as FeesArray[]) as fee}                
-                <Table.Row>
-                    <Table.Cell>
-                        {fee.amount}
-                    </Table.Cell>
-                    <Table.Cell>
-                        {fee.unit}
-                    </Table.Cell>
-                    <Table.Cell>
-                        {fee?.period? formatSeconds(fee?.period): 'n/a'}
-                    </Table.Cell>
-                </Table.Row>
-                {/each}
-                {/if}
-            </Table.Body>
-        </Table.Root>
-        {/each}
-        {/if}
-    </Card.Content>
-    <Card.Footer>
-        {#if paymentUrl}
-        <Button class="bg-orange-400 hover:bg-orange-500" href="{paymentUrl}" target="_blank">
-            Purchase Access
-        </Button>
-        {/if}
-    </Card.Footer>
-</Card.Root>
-{/if} -->

--- a/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardNips.svelte
+++ b/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardNips.svelte
@@ -71,7 +71,10 @@
                 {#each chunk as nip}
                     <Table.Row>
                     <Table.Cell>
-                        <a target="_blank" href="https://github.com/nostr-protocol/nips/blob/master/{nipLeadingZero(nip)}.md" 
+                        <a
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            href="https://github.com/nostr-protocol/nips/blob/master/{nipLeadingZero(nip)}.md"
                             class="font-bold text-black/80 hover:text-black/90 py-1 px-2 bg-black/5 dark:bg-white/10 rounded-sm  dark:text-white/70">
                             {formatNip(nip)}
                         </a>
@@ -82,15 +85,6 @@
                 </Table.Body>
             </Table.Root>
             {/each}
-            <!-- {#each supportedNips as nip}
-                <span class="block mb-2">
-                    <a target="_blank" href="https://github.com/nostr-protocol/nips/blob/master/{nipLeadingZero(nip)}.md" 
-                        class="font-bold text-black/80 hover:text-black/90 py-1 px-2 bg-black/5 dark:bg-white/10 rounded-sm  dark:text-white/70">
-                        {formatNip(nip)}
-                    </a>
-                    <span class="text-black/70 dark:text-white/70">{ $NIP_NAMES[ nipLeadingZero(nip).toString() ] }</span>
-                </span>
-            {/each} -->
             {/if}
         </div>
     </Card.Content>


### PR DESCRIPTION
## Summary

- Reject raw user-authored iframe elements while preserving validated app-generated YouTube embeds.
- Add explicit noopener/noreferrer isolation to every literal target=_blank GUI link.
- Add regression coverage for raw iframe stripping and opener isolation.
- Remove obsolete commented link/card markup from the touched relay cards.

## Security rationale

The note sanitizer previously extended the global DOMPurify policy to allow iframe elements so YouTube embeds could survive. That also allowed user-authored iframe content through the same policy. This change tokenizes validated YouTube IDs before sanitization and restores only app-generated sandboxed embeds afterward.

## Verification

- pnpm --dir apps/gui exec vitest run src/lib/utils/notes.test.ts src/lib/utils/sanitize.test.ts src/lib/utils/v2.5-xss-smoke.test.ts: 84 tests passed
- pnpm --dir apps/gui test: 306 tests passed
- pnpm --dir apps/gui lint: passed
- pnpm --filter @nostrwatch/gui... build: passed
- git diff origin/next...HEAD --check: passed

## Remaining risk

Interactive YouTube playback under the new iframe sandbox attributes was not browser-tested; preservation and generated markup are covered by unit tests.