### PR TITLE
Fix live data pagination state

### DIFF
--- a/apps/gui/src/lib/components/@Careswitch/svelte-data-table/DataTable.pagination.test.ts
+++ b/apps/gui/src/lib/components/@Careswitch/svelte-data-table/DataTable.pagination.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { DataTable, type ColumnDef } from './DataTable.svelte';
+
+type Row = {
+	id: number;
+	name: string;
+};
+
+const columns: ColumnDef<Row>[] = [
+	{
+		id: 'name',
+		key: 'name',
+		name: 'Name'
+	}
+];
+
+const rows: Row[] = [
+	{ id: 1, name: 'one' },
+	{ id: 2, name: 'two' },
+	{ id: 3, name: 'three' },
+	{ id: 4, name: 'four' },
+	{ id: 5, name: 'five' }
+];
+
+const createTable = () =>
+	new DataTable<Row>({
+		data: rows,
+		columns,
+		pageSize: 2
+	});
+
+describe('Given a paginated data table', () => {
+	it('when the page changes, then it exposes rows from the requested page', () => {
+		const table = createTable();
+
+		table.currentPage = 2;
+
+		expect(table.currentPage).toBe(2);
+		expect(table.rows.map((row) => row.name)).toEqual(['three', 'four']);
+	});
+
+	it('when row data refreshes, then it stays on the current page', () => {
+		const table = createTable();
+		table.currentPage = 2;
+
+		table.baseRows = [...rows, { id: 6, name: 'six' }];
+
+		expect(table.currentPage).toBe(2);
+		expect(table.rows.map((row) => row.name)).toEqual(['three', 'four']);
+	});
+
+	it('when refresh removes the current page, then it clamps to the last available page', () => {
+		const table = createTable();
+		table.currentPage = 3;
+
+		table.baseRows = rows.slice(0, 3);
+
+		expect(table.currentPage).toBe(2);
+		expect(table.rows.map((row) => row.name)).toEqual(['three']);
+	});
+});

--- a/apps/gui/src/lib/components/@Careswitch/svelte-data-table/DataTable.svelte.ts
+++ b/apps/gui/src/lib/components/@Careswitch/svelte-data-table/DataTable.svelte.ts
@@ -188,9 +188,9 @@ export class DataTable<T> {
 	 * @param {T[]} rows - The array of rows to reset the base data to.
 	 */
 	set baseRows(rows: T[]) {
-		this.#currentPage = 1;
 		this.#isFilterDirty = true;
 		this.#originalData = [...rows];
+		this.#currentPage = Math.min(this.#currentPage, this.totalPages);
 	}
 
 	/**

--- a/apps/gui/tests/pagination-smoke.spec.ts
+++ b/apps/gui/tests/pagination-smoke.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+
+test('Given paginated rows, when page changes and data refreshes, then current page stays visible', async ({
+	page
+}) => {
+	await test.step('Given a three-page table', async () => {
+		await page.goto(process.env.GUI_PAGINATION_SMOKE_URL ?? '/');
+		await page.addScriptTag({
+			type: 'module',
+			content: `
+				const target = document.createElement('div');
+				target.id = 'pagination-smoke-root';
+				document.body.replaceChildren(target);
+
+				const [{ DataTable }, PaginatorModule, svelte] = await Promise.all([
+					import('/src/lib/components/@Careswitch/svelte-data-table/DataTable.svelte.ts'),
+					import('/src/lib/components/data-view/table/DataTablePaginator.svelte'),
+					import('/node_modules/.vite/deps/svelte.js')
+				]);
+
+				const columns = [{ id: 'name', key: 'name', name: 'Name' }];
+				const rows = [
+					{ id: 1, name: 'one' },
+					{ id: 2, name: 'two' },
+					{ id: 3, name: 'three' },
+					{ id: 4, name: 'four' },
+					{ id: 5, name: 'five' }
+				];
+				const table = new DataTable({ data: rows, columns, pageSize: 2 });
+
+				svelte.mount(PaginatorModule.default, {
+					target,
+					props: { tableInstance: table }
+				});
+
+				window.__paginationSmoke = {
+					snapshot: () => ({
+						currentPage: table.currentPage,
+						rowNames: table.rows.map((row) => row.name)
+					}),
+					refreshRows: async () => {
+						table.baseRows = [...rows, { id: 6, name: 'six' }];
+						await svelte.tick();
+					}
+				};
+
+				await svelte.tick();
+			`
+		});
+		await page.waitForFunction(() => (window as any).__paginationSmoke !== undefined);
+		await expect(page.locator('#pagination-smoke-root')).toContainText('page 1 of 3');
+	});
+
+	const root = page.locator('#pagination-smoke-root');
+	const nextPage = root.locator('button').nth(1);
+
+	await test.step('When user changes to page two', async () => {
+		await nextPage.click();
+	});
+
+	await test.step('Then page two rows become current', async () => {
+		await expect(root).toContainText('page 2 of 3');
+		await expect
+			.poll(() => page.evaluate(() => (window as any).__paginationSmoke.snapshot()))
+			.toEqual({ currentPage: 2, rowNames: ['three', 'four'] });
+	});
+
+	await test.step('When information refreshes', async () => {
+		await page.evaluate(() => (window as any).__paginationSmoke.refreshRows());
+	});
+
+	await test.step('Then table remains on page two', async () => {
+		await expect(root).toContainText('page 2 of 3');
+		await expect
+			.poll(() => page.evaluate(() => (window as any).__paginationSmoke.snapshot()))
+			.toEqual({ currentPage: 2, rowNames: ['three', 'four'] });
+	});
+});


### PR DESCRIPTION
## Problem

Live row refreshes reset currentPage, so paginator clicks appear inert and every redraw returns to first page.

## Change

- preserve current page when base rows refresh
- clamp to final available page only when refreshed data shrinks
- add Given/When/Then model coverage
- add Chromium paginator click plus refresh smoke coverage

## Verification

- pnpm test: 24 files, 316 tests passed
- pagination BDD: 3 tests passed
- Playwright Chromium pagination smoke: 1 test passed
- pnpm lint: baseline clean
- pnpm build: exit 0
- git diff --check: clean

## Known baseline

pnpm check still reports pre-existing diagnostics; clean origin/next reproduces baseline failure before this patch.