### PR TITLE
Align rstate with ContextVM SDK 0.13

### DIFF
--- a/apps/rstate/.env.example
+++ b/apps/rstate/.env.example
@@ -33,6 +33,7 @@ CVM_AUTH_ALLOW_ANY=false
 # CEP-8 CVM Payments
 CVM_PAYMENTS_ENABLED=false
 CVM_NWC_CONNECTION_STRING=
+CVM_PAYMENT_INTERACTION_POLICY=optional
 # CVM_PRICING_YAML=./config/pricing.cvm.yaml  # optional CVM-specific overrides
 
 # ========================================

--- a/apps/rstate/package.json
+++ b/apps/rstate/package.json
@@ -35,11 +35,10 @@
     "docker:stop": "docker-compose down"
   },
   "dependencies": {
-    "@contextvm/sdk": "^0.6.2",
+    "@contextvm/sdk": "^0.13.9",
     "@fastify/cors": "^11.1.0",
     "@fastify/swagger": "^9.5.2",
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@noble/hashes": "^1.5.0",
     "@noble/secp256k1": "^2.1.0",
     "@nostrwatch/announce": "workspace:^",
     "@nostrwatch/publisher": "workspace:^",
@@ -60,7 +59,7 @@
     "@types/ws": "^8.5.13",
     "tsup": "^8.3.5",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2",
+    "typescript": "^5.9.3",
     "vitest": "^3.2.6"
   },
   "engines": {

--- a/apps/rstate/src/payments/cvm-payment-policy.ts
+++ b/apps/rstate/src/payments/cvm-payment-policy.ts
@@ -1,0 +1,16 @@
+import type { PaymentInteractionPolicy } from '@contextvm/sdk'
+
+const DEFAULT_CVM_PAYMENT_INTERACTION_POLICY: PaymentInteractionPolicy = 'optional'
+
+export function resolveCvmPaymentInteractionPolicy(
+  env: { [key: string]: string | undefined } = process.env
+): PaymentInteractionPolicy {
+  const rawPolicy = env.CVM_PAYMENT_INTERACTION_POLICY?.trim()
+
+  if (!rawPolicy) return DEFAULT_CVM_PAYMENT_INTERACTION_POLICY
+  if (rawPolicy === 'optional' || rawPolicy === 'transparent') return rawPolicy
+
+  throw new Error(
+    `CVM_PAYMENT_INTERACTION_POLICY must be "optional" or "transparent"; got "${rawPolicy}"`
+  )
+}

--- a/apps/rstate/src/resilient-relay-pool.ts
+++ b/apps/rstate/src/resilient-relay-pool.ts
@@ -171,6 +171,7 @@ export class ResilientRelayPool implements RelayPool {
         this.subscriptions.clear()
         logger.info('RelayHandler: all subscriptions unsubscribed')
       },
+      getRelayUrls: () => this.relays.map(relay => relay.url),
     }
   }
 

--- a/apps/rstate/src/server.ts
+++ b/apps/rstate/src/server.ts
@@ -7,6 +7,7 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { NostrServerTransport, PrivateKeySigner, EncryptionMode, withServerPayments, LnBolt11NwcPaymentProcessor } from '@contextvm/sdk'
 import { loadPricedCapabilities } from './payments/cvm-pricing.js'
+import { resolveCvmPaymentInteractionPolicy } from './payments/cvm-payment-policy.js'
 import { ResilientRelayPool } from './resilient-relay-pool.js'
 import type { Config } from './config.js'
 import { getLogger } from './utils/logger.js'
@@ -207,7 +208,7 @@ export class CVMServer {
         name: 'RelayVM',
         about: 'ContextVM server that aggregates NIP-66 relay intelligence and exposes it via MCP over Nostr. Service provided by nostr.watch',
       },
-      isPublicServer: cvmConfig.allowedPubkeys.length === 0,
+      isAnnouncedServer: cvmConfig.allowedPubkeys.length === 0,
       allowedPublicKeys: cvmConfig.allowedPubkeys.length > 0 ? cvmConfig.allowedPubkeys : undefined,
     })
 
@@ -224,13 +225,18 @@ export class CVMServer {
       })
 
       const pricedCapabilities = loadPricedCapabilities()
+      const paymentInteraction = resolveCvmPaymentInteractionPolicy()
 
       this.transport = withServerPayments(this.transport, {
         processors: [nwcProcessor],
         pricedCapabilities,
+        paymentInteraction,
       })
 
-      logger.info({ pricedTools: pricedCapabilities.length }, 'CVM payment gating enabled (CEP-8)')
+      logger.info({
+        pricedTools: pricedCapabilities.length,
+        paymentInteraction,
+      }, 'CVM payment gating enabled (CEP-8)')
     }
 
     // DISABLED: Subscription system

--- a/apps/rstate/test/cvm-payment-policy.test.ts
+++ b/apps/rstate/test/cvm-payment-policy.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCvmPaymentInteractionPolicy } from '../src/payments/cvm-payment-policy.js'
+
+describe('CVM payment interaction policy', () => {
+  it('defaults to the ContextVM 0.13 optional lifecycle policy', () => {
+    expect(resolveCvmPaymentInteractionPolicy({})).toBe('optional')
+  })
+
+  it('accepts transparent-only compatibility mode', () => {
+    expect(resolveCvmPaymentInteractionPolicy({ CVM_PAYMENT_INTERACTION_POLICY: 'transparent' })).toBe('transparent')
+  })
+
+  it('accepts the explicit optional policy value', () => {
+    expect(resolveCvmPaymentInteractionPolicy({ CVM_PAYMENT_INTERACTION_POLICY: ' optional ' })).toBe('optional')
+  })
+
+  it('rejects wire-level payment interaction modes as server policy values', () => {
+    expect(() => resolveCvmPaymentInteractionPolicy({
+      CVM_PAYMENT_INTERACTION_POLICY: 'explicit_gating',
+    })).toThrow('CVM_PAYMENT_INTERACTION_POLICY must be "optional" or "transparent"')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,7 +328,7 @@ importers:
         version: 3.0.7
       jsdom:
         specifier: ^29.1.1
-        version: 29.1.1(@noble/hashes@2.0.1)
+        version: 29.1.1(@noble/hashes@2.2.0)
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -391,7 +391,7 @@ importers:
         version: 7.3.6(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.15.3)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.6(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4))
+        version: 4.1.10(@types/node@22.15.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.6(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4))
       ws:
         specifier: 8.21.0
         version: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -399,8 +399,8 @@ importers:
   apps/rstate:
     dependencies:
       '@contextvm/sdk':
-        specifier: ^0.6.2
-        version: 0.6.2(typescript@5.8.3)
+        specifier: ^0.13.9
+        version: 0.13.9(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@fastify/cors':
         specifier: ^11.1.0
         version: 11.1.0
@@ -409,10 +409,7 @@ importers:
         version: 9.5.2
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
-        version: 1.27.1(zod@4.3.6)
-      '@noble/hashes':
-        specifier: ^1.5.0
-        version: 1.5.0
+        version: 1.27.1(zod@4.4.3)
       '@noble/secp256k1':
         specifier: ^2.1.0
         version: 2.3.0
@@ -433,7 +430,7 @@ importers:
         version: 8.20.0
       applesauce-relay:
         specifier: ^4.0.0
-        version: 4.2.0(typescript@5.8.3)
+        version: 4.2.0(typescript@5.9.3)
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -442,7 +439,7 @@ importers:
         version: 5.8.5
       nostr-tools:
         specifier: ^2.11.0
-        version: 2.11.0(typescript@5.8.3)
+        version: 2.11.0(typescript@5.9.3)
       pino:
         specifier: ^9.5.0
         version: 9.14.0
@@ -464,16 +461,16 @@ importers:
         version: 8.18.1
       tsup:
         specifier: ^8.3.5
-        version: 8.4.0(jiti@1.21.7)(postcss@8.5.16)(tsx@4.20.6)(typescript@5.8.3)(yaml@2.8.4)
+        version: 8.4.0(jiti@1.21.7)(postcss@8.5.16)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.4)
       tsx:
         specifier: ^4.19.2
         version: 4.20.6
       typescript:
-        specifier: ^5.7.2
-        version: 5.8.3
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@1.5.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
 
   internal/announce:
     dependencies:
@@ -516,7 +513,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
 
   internal/logger:
     dependencies:
@@ -622,7 +619,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.7.4)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.7.4)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
       webpack:
         specifier: 5.104.1
         version: 5.104.1(esbuild@0.28.1)(webpack-cli@5.1.4)
@@ -786,7 +783,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
       webpack:
         specifier: 5.104.1
         version: 5.104.1(esbuild@0.28.1)(webpack-cli@5.1.4)
@@ -1101,7 +1098,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
 
   libraries/db:
     dependencies:
@@ -1166,7 +1163,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
 
   libraries/nocap:
     dependencies:
@@ -1281,7 +1278,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
       vitest-nostr:
         specifier: 0.4.1
         version: 0.4.1(vitest-websocket-mock@0.2.2(vitest@3.2.6))(vitest@3.2.6)
@@ -1315,7 +1312,7 @@ importers:
         version: 1.8.16
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
       vitest-nostr:
         specifier: 0.4.1
         version: 0.4.1(vitest-websocket-mock@0.4.0(vitest@3.2.6))(vitest@3.2.6)
@@ -1376,7 +1373,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
       vitest-nostr:
         specifier: 0.4.1
         version: 0.4.1(vitest-websocket-mock@0.4.0(vitest@3.2.6))(vitest@3.2.6)
@@ -1425,7 +1422,7 @@ importers:
         version: 1.8.16
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
       vitest-nostr:
         specifier: 0.4.1
         version: 0.4.1(vitest-websocket-mock@0.4.0(vitest@3.2.6))(vitest@3.2.6)
@@ -1504,7 +1501,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
       vitest-nostr:
         specifier: 0.4.1
         version: 0.4.1(vitest-websocket-mock@0.4.0(vitest@3.2.6))(vitest@3.2.6)
@@ -1583,7 +1580,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 4.1.0
-        version: 4.1.0(@types/node@22.15.3)(@vitest/ui@3.2.6)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@6.4.3(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4))
+        version: 4.1.0(@types/node@22.15.3)(@vitest/ui@3.2.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@6.4.3(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4))
       vitest-nostr:
         specifier: 0.4.1
         version: 0.4.1(vitest-websocket-mock@0.4.0(vitest@4.1.0))(vitest@4.1.0)
@@ -1659,7 +1656,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
       vitest-nostr:
         specifier: 0.4.1
         version: 0.4.1(vitest-websocket-mock@0.4.0(vitest@3.2.6))(vitest@3.2.6)
@@ -1744,7 +1741,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.19.3)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.19.3)(yaml@2.8.4)
 
   libraries/nostrings:
     dependencies:
@@ -1769,7 +1766,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@18.19.87)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@18.19.87)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
 
   libraries/relay-charts:
     dependencies:
@@ -2158,7 +2155,7 @@ importers:
         version: 4.9.5
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@16.18.126)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@16.18.126)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
       yaml-loader:
         specifier: 0.8.1
         version: 0.8.1
@@ -2198,7 +2195,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
 
   libraries/uptime-kuma-monitor:
     dependencies:
@@ -3214,11 +3211,17 @@ packages:
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
 
-  '@contextvm/sdk@0.6.2':
-    resolution: {integrity: sha512-rerqo6GwpV8kO37TwAI9L/SZeCfi1Y/U3a0TUyVA8+uqvHTdBXPz7jsKwHqr4kbpzvIWXSFEpO+/Y0/hMKtUYA==}
+  '@contextvm/mcp-sdk@1.30.0':
+    resolution: {integrity: sha512-Z4xyxxxtKnczEgVzLagaUdT1EtoVzc1bjr6kpIfTlw7mP5ESAzXeDUAMO9leIwituphz2ELE6ad9BjW7blDjjw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25 || ^4.0
+
+  '@contextvm/sdk@0.13.9':
+    resolution: {integrity: sha512-YmVrO2z5ILAORLEvFogk4gEnjpGMMMGHhdGXdxJlxaIMbXCusjwLzugs9XWEUMeuLgGfIWOEL9ZURuTm4RXrNw==}
     engines: {bun: '>=1.2.0'}
     peerDependencies:
-      typescript: ^5.9.2
+      typescript: ^5.9.3
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -4113,6 +4116,10 @@ packages:
 
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
   '@noble/secp256k1@2.3.0':
@@ -5927,11 +5934,17 @@ packages:
   applesauce-core@5.1.0:
     resolution: {integrity: sha512-kk4nHndK4zjS8Sa6mC8LGtQ0LDSP4hlCGPJ9lpyIln7MkZaNFWD9eFd+fsEhfE9kyrne9IyYuVfJNp+EqY1b9w==}
 
+  applesauce-core@6.2.0:
+    resolution: {integrity: sha512-O6AlVyzqcuIhTOIuexm6UWmx7mRIa2D98gJP7K7vFGf90YdtvSH78AsKQWZXJ0Pk/K14at+9zkwfCkFr7ghgNw==}
+
   applesauce-relay@4.2.0:
     resolution: {integrity: sha512-OAYGImq1OkSXUZa5oT+td03DO8h5FQslX+dopCtzPb1v82akcOz7WOq1b3U8e5W1TttB9ZqHKT+UuurSLqNDVQ==}
 
   applesauce-relay@5.1.0:
     resolution: {integrity: sha512-d0LTJmQmr5gsYFm9A6efPEo2Bx/ewoL7LNsIdieMx34QohZBpPb137RvU9KQ1lFIXTm0tudd8VYfAPncqti2OQ==}
+
+  applesauce-relay@6.2.1:
+    resolution: {integrity: sha512-YIUHEtL2Fl5FZjeKYe/IuwL3OnMUNP2j4ydSr3iZDeHEZSEda4d1PoChefiNhtjE/U/F5OBHEbAX1zCHRZoxpg==}
 
   arch@2.2.0:
     resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
@@ -6278,6 +6291,10 @@ packages:
 
   caniuse-lite@1.0.30001803:
     resolution: {integrity: sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==}
+
+  canonicalize@2.1.0:
+    resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
+    hasBin: true
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -9162,14 +9179,6 @@ packages:
       typescript:
         optional: true
 
-  nostr-tools@2.18.2:
-    resolution: {integrity: sha512-lUCJQd9YZG3kEvxV5Zgm7qUkBpaeuvFrtqBz4TJLAxHzUn2pE7nmZZRDQmNzp5neEw20tQS3jR16o7XzzF8ncg==}
-    peerDependencies:
-      typescript: '>=5.0.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   nostr-tools@2.19.4:
     resolution: {integrity: sha512-qVLfoTpZegNYRJo5j+Oi6RPu0AwLP6jcvzcB3ySMnIT5DrAGNXfs5HNBspB/2HiGfH3GY+v6yXkTtcKSBQZwSg==}
     peerDependencies:
@@ -11251,6 +11260,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typical@4.0.0:
     resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
     engines: {node: '>=8'}
@@ -11942,6 +11956,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zrender@6.1.0:
     resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
@@ -13193,18 +13210,30 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@contextvm/sdk@0.6.2(typescript@5.8.3)':
+  '@contextvm/mcp-sdk@1.30.0(zod@4.4.3)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
-      applesauce-relay: 5.1.0(typescript@5.8.3)
-      nostr-tools: 2.18.2(typescript@5.8.3)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      cross-spawn: 7.0.6
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
+
+  '@contextvm/sdk@0.13.9(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@contextvm/mcp-sdk': 1.30.0(zod@4.4.3)
+      '@noble/hashes': 2.2.0
+      applesauce-relay: 6.2.1(typescript@5.9.3)
+      canonicalize: 2.1.0
+      nostr-tools: 2.23.9(typescript@5.9.3)
       pino: 10.3.1
       rxjs: 7.8.2
-      typescript: 5.8.3
-      zod: 4.3.6
+      typescript: 5.9.3
+      ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      zod: 4.4.3
     transitivePeerDependencies:
-      - '@cfworker/json-schema'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -13554,9 +13583,9 @@ snapshots:
       '@noble/hashes': 1.5.0
     optional: true
 
-  '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
+  '@exodus/bytes@1.15.0(@noble/hashes@2.2.0)':
     optionalDependencies:
-      '@noble/hashes': 2.0.1
+      '@noble/hashes': 2.2.0
 
   '@fastify/accept-negotiator@1.1.0': {}
 
@@ -14001,7 +14030,7 @@ snapshots:
       nanoid: 5.1.5
       svelte: 5.56.4(@typescript-eslint/types@8.6.0)
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.28)
       ajv: 8.20.0
@@ -14018,8 +14047,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -14074,6 +14103,8 @@ snapshots:
   '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.0.1': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@noble/secp256k1@2.3.0': {}
 
@@ -14649,7 +14680,7 @@ snapshots:
     dependencies:
       nanoid: 5.1.5
       type-fest: 5.0.0
-      zod: 4.1.13
+      zod: 4.3.6
 
   '@scure/base@1.1.1': {}
 
@@ -15587,7 +15618,7 @@ snapshots:
       std-env: 3.9.0
       strip-literal: 2.1.1
       test-exclude: 6.0.0
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.19.3)(yaml@2.8.4)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.19.3)(yaml@2.8.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -15718,7 +15749,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.13
       tinyrainbow: 2.0.0
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.19.3)(yaml@2.8.4)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.19.3)(yaml@2.8.4)
 
   '@vitest/ui@3.2.6(vitest@3.2.6)':
     dependencies:
@@ -15729,7 +15760,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 2.0.0
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@1.5.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
 
   '@vitest/ui@3.2.6(vitest@4.1.0)':
     dependencies:
@@ -15740,7 +15771,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 2.0.0
-      vitest: 4.1.0(@types/node@22.15.3)(@vitest/ui@3.2.6)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@6.4.3(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4))
+      vitest: 4.1.0(@types/node@22.15.3)(@vitest/ui@3.2.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@6.4.3(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4))
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -16130,7 +16161,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
-  applesauce-core@4.2.0(typescript@5.8.3):
+  applesauce-core@4.2.0(typescript@5.9.3):
     dependencies:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
@@ -16139,7 +16170,7 @@ snapshots:
       hash-sum: 2.0.0
       light-bolt11-decoder: 3.2.0
       nanoid: 5.1.5
-      nostr-tools: 2.17.2(typescript@5.8.3)
+      nostr-tools: 2.17.2(typescript@5.9.3)
       rxjs: 7.8.2
     transitivePeerDependencies:
       - supports-color
@@ -16157,12 +16188,24 @@ snapshots:
       - supports-color
       - typescript
 
-  applesauce-relay@4.2.0(typescript@5.8.3):
+  applesauce-core@6.2.0(typescript@5.9.3):
+    dependencies:
+      debug: 4.4.3
+      fast-deep-equal: 3.1.3
+      hash-sum: 2.0.0
+      nanoid: 5.1.5
+      nostr-tools: 2.19.4(typescript@5.9.3)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  applesauce-relay@4.2.0(typescript@5.9.3):
     dependencies:
       '@noble/hashes': 1.8.0
-      applesauce-core: 4.2.0(typescript@5.8.3)
+      applesauce-core: 4.2.0(typescript@5.9.3)
       nanoid: 5.1.5
-      nostr-tools: 2.17.2(typescript@5.8.3)
+      nostr-tools: 2.17.2(typescript@5.9.3)
       rxjs: 7.8.2
     transitivePeerDependencies:
       - supports-color
@@ -16174,6 +16217,17 @@ snapshots:
       applesauce-core: 5.1.0(typescript@5.8.3)
       nanoid: 5.1.5
       nostr-tools: 2.19.4(typescript@5.8.3)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  applesauce-relay@6.2.1(typescript@5.9.3):
+    dependencies:
+      '@noble/hashes': 2.2.0
+      applesauce-core: 6.2.0(typescript@5.9.3)
+      nanoid: 5.1.5
+      nostr-tools: 2.19.4(typescript@5.9.3)
       rxjs: 7.8.2
     transitivePeerDependencies:
       - supports-color
@@ -16561,6 +16615,8 @@ snapshots:
   camelcase@7.0.1: {}
 
   caniuse-lite@1.0.30001803: {}
+
+  canonicalize@2.1.0: {}
 
   ccount@2.0.1: {}
 
@@ -17065,10 +17121,10 @@ snapshots:
       - '@noble/hashes'
     optional: true
 
-  data-urls@7.0.0(@noble/hashes@2.0.1):
+  data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -18422,9 +18478,9 @@ snapshots:
       - '@noble/hashes'
     optional: true
 
-  html-encoding-sniffer@6.0.0(@noble/hashes@2.0.1):
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -19215,17 +19271,17 @@ snapshots:
       - '@noble/hashes'
     optional: true
 
-  jsdom@29.1.1(@noble/hashes@2.0.1):
+  jsdom@29.1.1(@noble/hashes@2.2.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0(@noble/hashes@2.0.1)
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0(@noble/hashes@2.0.1)
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.2
       parse5: 8.0.1
@@ -19236,7 +19292,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -20059,7 +20115,7 @@ snapshots:
       nostr-wasm: 0.1.0
       typescript: 5.8.3
 
-  nostr-tools@2.17.2(typescript@5.8.3):
+  nostr-tools@2.11.0(typescript@5.9.3):
     dependencies:
       '@noble/ciphers': 0.5.3
       '@noble/curves': 1.2.0
@@ -20067,11 +20123,11 @@ snapshots:
       '@scure/base': 1.1.1
       '@scure/bip32': 1.3.1
       '@scure/bip39': 1.2.1
-      nostr-wasm: 0.1.0
     optionalDependencies:
-      typescript: 5.8.3
+      nostr-wasm: 0.1.0
+      typescript: 5.9.3
 
-  nostr-tools@2.18.2(typescript@5.8.3):
+  nostr-tools@2.17.2(typescript@5.9.3):
     dependencies:
       '@noble/ciphers': 0.5.3
       '@noble/curves': 1.2.0
@@ -20081,7 +20137,7 @@ snapshots:
       '@scure/bip39': 1.2.1
       nostr-wasm: 0.1.0
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
 
   nostr-tools@2.19.4(typescript@5.8.3):
     dependencies:
@@ -20095,6 +20151,18 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
+  nostr-tools@2.19.4(typescript@5.9.3):
+    dependencies:
+      '@noble/ciphers': 0.5.3
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.1
+      '@scure/base': 1.1.1
+      '@scure/bip32': 1.3.1
+      '@scure/bip39': 1.2.1
+      nostr-wasm: 0.1.0
+    optionalDependencies:
+      typescript: 5.9.3
+
   nostr-tools@2.23.9(typescript@5.8.3):
     dependencies:
       '@noble/ciphers': 2.1.1
@@ -20106,6 +20174,18 @@ snapshots:
       nostr-wasm: 0.1.0
     optionalDependencies:
       typescript: 5.8.3
+
+  nostr-tools@2.23.9(typescript@5.9.3):
+    dependencies:
+      '@noble/ciphers': 2.1.1
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
+      '@scure/bip32': 2.0.1
+      '@scure/bip39': 2.0.1
+      nostr-wasm: 0.1.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   nostr-wasm@0.1.0: {}
 
@@ -22301,6 +22381,33 @@ snapshots:
       - tsx
       - yaml
 
+  tsup@8.4.0(jiti@1.21.7)(postcss@8.5.16)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.4):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.25.12)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.0
+      esbuild: 0.25.12
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.16)(tsx@4.20.6)(yaml@2.8.4)
+      resolve-from: 5.0.0
+      rollup: 4.59.0
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.13
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.16
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
   tsutils@3.21.0(typescript@5.8.3):
     dependencies:
       tslib: 1.14.1
@@ -22424,6 +22531,8 @@ snapshots:
   typescript@4.9.5: {}
 
   typescript@5.8.3: {}
+
+  typescript@5.9.3: {}
 
   typical@4.0.0: {}
 
@@ -22924,38 +23033,38 @@ snapshots:
 
   vitest-nostr@0.4.1(vitest-websocket-mock@0.2.2(vitest@3.2.6))(vitest@3.2.6):
     dependencies:
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
       vitest-websocket-mock: 0.2.2(vitest@3.2.6)
 
   vitest-nostr@0.4.1(vitest-websocket-mock@0.4.0(vitest@3.2.6))(vitest@3.2.6):
     dependencies:
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
       vitest-websocket-mock: 0.4.0(vitest@3.2.6)
 
   vitest-nostr@0.4.1(vitest-websocket-mock@0.4.0(vitest@4.1.0))(vitest@4.1.0):
     dependencies:
-      vitest: 4.1.0(@types/node@22.15.3)(@vitest/ui@3.2.6)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@6.4.3(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4))
+      vitest: 4.1.0(@types/node@22.15.3)(@vitest/ui@3.2.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@6.4.3(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4))
       vitest-websocket-mock: 0.4.0(vitest@4.1.0)
 
   vitest-websocket-mock@0.2.2(vitest@3.2.6):
     dependencies:
       jest-diff: 29.7.0
       mock-socket: 9.3.1
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
 
   vitest-websocket-mock@0.4.0(vitest@3.2.6):
     dependencies:
       '@vitest/utils': 2.1.9
       mock-socket: 9.3.1
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
 
   vitest-websocket-mock@0.4.0(vitest@4.1.0):
     dependencies:
       '@vitest/utils': 2.1.9
       mock-socket: 9.3.1
-      vitest: 4.1.0(@types/node@22.15.3)(@vitest/ui@3.2.6)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@6.4.3(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4))
+      vitest: 4.1.0(@types/node@22.15.3)(@vitest/ui@3.2.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@6.4.3(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4))
 
-  vitest@3.2.6(@types/debug@4.1.12)(@types/node@16.18.126)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4):
+  vitest@3.2.6(@types/debug@4.1.12)(@types/node@16.18.126)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -22984,7 +23093,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 16.18.126
       '@vitest/ui': 3.2.6(vitest@3.2.6)
-      jsdom: 29.1.1(@noble/hashes@2.0.1)
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -22999,7 +23108,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.6(@types/debug@4.1.12)(@types/node@18.19.87)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4):
+  vitest@3.2.6(@types/debug@4.1.12)(@types/node@18.19.87)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -23028,7 +23137,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 18.19.87
       '@vitest/ui': 3.2.6(vitest@3.2.6)
-      jsdom: 29.1.1(@noble/hashes@2.0.1)
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -23043,7 +23152,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.19.3)(yaml@2.8.4):
+  vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.19.3)(yaml@2.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -23072,7 +23181,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 20.17.32
       '@vitest/ui': 3.1.1(vitest@3.2.6)
-      jsdom: 29.1.1(@noble/hashes@2.0.1)
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -23131,7 +23240,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4):
+  vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -23160,7 +23269,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 20.17.32
       '@vitest/ui': 3.2.6(vitest@3.2.6)
-      jsdom: 29.1.1(@noble/hashes@2.0.1)
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -23175,7 +23284,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@1.5.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4):
+  vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -23204,7 +23313,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 22.15.3
       '@vitest/ui': 3.2.6(vitest@3.2.6)
-      jsdom: 29.1.1(@noble/hashes@1.5.0)
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -23219,51 +23328,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@6.4.3(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4))
-      '@vitest/pretty-format': 3.2.7
-      '@vitest/runner': 3.2.6
-      '@vitest/snapshot': 3.2.6
-      '@vitest/spy': 3.2.6
-      '@vitest/utils': 3.2.6
-      chai: 5.2.0
-      debug: 4.4.3
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 2.3.2
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.17
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 6.4.3(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
-      vite-node: 3.2.4(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 22.15.3
-      '@vitest/ui': 3.2.6(vitest@3.2.6)
-      jsdom: 29.1.1(@noble/hashes@2.0.1)
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.7.4)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4):
+  vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.7.4)(@vitest/ui@3.2.6)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -23292,7 +23357,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 22.7.4
       '@vitest/ui': 3.2.6(vitest@3.2.6)
-      jsdom: 29.1.1(@noble/hashes@2.0.1)
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -23307,7 +23372,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.0(@types/node@22.15.3)(@vitest/ui@3.2.6)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@6.4.3(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)):
+  vitest@4.1.0(@types/node@22.15.3)(@vitest/ui@3.2.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@6.4.3(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@6.4.3(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4))
@@ -23332,11 +23397,11 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.15.3
       '@vitest/ui': 3.2.6(vitest@4.1.0)
-      jsdom: 29.1.1(@noble/hashes@2.0.1)
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@types/node@22.15.3)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.6(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)):
+  vitest@4.1.10(@types/node@22.15.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.6(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@22.15.3)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.8.4))
@@ -23360,7 +23425,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.15.3
-      jsdom: 29.1.1(@noble/hashes@2.0.1)
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
@@ -23551,9 +23616,9 @@ snapshots:
       - '@noble/hashes'
     optional: true
 
-  whatwg-url@16.0.1(@noble/hashes@2.0.1):
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -23745,13 +23810,15 @@ snapshots:
 
   zimmerframe@1.1.2: {}
 
-  zod-to-json-schema@3.25.1(zod@4.3.6):
+  zod-to-json-schema@3.25.1(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   zod@4.1.13: {}
 
   zod@4.3.6: {}
+
+  zod@4.4.3: {}
 
   zrender@6.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,3 +99,5 @@ allowBuilds:
   secp256k1: true
   svelte-preprocess: false
   utf-8-validate: true
+minimumReleaseAgeExclude:
+  - '@contextvm/sdk@0.13.9'


### PR DESCRIPTION
## Summary
- upgrade rstate to @contextvm/sdk 0.13.9 and TypeScript 5.9
- adapt the CVM transport integration to the 0.13 server announcement and relay handler contracts
- add explicit CVM payment interaction policy handling with optional as the default and transparent as the compatibility mode
- document CVM_PAYMENT_INTERACTION_POLICY in the rstate env example

## Validation
- pnpm -C apps/rstate run type-check
- pnpm -C apps/rstate exec vitest run
- pnpm -C apps/rstate run build
- pnpm peers check --filter @nostr-watch/rstate

## Deployment Notes
- Set CVM_PAYMENT_INTERACTION_POLICY=optional in the CVM deployment env to make the new lifecycle explicit.
- The live deployed CVM relay/payment flow was not exercised in this branch.