### PR TITLE
Harden formatted GUI HTML with native Sanitizer API

### DIFF
--- a/apps/gui/src/lib/components/data-view/filters/DataViewFilters.svelte
+++ b/apps/gui/src/lib/components/data-view/filters/DataViewFilters.svelte
@@ -25,6 +25,7 @@
 	import SavePreset from './SavePreset.svelte';
 	import { throttledDerived } from '$utils/stores.js';
 	import { delay } from '@nostrwatch/utils';
+	import { sanitizedHtml } from '$utils/sanitize';
 
     // **Props Passed to the Component**
     export let dataKey: string;
@@ -745,7 +746,7 @@
                                         disabled={$disabledFilters[filter.key]?.has(String(value).toLowerCase())}
                                     >
                                         {#if $config.filterFormatters?.[filter.key]}
-                                            {@html $config.filterFormatters[filter.key](value)}
+                                            <span use:sanitizedHtml={$config.filterFormatters[filter.key](value)}></span>
                                         {:else}
                                             {value}
                                         {/if}

--- a/apps/gui/src/lib/components/data-view/table/DataTable.svelte
+++ b/apps/gui/src/lib/components/data-view/table/DataTable.svelte
@@ -24,6 +24,7 @@
 	import Loading from '$lib/components/partials/Loading.svelte';
 	import RelayLivenessCounts from '$lib/components/partials/RelayLivenessCounts.svelte';
 	import DataViewTopBar from './DataViewTopBar.svelte';
+	import { sanitizedHtml } from '$utils/sanitize';
 
     export let dataKey: string;
     export let data: Readable<any[]>;
@@ -328,7 +329,7 @@
                             <Table.Cell>
                                 <div class="max-w-full truncate">
                                     {#if $config.tableFormatters?.[column.key]}
-                                        {@html $config.tableFormatters[column.key](row[column.key], row)}
+                                        <div use:sanitizedHtml={$config.tableFormatters[column.key](row[column.key], row)}></div>
                                     {:else}
                                         {row[column.key]}
                                     {/if}

--- a/apps/gui/src/lib/components/feeds/FeedNote.svelte
+++ b/apps/gui/src/lib/components/feeds/FeedNote.svelte
@@ -11,6 +11,7 @@
 	import FeedNoteZaps from './FeedNoteZaps.svelte';
 	import FeedNoteReactions from './FeedNoteReactions.svelte';
 	import { fade, fly } from 'svelte/transition';
+	import { sanitizedHtml } from '$utils/sanitize';
 
     export let note: NostrEvent;
     export let index: number = 0;
@@ -103,9 +104,10 @@
         <a href="https://njump.me/{note.reference}" target="_blank" rel="noopener noreferrer">link</a>
     </div>
     
-    <div class="content text-black/55 dark:text-white/55 text-xl my-6 overflow-hidden overflow-ellipsis {noteClamp? `line-clamp-${noteClamp}` : ''}]">
-        {@html $content}
-    </div>
+    <div
+        class="content text-black/55 dark:text-white/55 text-xl my-6 overflow-hidden overflow-ellipsis {noteClamp? `line-clamp-${noteClamp}` : ''}]"
+        use:sanitizedHtml={{ html: $content, allowYoutubeEmbeds: true }}
+    ></div>
     <div class="actions flex mt-2 hover:opacity-100 {actionsClass} min-h-6">
         <div class="flex-grow">
             
@@ -151,19 +153,19 @@
         @apply leading-8;
     }
 
-    .note > .content > p {
+    .note > .content :global(p) {
         margin-bottom: 10px;
     }
-    .note > .content > ul {
+    .note > .content :global(ul) {
         @apply p-2;
     }
 
-    .note > .content > ul > li {
+    .note > .content :global(ul > li) {
         @apply list-decimal list-item mb-4 list-inside leading-6 text-lg;
         padding: 5px;
     }
 
-    .note > .content pre {
+    .note > .content :global(pre) {
         display:none;
     }
 

--- a/apps/gui/src/lib/components/feeds/FeedNoteContent.svelte
+++ b/apps/gui/src/lib/components/feeds/FeedNoteContent.svelte
@@ -4,6 +4,7 @@
 	import { onMount } from "svelte";
 	import { writable, type Writable } from "svelte/store";
 	import Reader from "../modal/Reader.svelte";
+	import { sanitizedHtml } from "$utils/sanitize";
 
     export let note: NostrEvent;
     export let useReaderModal: boolean = false;
@@ -29,5 +30,5 @@
 {#if useReaderModal && $content}
     <Reader readerContent={content} {readerTitle} />
 {:else}
-    {@html $content}
+    <div use:sanitizedHtml={{ html: $content, allowYoutubeEmbeds: true }}></div>
 {/if}

--- a/apps/gui/src/lib/components/layout/PageHeader.svelte
+++ b/apps/gui/src/lib/components/layout/PageHeader.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 
     import { clickToCopy } from "$utils/ux";
-    import { safeImageUrl, sanitizeHtml } from "$utils/sanitize";
+    import { safeImageUrl, sanitizedHtml } from "$utils/sanitize";
     import { bannerStyleString } from "$utils/style-helpers";
 
     export let title: string;
@@ -22,12 +22,6 @@
 
     // Validate the relay-controlled icon URL before binding it to <img src>.
     $: safeIcon = safeImageUrl(icon);
-
-    // Most callers pass plain text (e.g. NIP-11 description). The
-    // /relays/software/[softwareKey] page passes pre-formatted HTML, so we
-    // sanitize via DOMPurify rather than dropping {@html} entirely.
-    // sanitize() defaults strip script tags and event-handler attributes.
-    $: safeSubtitle = sanitizeHtml(subtitle);
 
 </script>
 <header
@@ -65,7 +59,7 @@
           {/if}
         </h1>
         {#if subtitle}
-            <span class="ml-3 text-lg block">{@html safeSubtitle}</span>
+            <span class="ml-3 text-lg block" use:sanitizedHtml={subtitle}></span>
         {/if}
         <slot />
       </div>

--- a/apps/gui/src/lib/components/lists/table/DataTable.svelte
+++ b/apps/gui/src/lib/components/lists/table/DataTable.svelte
@@ -23,6 +23,7 @@
 	import { bannerStyleString } from '$utils/style-helpers';
 	import { randomLoadingMessage } from '$utils/ux';
 	import Loading from '$lib/components/partials/Loading.svelte';
+	import { sanitizedHtml } from '$utils/sanitize';
 
     export let dataKey: string;
     export let data: Readable<any[]>;
@@ -354,7 +355,7 @@
                                         <Table.Cell class="font-mono">
                                             <div class="max-w-full truncate">
                                                 {#if $config.tableFormatters?.[column.key]}
-                                                    {@html $config.tableFormatters[column.key](row[column.key], row)}
+                                                    <div use:sanitizedHtml={$config.tableFormatters[column.key](row[column.key], row)}></div>
                                                 {:else}
                                                     {row[column.key]}
                                                 {/if}

--- a/apps/gui/src/lib/components/lists/table/Filters.svelte
+++ b/apps/gui/src/lib/components/lists/table/Filters.svelte
@@ -20,6 +20,7 @@
 	import FilterOptions from './FilterOptions.svelte';
 
     import type { DataTableConfig, Formatters } from './DataTableTypes';
+	import { sanitizedHtml } from '$utils/sanitize';
 
     // **Props Passed to the Component**
     export let dataKey: string;
@@ -718,7 +719,7 @@
                                         disabled={$disabledFilters[filter.key]?.has(String(value).toLowerCase())}
                                     >
                                         {#if $config.filterFormatters?.[filter.key]}
-                                            {@html $config.filterFormatters[filter.key](value)}
+                                            <span use:sanitizedHtml={$config.filterFormatters[filter.key](value)}></span>
                                         {:else}
                                             {value}
                                         {/if}

--- a/apps/gui/src/lib/components/modal/Reader.svelte
+++ b/apps/gui/src/lib/components/modal/Reader.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-    import * as Dialog from "$lib/components/ui/dialog"
 	import Button from "$ui/button/button.svelte";
 	import { parseNote } from "$utils/notes";
 	import type { NostrEvent } from "@nostrwatch/route66/models";
 	import { onMount } from "svelte";
 	import { writable, type Readable, type Writable } from "svelte/store";
+	import { sanitizedHtml } from "$utils/sanitize";
     
 
     const showReader: Writable<boolean> = writable(false);
@@ -64,7 +64,10 @@
 
 {#if showSummary}
 <section class="reader-content line-clamp-6 relative">
-    {@html $content}
+    <div
+        class="reader-content-body"
+        use:sanitizedHtml={{ html: $content, allowYoutubeEmbeds: true }}
+    ></div>
     <div class="absolute bottom-0 right-0 left-0 bg-gradient-to-t from-{gradientColor} h-20"></div>
 </section>
 {/if}
@@ -92,37 +95,24 @@
         </a>
     </h2>
     {/if}
-    <section class="reader-content">
-        {@html $content}
-    </section>
+    <section
+        class="reader-content"
+        use:sanitizedHtml={{ html: $content, allowYoutubeEmbeds: true }}
+    ></section>
 </section>
-
-<!-- <Dialog.Root>
-    <Dialog.Trigger>{triggerText}</Dialog.Trigger>
-    <Dialog.Content class="w-3/4">
-      <Dialog.Header>
-        {#if readerTitle}
-          <Dialog.Title>{readerTitle}</Dialog.Title>
-        {/if}
-        <Dialog.Description>
-        <section class="reader-content">
-            {@html $readerContent}
-        </section>
-        </Dialog.Description>
-      </Dialog.Header>
-    </Dialog.Content>
-</Dialog.Root> -->
 
 <style lang="postcss" global>
     .reader-content {
         @apply p-4 text-xl overflow-y-scroll max-w-[750px] m-auto opacity-80;
     }
 
-    .reader-content > h2 {
+    .reader-content > h2,
+    .reader-content > .reader-content-body > h2 {
         @apply text-2xl mb-5 border-b-[1px] border-white/50 pb-4 mt-10;
     }
 
-    .reader-content > * {
+    .reader-content > *,
+    .reader-content > .reader-content-body > * {
         @apply text-left;
     }
 
@@ -130,7 +120,8 @@
         @apply leading-10 ;
     }
 
-    .reader-content > p {
+    .reader-content > p,
+    .reader-content > .reader-content-body > p {
         @apply block my-5;
     }
 

--- a/apps/gui/src/lib/components/partials/JsonHighlighter.svelte
+++ b/apps/gui/src/lib/components/partials/JsonHighlighter.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
-    // import { onMount } from 'svelte';
-    import { JsonHighlighter, type AjvResult } from '$lib/utils/JsonHighlighter.js';
-  
-    export let jsonString: string = '';
-    export let ajvResult: AjvResult = { errors: [] };
-  
-    let highlightedHtml = '';  
-    $: highlightedHtml = JsonHighlighter.highlight(jsonString, ajvResult);
-  </script>
-  
-  {@html highlightedHtml}
-  
-  <style></style>
-  
+  import { JsonHighlighter, type AjvResult } from '$lib/utils/JsonHighlighter.js';
+  import { sanitizedHtml } from '$utils/sanitize';
+
+  export let jsonString: string = '';
+  export let ajvResult: AjvResult = { errors: [] };
+
+  let highlightedHtml = '';
+  $: highlightedHtml = JsonHighlighter.highlight(jsonString, ajvResult);
+</script>
+
+<div use:sanitizedHtml={highlightedHtml}></div>
+
+<style></style>

--- a/apps/gui/src/lib/utils/html-sink-audit.test.ts
+++ b/apps/gui/src/lib/utils/html-sink-audit.test.ts
@@ -1,31 +1,10 @@
 /**
- * Cross-cutting {@html} audit — TEST-06.
+ * Cross-cutting HTML insertion audit.
  *
- * Walks every .svelte file in apps/gui/src and asserts every `{@html EXPR}`
- * matches a known-safe whitelist pattern. A new `{@html}` sink that doesn't
- * fit one of the whitelisted shapes fails this test loudly with a clear
- * "must be added to whitelist with security justification" message.
- *
- * The whitelist is INTENTIONALLY narrow. Adding an entry requires a written
- * security justification in code review. The whitelist should shrink, not
- * grow, as MIGR-01 (formatter migration to Svelte components, deferred to
- * v2.6+ as AUDIT-01) progresses.
- *
- * Inventory at v2.5 close (11 LIVE sinks; HTML comments stripped before walk):
- *   - PageHeader: safeSubtitle (Phase 24)                                — 1
- *   - 3 feed components: $content (Phase 28 DOMPurify)                    — 3
- *     (FeedNoteContent, FeedNote, Reader x1)
- *   - Reader: $content (second sink)                                      — 1
- *   - CardLimitation: $NIP_11_LIMITATIONS?.[key] (static dict)            — 1
- *   - JsonHighlighter: highlightedHtml (local escapeHtml)                 — 1
- *   - 2 DataTables: $config.tableFormatters[column.key](...) (#899/#900)  — 2
- *   - 2 Filters: $config.filterFormatters[filter.key](value) (#899/#900)  — 2
- *
- * Note: a third Reader `{@html $readerContent}` exists at Reader.svelte:110
- * but is wrapped in an `<!-- ... -->` comment block (dead Dialog code, lines
- * 101-115). The walker strips HTML comments before counting, matching the
- * live runtime surface — 11 sinks. The `$readerContent` whitelist entry stays
- * in case the dead-code block is re-enabled in the future.
+ * Raw Svelte `{@html}` delegates insertion to framework-owned `innerHTML`.
+ * Every formatted HTML surface must instead use the `sanitizedHtml` action,
+ * which prefers the browser-native Sanitizer API and has a DOMPurify fragment
+ * fallback for browsers without `Element.setHTML()`.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -35,29 +14,10 @@ import { resolve, join, relative } from 'path';
 // apps/gui/src — resolved relative to this file (apps/gui/src/lib/utils/...)
 const APPS_GUI_SRC = resolve(__dirname, '../..');
 
-// Capture the EXPR inside `{@html EXPR}`. `[^}]+` is fine — Svelte `{@html}`
-// cannot contain a literal `}` in the expression because it terminates the
-// directive.
 const HTML_SINK_RE = /\{@html\s+([^}]+)\}/g;
-
-const WHITELIST_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
-    { pattern: /^safeSubtitle$/, reason: 'PageHeader — wrapped via Phase 24 safe* helper' },
-    { pattern: /^\$content$/, reason: 'parseNote-produced store — Phase 28 always-on DOMPurify' },
-    { pattern: /^\$readerContent$/, reason: 'Reader alt path — same parseNote sanitization' },
-    {
-        pattern: /^\$NIP_11_LIMITATIONS\?\.\[key\](\s*\|\|\s*['"][^'"]*['"])?$/,
-        reason: 'CardLimitation — static dictionary lookup, no relay input',
-    },
-    { pattern: /^highlightedHtml$/, reason: 'JsonHighlighter — local escapeHtml on every value' },
-    {
-        pattern: /^\$config\.tableFormatters\[column\.key\]\(row\[column\.key\],\s*row\)$/,
-        reason: 'DataTable cells — registered formatters, encode-on-output safe (#899/#900)',
-    },
-    {
-        pattern: /^\$config\.filterFormatters\[filter\.key\]\(value\)$/,
-        reason: 'Filters — registered formatters, encode-on-output safe (#899/#900)',
-    },
-];
+const SANITIZED_HTML_ACTION_RE = /\buse:sanitizedHtml(?:\s|=|>)/g;
+const DIRECT_HTML_WRITE_RE =
+    /\.(?:innerHTML|outerHTML)\s*=|\.insertAdjacentHTML\s*\(|document\.write\s*\(|\.setHTMLUnsafe\s*\(/g;
 
 function walkSourceFiles(dir: string, ext: RegExp): string[] {
     const out: string[] = [];
@@ -75,7 +35,7 @@ function walkSourceFiles(dir: string, ext: RegExp): string[] {
 }
 
 describe('html-sink audit', () => {
-    it('every {@html EXPR} across apps/gui/src/**/*.svelte matches a known-safe whitelist', () => {
+    it('contains no live Svelte {@html} insertion sinks', () => {
         const allSvelte = walkSourceFiles(APPS_GUI_SRC, /\.svelte$/);
         const offenders: Array<{ file: string; expr: string }> = [];
 
@@ -84,50 +44,65 @@ describe('html-sink audit', () => {
             // Strip HTML comments so commented-out `{@html ...}` examples / dead
             // code blocks don't trigger the walker.
             const live = source.replace(/<!--[\s\S]*?-->/g, '');
-            HTML_SINK_RE.lastIndex = 0; // reset regex state across files
+            HTML_SINK_RE.lastIndex = 0;
             let match: RegExpExecArray | null;
             while ((match = HTML_SINK_RE.exec(live)) !== null) {
-                const trimmed = match[1].trim();
-                const ok = WHITELIST_PATTERNS.some(({ pattern }) => pattern.test(trimmed));
-                if (!ok) {
-                    offenders.push({ file: relative(APPS_GUI_SRC, fullPath), expr: trimmed });
-                }
+                offenders.push({
+                    file: relative(APPS_GUI_SRC, fullPath),
+                    expr: match[1].trim(),
+                });
             }
         }
 
         expect(
             offenders,
-            `Unknown {@html} sinks (must be added to whitelist with security justification):\n${offenders
+            `Raw {@html} sinks must use the sanitizedHtml action instead:\n${offenders
                 .map((o) => `  ${o.file}: ${o.expr}`)
                 .join('\n')}`
         ).toEqual([]);
     });
 
-    it('v2.5 inventory contains at least 11 live {@html} sinks', () => {
-        // Locks the LIVE inventory floor at v2.5 close. HTML comments are
-        // stripped before counting (matches the runtime surface — dead-code
-        // sinks like Reader.svelte:110 inside <!-- ... --> are not rendered).
-        //
-        // A future contributor REMOVING a live sink (shrinking the canary
-        // surface) will fail this test, prompting an explicit decision to
-        // lower the floor. ADDING a new sink without whitelist coverage is
-        // still caught by the first test above.
-        //
-        // The plan-time inventory listed 13 (counting the commented-out
-        // $readerContent at Reader.svelte:110). Live count is now 11 after
-        // removing the unused masonry feed path.
+    it('migrates the previous 11-sink inventory to sanitizedHtml actions', () => {
         const allSvelte = walkSourceFiles(APPS_GUI_SRC, /\.svelte$/);
-        let totalSinkCount = 0;
+        let actionCount = 0;
 
         for (const fullPath of allSvelte) {
             const source = readFileSync(fullPath, 'utf8');
             const live = source.replace(/<!--[\s\S]*?-->/g, '');
-            HTML_SINK_RE.lastIndex = 0;
-            const matches = live.match(HTML_SINK_RE);
-            if (matches) totalSinkCount += matches.length;
+            SANITIZED_HTML_ACTION_RE.lastIndex = 0;
+            actionCount += live.match(SANITIZED_HTML_ACTION_RE)?.length ?? 0;
         }
 
-        expect(totalSinkCount).toBeGreaterThanOrEqual(11);
+        expect(actionCount).toBeGreaterThanOrEqual(11);
+    });
+
+    it('contains no direct unsafe DOM HTML writes', () => {
+        const sourceFiles = walkSourceFiles(APPS_GUI_SRC, /\.(?:svelte|[cm]?[jt]s)$/).filter(
+            (file) => !/\.(?:test|spec)\.[cm]?[jt]s$/.test(file)
+        );
+        const offenders: Array<{ file: string; expression: string }> = [];
+
+        for (const fullPath of sourceFiles) {
+            const source = stripJsComments(readFileSync(fullPath, 'utf8')).replace(
+                /<!--[\s\S]*?-->/g,
+                ''
+            );
+            DIRECT_HTML_WRITE_RE.lastIndex = 0;
+            let match: RegExpExecArray | null;
+            while ((match = DIRECT_HTML_WRITE_RE.exec(source)) !== null) {
+                offenders.push({
+                    file: relative(APPS_GUI_SRC, fullPath),
+                    expression: match[0],
+                });
+            }
+        }
+
+        expect(
+            offenders,
+            `Unsafe DOM HTML writes must use setSanitizedHtml instead:\n${offenders
+                .map((o) => `  ${o.file}: ${o.expression}`)
+                .join('\n')}`
+        ).toEqual([]);
     });
 });
 

--- a/apps/gui/src/lib/utils/sanitize.ts
+++ b/apps/gui/src/lib/utils/sanitize.ts
@@ -12,8 +12,8 @@ import createDOMPurify, {
  * kind:0 metadata field, kind:1 note content, or any other relay-controlled
  * string reaches a Svelte template. Encode at the sink, not at the data layer.
  *
- * The DataTable layer renders cell contents via `{@html ...}` (see
- * apps/gui/src/lib/components/data-view/table/DataTable.svelte). Many of the
+ * The DataTable layer renders formatted cell contents through the
+ * `sanitizedHtml` action. Many of the
  * formatters in `apps/gui/src/lib/config/dataTable/*.ts` build HTML strings
  * that interpolate fields a relay operator controls (icon, banner, name,
  * description, photo, pubkey, paymentsUrl). Without escaping, a malicious
@@ -67,26 +67,12 @@ import createDOMPurify, {
  *   - `apps/gui/src/lib/utils/html-sink-audit.test.ts`                         — cross-cutting `{@html}` walker
  *   - `apps/gui/src/lib/utils/cardinsights-relayfeeitem-adversarial.test.ts`   — function-level CARD-02/03 smoke
  *
- * # Deferred AUDIT-01 (formatter migration)
+ * # HTML insertion boundary
  *
- * AUDIT-01 — replace the HTML-string formatters in
- * `apps/gui/src/lib/config/dataTable/*.ts` with Svelte components and drop
- * `{@html}` from `DataTable.svelte` and `PageHeader.svelte` — is FORMALLY
- * DEFERRED to v2.6+. v2.5 closed every live vector via encode-on-output
- * discipline; the dataTable formatters are encode-on-output safe today
- * (verified by #899/#900 tests + the html-sink-audit canary). Migration to
- * Svelte components is a larger refactor (5+ formatter files, hundreds of
- * HTML-string emissions per file, plus DataTable / PageHeader internals);
- * the right time is when there's a separate UI/styling milestone that
- * touches DataTable anyway.
- *
- * The deferral is recorded in `.planning/PROJECT.md` Key Decisions:
- *   "Defer AUDIT-01 (formatter migration to Svelte components) to v2.6+"
- *
- * When AUDIT-01 lands, this entire `sanitize.ts` module can be deleted.
- * Until then, the cross-cutting `{@html}` walker (html-sink-audit.test.ts)
- * is the canary that catches new sinks added without going through one
- * of these helpers.
+ * All formatted HTML is inserted through `sanitizedHtml`. Firefox 148+
+ * uses the browser-native Sanitizer API through `Element.setHTML()`; other
+ * browsers receive a DOMPurify-produced `DocumentFragment`. The structural
+ * audit rejects any new raw Svelte `{@html}` sink.
  *
  * # Module exports
  *
@@ -103,12 +89,8 @@ import createDOMPurify, {
  *                        breakout char set as `safeImageUrl`. Use at
  *                        `<a href>` / `<Button href>` sinks.
  *
- * Use these helpers at every {@html} sink that interpolates relay-controlled
- * data. The intent is encode-on-output at the formatter, not at the data layer.
- *
- * FOLLOW-UP: see "# Deferred AUDIT-01 (formatter migration)" above and
- * the corresponding row in `.planning/PROJECT.md` Key Decisions. Once
- * AUDIT-01 lands in v2.6+, this entire module can be deleted.
+ * Use these helpers when HTML strings interpolate relay-controlled data, then
+ * insert the completed string with `sanitizedHtml` for defense in depth.
  */
 
 // Module-private: single source of truth for the URL/CSS attribute breakout
@@ -216,13 +198,156 @@ function getDomPurify(): DOMPurifyInstance | undefined {
 }
 
 /**
- * Sanitize HTML for the remaining `{@html}` sinks that intentionally render
- * formatted relay-controlled content. In SSR/no-window contexts DOMPurify
- * cannot build a DOM-backed sanitizer, so fail closed by entity-escaping.
+ * Sanitize an HTML string before further processing. In SSR/no-window contexts
+ * DOMPurify cannot build a DOM-backed sanitizer, so fail closed by
+ * entity-escaping.
  */
 export function sanitizeHtml(input: unknown, config?: Config): string {
     if (typeof input !== 'string') return '';
     const purifier = getDomPurify();
     if (!purifier || typeof purifier.sanitize !== 'function') return escapeHtml(input);
     return purifier.sanitize(input, config);
+}
+
+const ACTIVE_CONTENT_ELEMENTS = [
+    'base',
+    'button',
+    'embed',
+    'form',
+    'frame',
+    'iframe',
+    'input',
+    'link',
+    'meta',
+    'object',
+    'script',
+    'select',
+    'style',
+    'textarea',
+];
+
+const YOUTUBE_EMBED_RE = /<iframe width="100%" height="auto" src="https:\/\/www\.youtube\.com\/embed\/([A-Za-z0-9_-]+)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen referrerpolicy="strict-origin-when-cross-origin" sandbox="allow-scripts allow-same-origin allow-presentation"><\/iframe>/g;
+const YOUTUBE_SLOT_CLASS = 'nw-youtube-embed-slot';
+
+type SanitizedHtmlOptions = {
+    html: unknown;
+    allowYoutubeEmbeds?: boolean;
+};
+
+type NativeSanitizingElement = HTMLElement & {
+    setHTML?: (
+        input: string,
+        options?: { sanitizer: { removeElements: string[] } }
+    ) => void;
+};
+
+function normalizedOptions(value: unknown): Required<SanitizedHtmlOptions> {
+    if (
+        typeof value === 'object' &&
+        value !== null &&
+        Object.prototype.hasOwnProperty.call(value, 'html')
+    ) {
+        const options = value as SanitizedHtmlOptions;
+        return {
+            html: typeof options.html === 'string' ? options.html : '',
+            allowYoutubeEmbeds: options.allowYoutubeEmbeds === true,
+        };
+    }
+
+    return {
+        html: typeof value === 'string' ? value : '',
+        allowYoutubeEmbeds: false,
+    };
+}
+
+function prepareYoutubeSlots(html: string, allowYoutubeEmbeds: boolean): string {
+    if (!allowYoutubeEmbeds) return html;
+    return html.replace(
+        YOUTUBE_EMBED_RE,
+        (_match, videoId: string) =>
+            `<span class="${YOUTUBE_SLOT_CLASS}" data-nw-youtube-id="${videoId}"></span>`
+    );
+}
+
+function insertWithDomPurify(node: HTMLElement, html: string): void {
+    const purifier = getDomPurify();
+    if (!purifier || typeof purifier.sanitize !== 'function') {
+        node.textContent = html;
+        return;
+    }
+
+    const fragment = purifier.sanitize(html, {
+        ADD_ATTR: ['target'],
+        FORBID_TAGS: ACTIVE_CONTENT_ELEMENTS,
+        RETURN_DOM_FRAGMENT: true,
+    }) as DocumentFragment;
+    node.replaceChildren(fragment);
+}
+
+function normalizeInsertedLinks(node: HTMLElement): void {
+    for (const link of node.querySelectorAll<HTMLAnchorElement>('a[target]')) {
+        if (link.target.toLowerCase() !== '_blank') {
+            link.removeAttribute('target');
+            continue;
+        }
+
+        const rel = new Set(link.rel.split(/\s+/).filter(Boolean));
+        rel.add('noopener');
+        rel.add('noreferrer');
+        link.rel = [...rel].join(' ');
+    }
+}
+
+function restoreYoutubeEmbeds(node: HTMLElement, allowYoutubeEmbeds: boolean): void {
+    const slots = node.querySelectorAll<HTMLElement>(`.${YOUTUBE_SLOT_CLASS}`);
+    for (const slot of slots) {
+        const videoId = slot.dataset.nwYoutubeId;
+        if (!allowYoutubeEmbeds || !videoId || !/^[A-Za-z0-9_-]+$/.test(videoId)) {
+            slot.remove();
+            continue;
+        }
+
+        const iframe = document.createElement('iframe');
+        iframe.width = '100%';
+        iframe.height = 'auto';
+        iframe.src = `https://www.youtube.com/embed/${videoId}`;
+        iframe.setAttribute('frameborder', '0');
+        iframe.allow =
+            'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+        iframe.setAttribute('allowfullscreen', '');
+        iframe.referrerPolicy = 'strict-origin-when-cross-origin';
+        iframe.setAttribute(
+            'sandbox',
+            'allow-scripts allow-same-origin allow-presentation'
+        );
+        slot.replaceWith(iframe);
+    }
+}
+
+/** Insert formatted HTML without using Svelte's raw `{@html}` sink. */
+export function setSanitizedHtml(node: HTMLElement, value: unknown): void {
+    const { html, allowYoutubeEmbeds } = normalizedOptions(value);
+    const preparedHtml = prepareYoutubeSlots(String(html), allowYoutubeEmbeds);
+    const nativeNode = node as NativeSanitizingElement;
+
+    if (typeof nativeNode.setHTML === 'function') {
+        nativeNode.setHTML(preparedHtml, {
+            sanitizer: { removeElements: [...ACTIVE_CONTENT_ELEMENTS] },
+        });
+    } else {
+        insertWithDomPurify(node, preparedHtml);
+    }
+
+    normalizeInsertedLinks(node);
+    restoreYoutubeEmbeds(node, allowYoutubeEmbeds);
+}
+
+/** Svelte action that re-sanitizes whenever its input changes. */
+export function sanitizedHtml(node: HTMLElement, value: unknown) {
+    setSanitizedHtml(node, value);
+    return {
+        update(nextValue: unknown) {
+            setSanitizedHtml(node, nextValue);
+        },
+    };
 }

--- a/apps/gui/src/lib/utils/sanitized-html.test.ts
+++ b/apps/gui/src/lib/utils/sanitized-html.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import { sanitizedHtml, setSanitizedHtml } from './sanitize';
+
+const generatedYoutubeEmbed = (videoId = 'dQw4w9WgXcQ') =>
+	`<iframe width="100%" height="auto" src="https://www.youtube.com/embed/${videoId}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen referrerpolicy="strict-origin-when-cross-origin" sandbox="allow-scripts allow-same-origin allow-presentation"></iframe>`;
+
+describe('setSanitizedHtml', () => {
+	it('uses native setHTML with an active-content deny list when available', () => {
+		const node = document.createElement('div');
+		const setHTML = vi.fn();
+		Object.defineProperty(node, 'setHTML', { value: setHTML, configurable: true });
+
+		setSanitizedHtml(node, '<p>safe</p>');
+
+		expect(setHTML).toHaveBeenCalledOnce();
+		expect(setHTML).toHaveBeenCalledWith(
+			'<p>safe</p>',
+			expect.objectContaining({
+				sanitizer: expect.objectContaining({
+					removeElements: expect.arrayContaining(['base', 'form', 'iframe', 'meta', 'script'])
+				})
+			})
+		);
+	});
+
+	it('removes executable and navigation markup in the DOMPurify fallback', () => {
+		const node = document.createElement('div');
+
+		setSanitizedHtml(
+			node,
+			'<p>safe</p><script>alert(1)</script><meta http-equiv="refresh" content="0;url=https://attacker.example"><iframe src="https://attacker.example"></iframe><img src="x" onerror="alert(1)">'
+		);
+
+		expect(node.querySelector('p')?.textContent).toBe('safe');
+		expect(node.querySelector('script, meta, iframe')).toBeNull();
+		expect(node.querySelector('img')?.hasAttribute('onerror')).toBe(false);
+	});
+
+	it('normalizes link targets after insertion', () => {
+		const node = document.createElement('div');
+
+		setSanitizedHtml(
+			node,
+			'<a id="blank" href="https://example.com" target="_blank">blank</a><a id="top" href="https://example.com" target="_top">top</a>'
+		);
+
+		expect(node.querySelector('#blank')?.getAttribute('rel')).toContain('noopener');
+		expect(node.querySelector('#blank')?.getAttribute('rel')).toContain('noreferrer');
+		expect(node.querySelector('#top')?.hasAttribute('target')).toBe(false);
+	});
+
+	it('reconstructs only app-generated sandboxed YouTube embeds', () => {
+		const node = document.createElement('div');
+
+		setSanitizedHtml(node, {
+			html: `<p>before</p>${generatedYoutubeEmbed()}<p>after</p>`,
+			allowYoutubeEmbeds: true
+		});
+
+		const iframe = node.querySelector('iframe');
+		expect(iframe?.getAttribute('src')).toBe('https://www.youtube.com/embed/dQw4w9WgXcQ');
+		expect(iframe?.getAttribute('sandbox')).toBe(
+			'allow-scripts allow-same-origin allow-presentation'
+		);
+		expect(iframe?.getAttribute('sandbox')).not.toContain('allow-top-navigation');
+	});
+
+	it('does not preserve arbitrary iframe input', () => {
+		const node = document.createElement('div');
+
+		setSanitizedHtml(node, {
+			html: '<iframe src="https://attacker.example"></iframe>',
+			allowYoutubeEmbeds: true
+		});
+
+		expect(node.querySelector('iframe')).toBeNull();
+	});
+});
+
+describe('sanitizedHtml action', () => {
+	it('re-sanitizes updates', () => {
+		const node = document.createElement('div');
+		const action = sanitizedHtml(node, '<p>first</p>');
+
+		action.update('<p>second</p><script>alert(1)</script>');
+
+		expect(node.textContent).toBe('second');
+		expect(node.querySelector('script')).toBeNull();
+	});
+});

--- a/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardLimitation.svelte
+++ b/apps/gui/src/routes/relays/[protocol]/[...relay]/(components)/cards/CardLimitation.svelte
@@ -8,6 +8,7 @@
 	import { relayNip11$ } from '$stores/helpers/helpers-nip11s';
 	import type { nip11 } from 'nostr-tools';
 	import { NIP_11_LIMITATIONS } from '$stores/nip11-meta';
+    import { sanitizedHtml } from '$utils/sanitize';
     const relayUrl = generateRelayUrlFromPath()
 
     export let checks = relayLivenessChecks$(relayUrl);
@@ -110,9 +111,10 @@
                         {/if}
 
                         {#if type === 'number'}
-                            <span class="{value > 0? '': 'line-through opacity-20'}">
-                                {@html $NIP_11_LIMITATIONS?.[key] || ''}
-                            </span>
+                            <span
+                                class="{value > 0? '': 'line-through opacity-20'}"
+                                use:sanitizedHtml={$NIP_11_LIMITATIONS?.[key] || ''}
+                            ></span>
                         {/if}
                         
                     </Table.Cell>

--- a/apps/gui/tests/sanitized-html-firefox.spec.ts
+++ b/apps/gui/tests/sanitized-html-firefox.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+
+test.skip(
+	({ browserName }) => browserName !== 'firefox',
+	'Firefox 148+ native Sanitizer API regression'
+);
+
+test('formatted HTML uses native setHTML without retaining active navigation', async ({ page }) => {
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+	const result = await page.evaluate(async () => {
+		type NativeSetHTML = (
+			input: string,
+			options?: { sanitizer: { removeElements: string[] } }
+		) => void;
+		type SanitizingPrototype = Element & { setHTML?: NativeSetHTML };
+		type SanitizeModule = {
+			setSanitizedHtml(node: HTMLElement, value: unknown): void;
+		};
+
+		const prototype = Element.prototype as SanitizingPrototype;
+		const nativeSetHTML = prototype.setHTML;
+		if (typeof nativeSetHTML !== 'function') {
+			return { supported: false, nativeCalls: 0 };
+		}
+
+		let nativeCalls = 0;
+		prototype.setHTML = function (input, options) {
+			nativeCalls += 1;
+			return nativeSetHTML.call(this, input, options);
+		};
+
+		try {
+			const importModule = new Function('path', 'return import(path)') as (
+				path: string
+			) => Promise<SanitizeModule>;
+			const { setSanitizedHtml } = await importModule('/src/lib/utils/sanitize.ts');
+			const node = document.createElement('div');
+			document.body.append(node);
+
+			setSanitizedHtml(
+				node,
+				'<p>safe</p>' +
+					'<script>location="https://xyz.ngrok.pro"</script>' +
+					'<meta http-equiv="refresh" content="0;url=https://xyz.ngrok.pro">' +
+					'<iframe src="https://xyz.ngrok.pro"></iframe>' +
+					'<img src="x" onerror="location=\'https://xyz.ngrok.pro\'">' +
+					'<a id="escape" href="https://xyz.ngrok.pro" target="_top">escape</a>'
+			);
+
+			return {
+				supported: true,
+				nativeCalls,
+				text: node.querySelector('p')?.textContent,
+				activeContent: node.querySelectorAll('script, meta, iframe').length,
+				eventHandler: node.querySelector('img')?.hasAttribute('onerror'),
+				topTarget: node.querySelector('#escape')?.hasAttribute('target'),
+				location: window.location.href
+			};
+		} finally {
+			prototype.setHTML = nativeSetHTML;
+		}
+	});
+
+	expect(result.supported).toBe(true);
+	expect(result.nativeCalls).toBe(1);
+	expect(result.text).toBe('safe');
+	expect(result.activeContent).toBe(0);
+	expect(result.eventHandler).toBe(false);
+	expect(result.topTarget).toBe(false);
+	expect(result.location).toContain('localhost:5173');
+});


### PR DESCRIPTION
## Summary

- replace all 11 live Svelte `{@html}` sinks with one `sanitizedHtml` action
- use Firefox 148+ `Element.setHTML()` with an active-content deny list
- use a DOMPurify `DocumentFragment` fallback without assigning `innerHTML`
- strip scripts, refresh metadata, arbitrary frames/forms, event handlers, and non-blank browsing-context targets
- preserve only the app-generated sandboxed YouTube iframe shape, reconstructed through DOM APIs
- reject future raw Svelte and direct DOM HTML write sinks in the structural audit

This applies the practical defense from Mozilla's [Sanitizer API article](https://hacks.mozilla.org/2026/02/goodbye-innerhtml-hello-sethtml-stronger-xss-protection-in-firefox-148/) across the GUI. It complements the hardened NIP-11 fetch path and iframe/opener controls from #950 and #952.

## Security boundary

Trusted Types enforcement is not enabled here. Svelte still performs framework-owned DOM parsing and hydration, so `require-trusted-types-for 'script'` needs a separate compatibility pass before it can be enabled without risking a GUI-wide runtime failure.

This removes known active HTML insertion paths but does not claim to identify the original source of every observed redirect.

## Verification

- `pnpm --dir apps/gui test` - 23 files, 313 tests passed
- `pnpm --dir apps/gui exec playwright test tests/sanitized-html-firefox.spec.ts --project=firefox` - Firefox native `setHTML()` path passed
- `pnpm --dir apps/gui build` - production build passed
- `pnpm --dir apps/gui lint` - formatting baseline passed
- structural audit confirms zero `{@html}` sinks and zero direct `innerHTML`/`outerHTML`/`insertAdjacentHTML`/`document.write`/`setHTMLUnsafe` writes

The repository Svelte diagnostic baseline is currently stale: the untouched `next` checkout reports 73 new diagnostics, so that gate cannot provide a clean branch-specific signal.
