### PR TITLE
Harden every browser resource fetch against redirect escape

### DIFF
--- a/apps/gui/src/lib/fetchers/seed.ts
+++ b/apps/gui/src/lib/fetchers/seed.ts
@@ -13,6 +13,7 @@ import {
   completeBootActivity,
 } from '$lib/stores/boot-activity';
 import { setSeedBootComplete, setSeedBootError, setSeedBootInProgress } from '$lib/stores/boot-state';
+import { fetchJsonResource as fetchJson } from '$lib/utils/fetch-json';
 
 type SeedGroup = { files?: string[]; events?: number; count?: number };
 
@@ -79,33 +80,6 @@ function chunk<T>(arr: T[], size: number): T[][] {
   const out: T[][] = [];
   for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
   return out;
-}
-
-async function fetchJson<T>(
-  url: string,
-  opts: { timeoutMs?: number; cache?: RequestCache } = {}
-): Promise<T | null> {
-  const timeoutMs = Number.isFinite(opts.timeoutMs) ? Math.max(0, opts.timeoutMs as number) : 15_000;
-  const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
-  const timeoutId =
-    controller && timeoutMs > 0 ? globalThis.setTimeout(() => controller.abort(), timeoutMs) : null;
-  try {
-    const res = await fetch(
-      url,
-      controller
-        ? {
-            signal: controller.signal,
-            cache: opts.cache,
-          }
-        : { cache: opts.cache }
-    );
-    if (!res.ok) return null;
-    return (await res.json()) as T;
-  } catch {
-    return null;
-  } finally {
-    if (timeoutId !== null) globalThis.clearTimeout(timeoutId);
-  }
 }
 
 async function withTimeout<T>(

--- a/apps/gui/src/lib/services/Nip05Service/index.ts
+++ b/apps/gui/src/lib/services/Nip05Service/index.ts
@@ -49,7 +49,7 @@ export class Nip05Service {
         }, timeoutMs);
 
         this.pending.set(key, { promise, resolve: resolveFn, timeoutId });
-        worker.postMessage({ pubkey, nip05 });
+        worker.postMessage({ pubkey, nip05, timeoutMs });
         return promise;
     }
 

--- a/apps/gui/src/lib/services/Nip05Service/nip05-fetch-paths.test.ts
+++ b/apps/gui/src/lib/services/Nip05Service/nip05-fetch-paths.test.ts
@@ -1,0 +1,25 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const sourceRoot = resolve(process.cwd(), 'src');
+
+const sourceFiles = (directory: string): string[] =>
+	readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+		const path = `${directory}/${entry.name}`;
+		if (entry.isDirectory()) return sourceFiles(path);
+		return /\.(?:ts|svelte)$/.test(entry.name) && !entry.name.includes('.test.') ? [path] : [];
+	});
+
+describe('NIP-05 network boundaries', () => {
+	it('routes every NIP-05 HTTP lookup through the hardened verifier', () => {
+		const unsafe = sourceFiles(sourceRoot)
+			.filter((path) => !path.endsWith('/verify-nip05.ts'))
+			.filter((path) =>
+				/\.well-known\/nostr\.json|nip05\.isValid\s*\(/.test(readFileSync(path, 'utf8'))
+			)
+			.map((path) => path.slice(sourceRoot.length));
+
+		expect(unsafe).toEqual([]);
+	});
+});

--- a/apps/gui/src/lib/services/Nip05Service/nip05.worker.ts
+++ b/apps/gui/src/lib/services/Nip05Service/nip05.worker.ts
@@ -1,24 +1,14 @@
-import { nip05 } from "nostr-tools";
 import type { Nip05 } from "nostr-tools/nip05";
-
-const check = (pubkey: string, value: Nip05) => {
-    if(nip05.isNip05(value)){
-        return nip05.isValid(pubkey, value)
-    }
-    return false;
-}
+import { verifyNip05 } from './verify-nip05';
 
 self.onmessage = ({ data }) => {
     let { nip05 } = data;
-    const { pubkey } = data;
+    const { pubkey, timeoutMs } = data;
     
     if(!nip05.includes('@')){
         nip05 = `_@${nip05}`
     }
     
-    const valid = check(pubkey, nip05)
-    if(valid instanceof Promise) {
-        return valid.then( (valid: boolean) => self.postMessage({pubkey, nip05, valid}) )
-    }
-    self.postMessage({pubkey, nip05, valid})
+    verifyNip05(pubkey, nip05 as Nip05, { timeoutMs })
+        .then((valid) => self.postMessage({ pubkey, nip05, valid }));
 }

--- a/apps/gui/src/lib/services/Nip05Service/verify-nip05.test.ts
+++ b/apps/gui/src/lib/services/Nip05Service/verify-nip05.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { verifyNip05 } from './verify-nip05';
+
+describe('hardened NIP-05 verification', () => {
+	it('rejects hostile redirects without requesting their sentinel target', async () => {
+		let sentinelHits = 0;
+		const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
+			if (init?.redirect !== 'error') {
+				sentinelHits += 1;
+				return new Response(JSON.stringify({ names: { alice: 'f'.repeat(64) } }), {
+					headers: { 'content-type': 'application/json' }
+				});
+			}
+
+			throw new TypeError('NetworkError when attempting to fetch resource.');
+		});
+
+		await expect(
+			verifyNip05('f'.repeat(64), 'alice@redirect.example', { fetchImpl })
+		).resolves.toBe(false);
+		expect(sentinelHits).toBe(0);
+	});
+
+	it('aborts a NIP-05 request that exceeds its timeout', async () => {
+		const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
+			await new Promise<void>((_resolve, reject) => {
+				init?.signal?.addEventListener('abort', () => {
+					reject(new DOMException('Aborted', 'AbortError'));
+				});
+			});
+			throw new Error('unreachable');
+		});
+
+		await expect(
+			verifyNip05('f'.repeat(64), 'alice@slow.example', {
+				fetchImpl,
+				timeoutMs: 10
+			})
+		).resolves.toBe(false);
+		expect((fetchImpl.mock.calls[0]?.[1]?.signal as AbortSignal).aborted).toBe(true);
+	});
+
+	it('rejects oversized NIP-05 documents before accepting their names map', async () => {
+		const fetchImpl = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(
+				new Response(
+					JSON.stringify({ names: { alice: 'f'.repeat(64) }, padding: 'x'.repeat(1024) }),
+					{ headers: { 'content-type': 'application/json' } }
+				)
+			);
+
+		await expect(
+			verifyNip05('f'.repeat(64), 'alice@large.example', {
+				fetchImpl,
+				maxBodyBytes: 128
+			})
+		).resolves.toBe(false);
+	});
+
+	it('rejects HTML responses even when their body contains valid-looking JSON', async () => {
+		const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+			new Response(JSON.stringify({ names: { alice: 'f'.repeat(64) } }), {
+				headers: { 'content-type': 'text/html' }
+			})
+		);
+
+		await expect(verifyNip05('f'.repeat(64), 'alice@html.example', { fetchImpl })).resolves.toBe(
+			false
+		);
+	});
+});

--- a/apps/gui/src/lib/services/Nip05Service/verify-nip05.ts
+++ b/apps/gui/src/lib/services/Nip05Service/verify-nip05.ts
@@ -1,0 +1,59 @@
+import { readResponseBodyWithLimit } from '$lib/utils/response-body';
+
+export type VerifyNip05Options = {
+	fetchImpl?: typeof fetch;
+	timeoutMs?: number;
+	maxBodyBytes?: number;
+};
+
+const NIP05_PATTERN = /^(?:([\w.+-]+)@)?([\w_-]+(?:\.[\w_-]+)+)$/;
+const NIP05_TIMEOUT_MS = 10_000;
+const NIP05_MAX_BODY_BYTES = 128 * 1024;
+
+const isJsonContentType = (contentType: string): boolean => {
+	const mime = contentType.split(';', 1)[0]?.trim().toLowerCase() ?? '';
+	return mime === 'application/json' || mime === 'text/json' || mime.endsWith('+json');
+};
+
+export const verifyNip05 = async (
+	pubkey: string,
+	identifier: string,
+	options: VerifyNip05Options = {}
+): Promise<boolean> => {
+	const match = identifier.match(NIP05_PATTERN);
+	if (!match) return false;
+
+	const [, name = '_', domain] = match;
+	const url = new URL(`https://${domain}/.well-known/nostr.json`);
+	url.searchParams.set('name', name);
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? NIP05_TIMEOUT_MS);
+	const maxBodyBytes = options.maxBodyBytes ?? NIP05_MAX_BODY_BYTES;
+
+	try {
+		const response = await (options.fetchImpl ?? fetch)(url, {
+			method: 'GET',
+			redirect: 'error',
+			credentials: 'omit',
+			referrerPolicy: 'no-referrer',
+			cache: 'no-store',
+			headers: { Accept: 'application/json' },
+			signal: controller.signal
+		});
+		if (!response.ok || response.redirected) return false;
+		const contentType = response.headers.get('content-type')?.trim() ?? '';
+		if (contentType && !isJsonContentType(contentType)) return false;
+
+		const body = await readResponseBodyWithLimit(
+			response,
+			maxBodyBytes,
+			() => new Error('NIP-05 response too large.')
+		);
+		const data = JSON.parse(body) as { names?: Record<string, unknown> };
+		return data?.names?.[name] === pubkey;
+	} catch {
+		return false;
+	} finally {
+		clearTimeout(timeout);
+	}
+};

--- a/apps/gui/src/lib/services/Nip11Service/fetch-relay-information.ts
+++ b/apps/gui/src/lib/services/Nip11Service/fetch-relay-information.ts
@@ -1,4 +1,5 @@
 import type { RelayInformation } from '@nostrwatch/route66/models';
+import { readResponseBodyWithLimit } from '$lib/utils/response-body';
 
 export const NIP11_ACCEPT = 'application/nostr+json';
 export const NIP11_MAX_BODY_BYTES = 128 * 1024;
@@ -88,53 +89,6 @@ const isJsonContentType = (contentType: string): boolean => {
 
 const startsLikeJsonObject = (body: string): boolean => body.trimStart().startsWith('{');
 
-const bytesFor = (text: string): number => new TextEncoder().encode(text).byteLength;
-
-const readBodyWithLimit = async (response: Response, maxBodyBytes: number): Promise<string> => {
-	const contentLength = response.headers.get('content-length');
-	if (contentLength) {
-		const parsedLength = Number(contentLength);
-		if (Number.isFinite(parsedLength) && parsedLength > maxBodyBytes) {
-			throw new Nip11FetchError('oversize', `NIP-11 response exceeds ${maxBodyBytes} bytes.`);
-		}
-	}
-
-	if (!response.body) {
-		const text = await response.text();
-		if (bytesFor(text) > maxBodyBytes) {
-			throw new Nip11FetchError('oversize', `NIP-11 response exceeds ${maxBodyBytes} bytes.`);
-		}
-		return text;
-	}
-
-	const reader = response.body.getReader();
-	const chunks: Uint8Array[] = [];
-	let received = 0;
-
-	while (true) {
-		const { done, value } = await reader.read();
-		if (done) break;
-		if (!value) continue;
-
-		const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
-		received += chunk.byteLength;
-		if (received > maxBodyBytes) {
-			await reader.cancel();
-			throw new Nip11FetchError('oversize', `NIP-11 response exceeds ${maxBodyBytes} bytes.`);
-		}
-		chunks.push(chunk);
-	}
-
-	const body = new Uint8Array(received);
-	let offset = 0;
-	for (const chunk of chunks) {
-		body.set(chunk, offset);
-		offset += chunk.byteLength;
-	}
-
-	return new TextDecoder().decode(body);
-};
-
 const parseRelayInformation = (body: string): RelayInformation => {
 	let parsed: unknown;
 	try {
@@ -179,7 +133,11 @@ export const fetchRelayInformation = async (
 			);
 		}
 
-		const body = await readBodyWithLimit(response, maxBodyBytes);
+		const body = await readResponseBodyWithLimit(
+			response,
+			maxBodyBytes,
+			() => new Nip11FetchError('oversize', `NIP-11 response exceeds ${maxBodyBytes} bytes.`)
+		);
 		if (!contentType && !startsLikeJsonObject(body)) {
 			throw new Nip11FetchError(
 				'invalid-content-type',

--- a/apps/gui/src/lib/utils/fetch-json.test.ts
+++ b/apps/gui/src/lib/utils/fetch-json.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchJsonResource } from './fetch-json';
+
+describe('browser JSON resource fetch policy', () => {
+	it('rejects redirects and omits ambient browser credentials', async () => {
+		const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+			new Response(JSON.stringify({ version: 1 }), {
+				headers: { 'content-type': 'application/json' }
+			})
+		);
+
+		await expect(
+			fetchJsonResource<{ version: number }>('https://seed.example/manifest.json', { fetchImpl })
+		).resolves.toEqual({ version: 1 });
+		expect(fetchImpl).toHaveBeenCalledWith(
+			'https://seed.example/manifest.json',
+			expect.objectContaining({
+				redirect: 'error',
+				credentials: 'omit',
+				referrerPolicy: 'no-referrer'
+			})
+		);
+	});
+});

--- a/apps/gui/src/lib/utils/fetch-json.ts
+++ b/apps/gui/src/lib/utils/fetch-json.ts
@@ -1,0 +1,32 @@
+export type FetchJsonResourceOptions = {
+	timeoutMs?: number;
+	cache?: RequestCache;
+	fetchImpl?: typeof fetch;
+};
+
+export const fetchJsonResource = async <T>(
+	url: string,
+	options: FetchJsonResourceOptions = {}
+): Promise<T | null> => {
+	const timeoutMs = Number.isFinite(options.timeoutMs)
+		? Math.max(0, options.timeoutMs as number)
+		: 15_000;
+	const controller = new AbortController();
+	const timeout = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : null;
+
+	try {
+		const response = await (options.fetchImpl ?? fetch)(url, {
+			redirect: 'error',
+			credentials: 'omit',
+			referrerPolicy: 'no-referrer',
+			cache: options.cache,
+			signal: controller.signal
+		});
+		if (!response.ok || response.redirected) return null;
+		return (await response.json()) as T;
+	} catch {
+		return null;
+	} finally {
+		if (timeout !== null) clearTimeout(timeout);
+	}
+};

--- a/apps/gui/src/lib/utils/response-body.ts
+++ b/apps/gui/src/lib/utils/response-body.ts
@@ -1,0 +1,43 @@
+export const readResponseBodyWithLimit = async (
+	response: Response,
+	maxBodyBytes: number,
+	tooLarge: () => Error
+): Promise<string> => {
+	const contentLength = response.headers.get('content-length');
+	if (contentLength) {
+		const parsedLength = Number(contentLength);
+		if (Number.isFinite(parsedLength) && parsedLength > maxBodyBytes) throw tooLarge();
+	}
+
+	if (!response.body) {
+		const text = await response.text();
+		if (new TextEncoder().encode(text).byteLength > maxBodyBytes) throw tooLarge();
+		return text;
+	}
+
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let received = 0;
+
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		if (!value) continue;
+
+		received += value.byteLength;
+		if (received > maxBodyBytes) {
+			await reader.cancel();
+			throw tooLarge();
+		}
+		chunks.push(value);
+	}
+
+	const body = new Uint8Array(received);
+	let offset = 0;
+	for (const chunk of chunks) {
+		body.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+
+	return new TextDecoder().decode(body);
+};

--- a/apps/gui/src/routes/monitors/[pubkey]/+page.svelte
+++ b/apps/gui/src/routes/monitors/[pubkey]/+page.svelte
@@ -16,6 +16,7 @@
     import Chart from 'chart.js/auto';
     import { decodeGeohash } from '$lib/utils/geohash';
     import { browser } from '$app/environment';
+    import { verifyNip05 } from '$lib/services/Nip05Service/verify-nip05';
     import 'leaflet/dist/leaflet.css';
 
     export const prerender = false;
@@ -56,30 +57,10 @@
     // NIP-05 validation
     let nip05Status: 'pending' | 'valid' | 'invalid' | null = null;
 
-    async function validateNip05(nip05: string, expectedPubkey: string): Promise<boolean> {
-        if (!nip05 || !expectedPubkey) return false;
-
-        try {
-            const [name, domain] = nip05.split('@');
-            if (!name || !domain) return false;
-
-            const url = `https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(name)}`;
-            const response = await fetch(url);
-            if (!response.ok) return false;
-
-            const data = await response.json();
-            const registeredPubkey = data.names?.[name];
-
-            return registeredPubkey === expectedPubkey;
-        } catch {
-            return false;
-        }
-    }
-
     // Validate NIP-05 when monitor data is available
     $: if (browser && monitorData?.nip05 && pubkey) {
         nip05Status = 'pending';
-        validateNip05(monitorData.nip05, pubkey).then(valid => {
+        verifyNip05(pubkey, monitorData.nip05).then(valid => {
             nip05Status = valid ? 'valid' : 'invalid';
         });
     }

--- a/apps/gui/tests/nip05-redirect-firefox.spec.ts
+++ b/apps/gui/tests/nip05-redirect-firefox.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+
+test.skip(({ browserName }) => browserName !== 'firefox', 'Firefox-only NIP-05 redirect repro');
+
+test('hostile NIP-05 302 does not follow sentinel or navigate parent frame', async ({ page }) => {
+	let sourceHits = 0;
+	let sentinelHits = 0;
+	const mainFrameNavigations: string[] = [];
+	page.on('framenavigated', (frame) => {
+		if (frame === page.mainFrame()) mainFrameNavigations.push(frame.url());
+	});
+
+	await page.route('https://redirect.example/**', async (route) => {
+		sourceHits += 1;
+		await route.fulfill({
+			status: 302,
+			headers: {
+				location: 'https://sentinel.example/captured',
+				'access-control-allow-origin': '*'
+			}
+		});
+	});
+	await page.route('https://sentinel.example/**', async (route) => {
+		sentinelHits += 1;
+		await route.fulfill({
+			status: 200,
+			headers: { 'content-type': 'application/json', 'access-control-allow-origin': '*' },
+			body: JSON.stringify({ names: { alice: 'f'.repeat(64) } })
+		});
+	});
+
+	await page.goto('/unsupported');
+	await page.waitForTimeout(500);
+	mainFrameNavigations.length = 0;
+	const initialFrameUrl = page.url();
+	const valid = await page.evaluate(async (pubkey) => {
+		const modulePath = '/src/lib/services/Nip05Service/verify-nip05.ts';
+		const { verifyNip05 } = await import(/* @vite-ignore */ modulePath);
+		return verifyNip05(pubkey, 'alice@redirect.example', { timeoutMs: 2_000 });
+	}, 'f'.repeat(64));
+
+	expect(valid).toBe(false);
+	expect(sourceHits).toBe(1);
+	expect(sentinelHits).toBe(0);
+	expect(mainFrameNavigations).toEqual([]);
+	expect(page.url()).toBe(initialFrameUrl);
+});
+
+test('valid NIP-05 JSON from an arbitrary origin still verifies', async ({ page }) => {
+	await page.route('https://untrusted.example/**', async (route) => {
+		await route.fulfill({
+			status: 200,
+			headers: { 'content-type': 'application/json', 'access-control-allow-origin': '*' },
+			body: JSON.stringify({ names: { alice: 'a'.repeat(64) } })
+		});
+	});
+
+	await page.goto('/unsupported');
+	await page.waitForTimeout(500);
+	const valid = await page.evaluate(async (pubkey) => {
+		const modulePath = '/src/lib/services/Nip05Service/verify-nip05.ts';
+		const { verifyNip05 } = await import(/* @vite-ignore */ modulePath);
+		return verifyNip05(pubkey, 'alice@untrusted.example', { timeoutMs: 2_000 });
+	}, 'a'.repeat(64));
+
+	expect(valid).toBe(true);
+});

--- a/apps/gui/tests/nip11-redirect-firefox.spec.ts
+++ b/apps/gui/tests/nip11-redirect-firefox.spec.ts
@@ -1,6 +1,5 @@
-import { createHash } from 'node:crypto';
 import http from 'node:http';
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.skip(({ browserName }) => browserName !== 'firefox', 'Firefox-only NIP-11 redirect repro');
 test.setTimeout(60_000);
@@ -40,55 +39,35 @@ test('hostile NIP-11 302 does not follow sentinel or navigate parent frame', asy
 		});
 		res.end();
 	});
-	server.on('upgrade', (req, socket) => {
-		const key = req.headers['sec-websocket-key'];
-		if (typeof key !== 'string') {
-			socket.destroy();
-			return;
-		}
-
-		const accept = createHash('sha1')
-			.update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
-			.digest('base64');
-		socket.write(
-			[
-				'HTTP/1.1 101 Switching Protocols',
-				'Upgrade: websocket',
-				'Connection: Upgrade',
-				`Sec-WebSocket-Accept: ${accept}`,
-				'\r\n'
-			].join('\r\n')
-		);
-	});
-
 	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
 	const address = server.address();
 	if (!address || typeof address === 'string') throw new Error('Hostile server failed to bind.');
 
 	try {
-		const route = `/relays/ws/127.0.0.1:${address.port}/nip-11`;
-		await page.goto(route);
+		const mainFrameNavigations: string[] = [];
+		page.on('framenavigated', (frame) => {
+			if (frame === page.mainFrame()) mainFrameNavigations.push(frame.url());
+		});
+		await page.goto('/unsupported');
+		await page.waitForTimeout(500);
+		mainFrameNavigations.length = 0;
 		const initialFrameUrl = page.url();
-		const startedAt = Date.now();
-		while (nip11Hits === 0 && Date.now() - startedAt < 15_000) {
-			await page.waitForTimeout(100);
-		}
-		if (nip11Hits === 0) {
-			throw new Error(
-				`NIP-11 endpoint was not requested; hits=${JSON.stringify(hits)}; page=${page.url()}`
-			);
-		}
-		await new Promise((resolve) => setTimeout(resolve, 100));
+		const errorCode = await page.evaluate(async (relay) => {
+			const modulePath = '/src/lib/services/Nip11Service/fetch-relay-information.ts';
+			const { fetchRelayInformation } = await import(/* @vite-ignore */ modulePath);
+			try {
+				await fetchRelayInformation(relay, { timeoutMs: 2_000 });
+				return null;
+			} catch (error) {
+				return (error as { code?: string }).code ?? 'unknown';
+			}
+		}, `ws://127.0.0.1:${address.port}`);
 
-		const sentinelHits = hits['/sentinel'] ?? 0;
-		if (sentinelHits !== 0) {
-			throw new Error(
-				`Sentinel was requested ${sentinelHits} time(s); hits=${JSON.stringify(hits)}`
-			);
-		}
-		if (page.url() !== initialFrameUrl) {
-			throw new Error(`Parent frame URL changed from ${initialFrameUrl} to ${page.url()}`);
-		}
+		expect(errorCode).toBe('fetch-failed');
+		expect(nip11Hits).toBe(1);
+		expect(hits['/sentinel'] ?? 0).toBe(0);
+		expect(mainFrameNavigations).toEqual([]);
+		expect(page.url()).toBe(initialFrameUrl);
 	} finally {
 		await new Promise<void>((resolve, reject) =>
 			server.close((error) => (error ? reject(error) : resolve()))

--- a/libraries/nocap/adapters/default/DnsAdapterDefault/src/index.test.ts
+++ b/libraries/nocap/adapters/default/DnsAdapterDefault/src/index.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Nocap as Base } from '@nostrwatch/nocap';
+
+const fetchMock = vi.hoisted(() => vi.fn());
+vi.mock('cross-fetch', () => ({ default: fetchMock }));
+
+import { DnsAdapterDefault } from './index';
+
+describe('DnsAdapterDefault remote fetch policy', () => {
+	beforeEach(() => {
+		fetchMock.mockReset();
+		fetchMock.mockResolvedValue(
+			new Response(JSON.stringify({ Answer: [{ data: '127.0.0.1' }] }), {
+				headers: { 'content-type': 'application/dns-json' }
+			})
+		);
+	});
+
+	it('rejects redirects and omits ambient browser credentials', async () => {
+		const base = {
+			url: 'wss://relay.example',
+			results: new Map([['network', 'clearnet']]),
+			logger: { debug: vi.fn(), error: vi.fn() },
+			finish: vi.fn()
+		} as unknown as Base;
+
+		await new DnsAdapterDefault(base).check_dns();
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			expect.stringContaining('https://1.1.1.1/dns-query'),
+			expect.objectContaining({
+				redirect: 'error',
+				credentials: 'omit',
+				referrerPolicy: 'no-referrer',
+				cache: 'no-store'
+			})
+		);
+	});
+});

--- a/libraries/nocap/adapters/default/DnsAdapterDefault/src/index.ts
+++ b/libraries/nocap/adapters/default/DnsAdapterDefault/src/index.ts
@@ -72,7 +72,13 @@ export class DnsAdapterDefault extends AbstractAdapter implements IAdapter {
         const query = `https://1.1.1.1/dns-query?name=${sanitizedUrl}`;
         const headers = { accept: 'application/dns-json' };
 
-        const response = await fetch(query, { headers }).catch((e) => { result = error(e.message, data); return null; });
+        const response = await fetch(query, {
+          headers,
+          redirect: 'error',
+          credentials: 'omit',
+          referrerPolicy: 'no-referrer',
+          cache: 'no-store'
+        }).catch((e) => { result = error(e.message, data); return null; });
         
         if (response) {
           const jsonData = await response.json();

--- a/libraries/nocap/adapters/default/DnsAdapterDefault/tsconfig.server.json
+++ b/libraries/nocap/adapters/default/DnsAdapterDefault/tsconfig.server.json
@@ -21,7 +21,7 @@
     }
   },
   "include": ["@nostrwatch/nocap.d.ts", "src/**/*"],
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"],
   "tsc-alias": {
     "resolveFullPaths": true,
     "resolveFullExtension": ".js"

--- a/libraries/nocap/adapters/default/DnsAdapterDefault/tsconfig.web.json
+++ b/libraries/nocap/adapters/default/DnsAdapterDefault/tsconfig.web.json
@@ -20,5 +20,5 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests", "./adapters"]
+  "exclude": ["node_modules", "dist", "tests", "./adapters", "src/**/*.test.ts"]
 }

--- a/libraries/nocap/adapters/default/GeoAdapterDefault/index.js
+++ b/libraries/nocap/adapters/default/GeoAdapterDefault/index.js
@@ -34,7 +34,14 @@ const IPV4 = /\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01
     else 
       endpoint = `http://ip-api.com/json/${ip}?fields=${FIELDS}`
 
-    response = await fetch(endpoint, { headers, signal }).catch(this.$.logger.error)
+    response = await fetch(endpoint, {
+      headers,
+      signal,
+      redirect: 'error',
+      credentials: 'omit',
+      referrerPolicy: 'no-referrer',
+      cache: 'no-store'
+    }).catch(this.$.logger.error)
 
     delete response.query
     delete response.status

--- a/libraries/nocap/adapters/default/GeoAdapterDefault/src/index.test.ts
+++ b/libraries/nocap/adapters/default/GeoAdapterDefault/src/index.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Nocap as Base } from '@nostrwatch/nocap';
+
+const fetchMock = vi.hoisted(() => vi.fn());
+vi.mock('cross-fetch', () => ({ fetch: fetchMock, default: fetchMock }));
+
+import { GeoAdapterDefault } from './index';
+// @ts-expect-error Legacy JS entry intentionally has no declaration file.
+import LegacyGeoAdapterDefault from '../index.js';
+
+describe('GeoAdapterDefault remote fetch policy', () => {
+	beforeEach(() => {
+		fetchMock.mockReset();
+		fetchMock.mockResolvedValue(
+			new Response(JSON.stringify({ countryCode: 'ZZ', query: '127.0.0.1', status: 'success' }), {
+				headers: { 'content-type': 'application/json' }
+			})
+		);
+	});
+
+	it('rejects redirects and omits ambient browser credentials', async () => {
+		const base = {
+			url: 'wss://relay.example',
+			config: {},
+			logger: { debug: vi.fn(), error: vi.fn() },
+			finish: vi.fn()
+		} as unknown as Base;
+
+		await new GeoAdapterDefault(base).getGeoData('127.0.0.1');
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			expect.stringContaining('ip-api.com/json/127.0.0.1'),
+			expect.objectContaining({
+				redirect: 'error',
+				credentials: 'omit',
+				referrerPolicy: 'no-referrer',
+				cache: 'no-store'
+			})
+		);
+	});
+
+	it('applies the same redirect policy in the shipped legacy adapter', async () => {
+		const base = {
+			config: { adapterOptions: { geo: {} } },
+			controller: new AbortController(),
+			logger: { debug: vi.fn(), error: vi.fn() }
+		};
+
+		await new LegacyGeoAdapterDefault(base).getGeoData('127.0.0.1');
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			expect.stringContaining('ip-api.com/json/127.0.0.1'),
+			expect.objectContaining({
+				redirect: 'error',
+				credentials: 'omit',
+				referrerPolicy: 'no-referrer',
+				cache: 'no-store'
+			})
+		);
+	});
+});

--- a/libraries/nocap/adapters/default/GeoAdapterDefault/src/index.ts
+++ b/libraries/nocap/adapters/default/GeoAdapterDefault/src/index.ts
@@ -47,7 +47,13 @@
         : `http://ip-api.com/json/${ip}?fields=${FIELDS}`;
 
       try {
-        const response = await fetch(endpoint, { headers: { accept: 'application/json' } });
+        const response = await fetch(endpoint, {
+          headers: { accept: 'application/json' },
+          redirect: 'error',
+          credentials: 'omit',
+          referrerPolicy: 'no-referrer',
+          cache: 'no-store'
+        });
         const jsonResponse = await response.json();
         delete jsonResponse.query;
         delete jsonResponse.status;

--- a/libraries/nocap/adapters/default/GeoAdapterDefault/tsconfig.server.json
+++ b/libraries/nocap/adapters/default/GeoAdapterDefault/tsconfig.server.json
@@ -19,7 +19,7 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"],
   "tsc-alias": {
     "resolveFullPaths": true,
     "resolveFullExtension": ".js"

--- a/libraries/nocap/adapters/default/GeoAdapterDefault/tsconfig.web.json
+++ b/libraries/nocap/adapters/default/GeoAdapterDefault/tsconfig.web.json
@@ -20,5 +20,5 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests", "./adapters"]
+  "exclude": ["node_modules", "dist", "tests", "./adapters", "src/**/*.test.ts"]
 }

--- a/libraries/nocap/adapters/default/InfoAdapterDefault/index.js
+++ b/libraries/nocap/adapters/default/InfoAdapterDefault/index.js
@@ -1,6 +1,26 @@
 import fetch from 'cross-fetch'
 // import Ajv from 'ajv'
 
+const NIP11_MAX_BODY_BYTES = 128 * 1024
+
+const isJsonContentType = (contentType) => {
+  const mime = contentType.split(';', 1)[0]?.trim().toLowerCase() ?? ''
+  return mime === 'application/json' || mime === 'text/json' || mime.endsWith('+json')
+}
+
+const readBodyWithLimit = async (response) => {
+  const contentLength = response.headers.get('content-length')
+  if(contentLength && Number(contentLength) > NIP11_MAX_BODY_BYTES) {
+    throw new Error(`NIP-11 response exceeds ${NIP11_MAX_BODY_BYTES} bytes.`)
+  }
+
+  const body = await response.text()
+  if(new TextEncoder().encode(body).byteLength > NIP11_MAX_BODY_BYTES) {
+    throw new Error(`NIP-11 response exceeds ${NIP11_MAX_BODY_BYTES} bytes.`)
+  }
+  return body
+}
+
 class InfoAdapterDefault {
   uses = ['AbortController']
 
@@ -14,7 +34,16 @@ class InfoAdapterDefault {
     let result, data = {}
     const url = new URL(this.$.url),
           headers = {"Accept": "application/nostr+json"},
-          method = 'GET'
+          method = 'GET',
+          requestInit = {
+            method,
+            headers,
+            signal: this.$.controller.signal,
+            redirect: 'error',
+            credentials: 'omit',
+            referrerPolicy: 'no-referrer',
+            cache: 'no-store'
+          }
 
     if( this.$.results.get('network') === 'tor' ) 
     {
@@ -31,16 +60,31 @@ class InfoAdapterDefault {
 
     try 
     {
-      await fetch(url.toString(), { method, headers, signal: this.$.controller.signal })
+      await fetch(url.toString(), requestInit)
         .then(async (response) => { 
-          if(!response.ok) 
+          const contentType = response.headers.get('content-type')?.trim() ?? ''
+          if(!response.ok || response.redirected)
           {
-            this.$.logger.debug(`check_info(): fetch error: ${e.message}`)
-            result = { status: "error", message: e.message, data }
+            const message = `NIP-11 request failed with HTTP ${response.status}.`
+            this.$.logger.debug(`check_info(): fetch error: ${message}`)
+            result = { status: "error", message, data }
+          }
+          else if(contentType && !isJsonContentType(contentType))
+          {
+            const message = `Unsupported NIP-11 content-type: ${contentType}`
+            this.$.logger.debug(`check_info(): fetch error: ${message}`)
+            result = { status: "error", message, data }
           }
           else {
             this.$.logger.debug(`check_info(): response status: ${response}`)
-            data = await response.json()
+            const body = await readBodyWithLimit(response)
+            const parsed = JSON.parse(body)
+            if(!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+              result = { status: "error", message: 'NIP-11 response must be a JSON object.', data }
+            }
+            else {
+              data = parsed
+            }
           }
           return response
         })

--- a/libraries/nocap/adapters/default/InfoAdapterDefault/src/index.test.ts
+++ b/libraries/nocap/adapters/default/InfoAdapterDefault/src/index.test.ts
@@ -1,0 +1,208 @@
+import http from 'node:http';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Nocap as Base, IResultData } from '@nostrwatch/nocap';
+import { InfoAdapterDefault } from './index';
+// @ts-expect-error Legacy JS entry intentionally has no declaration file.
+import LegacyInfoAdapterDefault from '../index.js';
+
+const listenRedirectServer = async () => {
+	const hits: Record<string, number> = {};
+	const server = http.createServer((req, res) => {
+		const path = req.url ?? '/';
+		hits[path] = (hits[path] ?? 0) + 1;
+		if (path === '/sentinel') {
+			res.writeHead(200, { 'content-type': 'application/nostr+json' });
+			res.end(JSON.stringify({ name: 'redirect target' }));
+			return;
+		}
+
+		res.writeHead(302, { location: '/sentinel' });
+		res.end();
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+	const address = server.address();
+	if (!address || typeof address === 'string') throw new Error('Failed to bind test server.');
+
+	return {
+		hits,
+		url: `ws://127.0.0.1:${address.port}`,
+		close: () =>
+			new Promise<void>((resolve, reject) =>
+				server.close((error) => (error ? reject(error) : resolve()))
+			)
+	};
+};
+
+describe('InfoAdapterDefault redirect handling', () => {
+	it('fails a redirected relay-info request without following its sentinel target', async () => {
+		const server = await listenRedirectServer();
+
+		const finish = vi.fn<(check: string, result: IResultData) => void>();
+		const base = {
+			url: server.url,
+			results: new Map([['network', 'clearnet']]),
+			logger: { debug: vi.fn(), error: vi.fn() },
+			finish
+		} as unknown as Base;
+
+		try {
+			await new InfoAdapterDefault(base).check_info();
+			expect(server.hits['/']).toBe(1);
+			expect(server.hits['/sentinel'] ?? 0).toBe(0);
+			expect(finish).toHaveBeenCalledWith(
+				'info',
+				expect.objectContaining({ status: 'error' })
+			);
+		} finally {
+			await server.close();
+		}
+	});
+
+	it('keeps the shipped legacy adapter from following relay-info redirects', async () => {
+		const server = await listenRedirectServer();
+		const finish = vi.fn();
+		const base = {
+			url: server.url,
+			results: new Map([['network', 'clearnet']]),
+			controller: new AbortController(),
+			logger: { debug: vi.fn(), error: vi.fn() },
+			finish
+		};
+
+		try {
+			await new LegacyInfoAdapterDefault(base).check_info();
+			expect(server.hits['/']).toBe(1);
+			expect(server.hits['/sentinel'] ?? 0).toBe(0);
+			expect(finish).toHaveBeenCalledWith(
+				'info',
+				expect.objectContaining({ status: 'error' })
+			);
+		} finally {
+			await server.close();
+		}
+	});
+
+	it('rejects HTML relay-info responses even when their body is valid JSON', async () => {
+		const server = http.createServer((_req, res) => {
+			res.writeHead(200, { 'content-type': 'text/html' });
+			res.end(JSON.stringify({ name: 'not NIP-11 content' }));
+		});
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+		const address = server.address();
+		if (!address || typeof address === 'string') throw new Error('Failed to bind test server.');
+
+		const finish = vi.fn<(check: string, result: IResultData) => void>();
+		const base = {
+			url: `ws://127.0.0.1:${address.port}`,
+			results: new Map([['network', 'clearnet']]),
+			logger: { debug: vi.fn(), error: vi.fn() },
+			finish
+		} as unknown as Base;
+
+		try {
+			await new InfoAdapterDefault(base).check_info();
+			expect(finish).toHaveBeenCalledWith(
+				'info',
+				expect.objectContaining({ status: 'error' })
+			);
+		} finally {
+			await new Promise<void>((resolve, reject) =>
+				server.close((error) => (error ? reject(error) : resolve()))
+			);
+		}
+	});
+
+	it('rejects HTML relay-info responses in the shipped legacy adapter', async () => {
+		const server = http.createServer((_req, res) => {
+			res.writeHead(200, { 'content-type': 'text/html' });
+			res.end(JSON.stringify({ name: 'not NIP-11 content' }));
+		});
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+		const address = server.address();
+		if (!address || typeof address === 'string') throw new Error('Failed to bind test server.');
+
+		const finish = vi.fn();
+		const base = {
+			url: `ws://127.0.0.1:${address.port}`,
+			results: new Map([['network', 'clearnet']]),
+			controller: new AbortController(),
+			logger: { debug: vi.fn(), error: vi.fn() },
+			finish
+		};
+
+		try {
+			await new LegacyInfoAdapterDefault(base).check_info();
+			expect(finish).toHaveBeenCalledWith(
+				'info',
+				expect.objectContaining({ status: 'error' })
+			);
+		} finally {
+			await new Promise<void>((resolve, reject) =>
+				server.close((error) => (error ? reject(error) : resolve()))
+			);
+		}
+	});
+
+	it('rejects oversized relay-info documents', async () => {
+		const server = http.createServer((_req, res) => {
+			res.writeHead(200, { 'content-type': 'application/nostr+json' });
+			res.end(JSON.stringify({ name: 'large', padding: 'x'.repeat(200 * 1024) }));
+		});
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+		const address = server.address();
+		if (!address || typeof address === 'string') throw new Error('Failed to bind test server.');
+
+		const finish = vi.fn<(check: string, result: IResultData) => void>();
+		const base = {
+			url: `ws://127.0.0.1:${address.port}`,
+			results: new Map([['network', 'clearnet']]),
+			logger: { debug: vi.fn(), error: vi.fn() },
+			finish
+		} as unknown as Base;
+
+		try {
+			await new InfoAdapterDefault(base).check_info();
+			expect(finish).toHaveBeenCalledWith(
+				'info',
+				expect.objectContaining({ status: 'error' })
+			);
+		} finally {
+			await new Promise<void>((resolve, reject) =>
+				server.close((error) => (error ? reject(error) : resolve()))
+			);
+		}
+	});
+
+	it('rejects oversized relay-info documents in the shipped legacy adapter', async () => {
+		const server = http.createServer((_req, res) => {
+			res.writeHead(200, { 'content-type': 'application/nostr+json' });
+			res.end(JSON.stringify({ name: 'large', padding: 'x'.repeat(200 * 1024) }));
+		});
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+		const address = server.address();
+		if (!address || typeof address === 'string') throw new Error('Failed to bind test server.');
+
+		const finish = vi.fn();
+		const base = {
+			url: `ws://127.0.0.1:${address.port}`,
+			results: new Map([['network', 'clearnet']]),
+			controller: new AbortController(),
+			logger: { debug: vi.fn(), error: vi.fn() },
+			finish
+		};
+
+		try {
+			await new LegacyInfoAdapterDefault(base).check_info();
+			expect(finish).toHaveBeenCalledWith(
+				'info',
+				expect.objectContaining({ status: 'error' })
+			);
+		} finally {
+			await new Promise<void>((resolve, reject) =>
+				server.close((error) => (error ? reject(error) : resolve()))
+			);
+		}
+	});
+});

--- a/libraries/nocap/adapters/default/InfoAdapterDefault/src/index.ts
+++ b/libraries/nocap/adapters/default/InfoAdapterDefault/src/index.ts
@@ -10,11 +10,30 @@ import {
 } from '@nostrwatch/nocap';
 
 const resultTpl: IResultData = { data: null, duration: -1 };
+const NIP11_MAX_BODY_BYTES = 128 * 1024;
 
 const error = (message: string, data: Record<string, any> = {}): IResultData => {
   const r: IResultData = { ...resultTpl, status: "error", message };
   if (Object.keys(data).length > 0) r.data = data;
   return r;
+};
+
+const isJsonContentType = (contentType: string): boolean => {
+  const mime = contentType.split(';', 1)[0]?.trim().toLowerCase() ?? '';
+  return mime === 'application/json' || mime === 'text/json' || mime.endsWith('+json');
+};
+
+const readBodyWithLimit = async (response: Response): Promise<string> => {
+  const contentLength = response.headers.get('content-length');
+  if (contentLength && Number(contentLength) > NIP11_MAX_BODY_BYTES) {
+    throw new Error(`NIP-11 response exceeds ${NIP11_MAX_BODY_BYTES} bytes.`);
+  }
+
+  const body = await response.text();
+  if (new TextEncoder().encode(body).byteLength > NIP11_MAX_BODY_BYTES) {
+    throw new Error(`NIP-11 response exceeds ${NIP11_MAX_BODY_BYTES} bytes.`);
+  }
+  return body;
 };
 
 export class InfoAdapterDefault extends AbstractAdapter implements IAdapter {
@@ -38,6 +57,15 @@ export class InfoAdapterDefault extends AbstractAdapter implements IAdapter {
     const headers = { "Accept": "application/nostr+json" };
     const method = 'GET';
     const network = this?.base?.results?.get('network')
+    const requestInit = {
+      method,
+      headers,
+      signal,
+      redirect: 'error' as const,
+      credentials: 'omit' as const,
+      referrerPolicy: 'no-referrer' as const,
+      cache: 'no-store' as const
+    };
 
     if (url.protocol === 'ws:') {
       url.protocol = 'http:';
@@ -48,7 +76,7 @@ export class InfoAdapterDefault extends AbstractAdapter implements IAdapter {
     try {
       let response;
       if(network === 'tor') {
-        response = await fetch(url.toString(), { method, headers, signal }).catch((e) => {
+        response = await fetch(url.toString(), requestInit).catch((e) => {
           result = error(e.message, data);
           return null;
         });
@@ -57,18 +85,31 @@ export class InfoAdapterDefault extends AbstractAdapter implements IAdapter {
         //   return null;
         // });
       } else {  
-        response = await fetch(url.toString(), { method, headers, signal }).catch((e) => {
+        response = await fetch(url.toString(), requestInit).catch((e) => {
           result = error(e.message, data);
           return null;
         });
       }
       if (response) {
-        data = await response.json();
-        result = { 
-          ...resultTpl,
-          status: "success",
-          data
-        };
+        const contentType = response.headers.get('content-type')?.trim() ?? '';
+        if (!response.ok || response.redirected) {
+          result = error(`NIP-11 request failed with HTTP ${response.status}.`, data);
+        } else if (contentType && !isJsonContentType(contentType)) {
+          result = error(`Unsupported NIP-11 content-type: ${contentType}`, data);
+        } else {
+          const body = await readBodyWithLimit(response);
+          const parsed = JSON.parse(body);
+          if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            result = error('NIP-11 response must be a JSON object.', data);
+          } else {
+            data = parsed;
+            result = {
+              ...resultTpl,
+              status: "success",
+              data
+            };
+          }
+        }
       }
     } catch (e) {
       result = error((e as Error).message, data);

--- a/libraries/nocap/adapters/default/InfoAdapterDefault/tsconfig.server.json
+++ b/libraries/nocap/adapters/default/InfoAdapterDefault/tsconfig.server.json
@@ -19,7 +19,7 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"],
   "tsc-alias": {
     "resolveFullPaths": true,
     "resolveFullExtension": ".js"

--- a/libraries/nocap/adapters/default/InfoAdapterDefault/tsconfig.web.json
+++ b/libraries/nocap/adapters/default/InfoAdapterDefault/tsconfig.web.json
@@ -20,5 +20,5 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests", "./adapters"]
+  "exclude": ["node_modules", "dist", "tests", "./adapters", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- Replace both GUI NIP-05 HTTP lookup paths with an app-owned verifier that uses `redirect: "error"`, omits credentials/referrers, times out, validates JSON MIME, and bounds response bodies.
- Preserve arbitrary NIP-05 domains and valid untrusted responses; no domain block, trust gate, proxy, or remote-fetch shutdown.
- Harden nocap InfoAdapterDefault, including the legacy file called out in the report, plus DNS and geo HTTP adapters.
- Reuse bounded response reading for NIP-11 and move seed JSON fetches onto the same redirect-error policy.
- Strengthen Firefox regressions for NIP-05, NIP-11, and active HTML navigation.

## Reproduced behavior

Before the fix:

1. monitor NIP-05 data reached either `nostr-tools nip05.isValid()` in the worker or a raw page-level `fetch()`;
2. the monitor-page path used default browser redirect-following semantics;
3. nocap InfoAdapterDefault also used default redirect-following semantics;
4. hostile 302 tests reached the sentinel target.

The RED nocap regression observed one sentinel hit. The NIP-05 path audit found both unsafe lookup owners:
- `Nip05Service/nip05.worker.ts`
- `routes/monitors/[pubkey]/+page.svelte`

## Security boundary

Every live app-owned browser JSON lookup now rejects redirects before response parsing. NIP-05 and NIP-11 additionally reject invalid MIME, oversized bodies, invalid JSON, and non-object responses where applicable.

Remote-resource audit:
- NIP-05: all GUI callsites route through hardened verifier.
- NIP-11: app-owned hardened worker fetch.
- nocap: info, DNS, and geo requests use redirect-error/credential-omit/referrer-omit policy.
- seed assets: shared hardened JSON fetch.
- raw remote HTML: sanitizer strips scripts, meta refresh, arbitrary iframes, handlers, and top-frame targets.
- generated YouTube iframe: sandbox excludes `allow-top-navigation`.
- images/video/CSS resources are passive subresources; WebSockets remain enabled and cannot navigate the parent browsing context.

The production bundle contains dependency NIP-05 helpers using `redirect: "manual"`, but source audit found no consumers; manual mode is non-following. Emitted live NIP-05/NIP-11 workers contain `redirect: "error"`.

## Verification

- `pnpm --dir apps/gui test` — 319 passed
- Firefox Playwright security suite — 4 passed:
  - hostile NIP-05 302: source hit once, sentinel hit zero, parent navigation zero
  - arbitrary valid NIP-05 origin still verifies
  - hostile NIP-11 302: source hit once, sentinel hit zero, parent navigation zero
  - active HTML navigation payload removed
- nocap adapter tests — 9 passed
- nocap DNS/geo/info adapter builds — passed
- `pnpm --dir apps/gui lint` — passed
- `pnpm --dir apps/gui build` — passed
- `git diff --check` — passed

`pnpm --dir apps/gui check` remains noisy after building workspace dependency artifacts: it reports existing repository diagnostics. Machine-output filtering found no new diagnostics in the new NIP-05/NIP-11/fetch helpers; remaining hits in the touched monitor page are on pre-existing route typing/Leaflet/SVG lines, outside this diff.
